### PR TITLE
Add profile-aware LLM generation bootstrap for Vibe templates

### DIFF
--- a/docs/VIBE_PROFILES.md
+++ b/docs/VIBE_PROFILES.md
@@ -1,0 +1,33 @@
+# Vibe Profile Generation
+
+Automata now supports a declarative `profile` attribute on generation-style eval tags.
+
+Example:
+
+```txt
+{=content profile="profiles/editorial-book.vibe"}
+```
+
+Host bootstrap flow:
+
+1. Construct `FillIn` with the default generation client.
+2. Call `setProfilePaths([...])` when profile files should resolve from local directories.
+3. Optionally call `registerProfileOverride($name, [...])` when a host wants a named profile alias to swap the generation driver and/or inject an inline prompt.
+4. Run the template normally.
+
+The runtime contract is:
+
+- When `profile` is absent, Automata uses the default generation client.
+- When `profile` points to a resolvable `.vibe` file, that file is loaded and prepended to the prompt context.
+- When a named override is registered, the host can replace the generation driver, the prompt, or both without changing templates.
+
+Runnable example:
+
+```bash
+php examples/generic/vibe_profile_fillin.php
+```
+
+The example prints JSON showing:
+
+- file-backed profile output and prompt
+- named override output and prompt

--- a/examples/generic/vibe_profile_fillin.php
+++ b/examples/generic/vibe_profile_fillin.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use BlueFission\Automata\LLM\Clients\IClient;
+use BlueFission\Automata\LLM\FillIn;
+use BlueFission\Automata\LLM\Reply;
+
+class ExampleProfileClient implements IClient
+{
+    public array $prompts = [];
+
+    public function __construct(private string $response)
+    {
+    }
+
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $this->prompts[] = (string)$input;
+
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        if ($callback) {
+            $callback($this->response);
+        }
+
+        return $reply;
+    }
+
+    public function complete($input, $config = []): Reply
+    {
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        return $reply;
+    }
+
+    public function respond($input, $config = []): Reply
+    {
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        return $reply;
+    }
+}
+
+$tempRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'automata_vibe_profiles_' . uniqid();
+$profileDir = $tempRoot . DIRECTORY_SEPARATOR . 'profiles';
+@mkdir($profileDir, 0777, true);
+file_put_contents(
+    $profileDir . DIRECTORY_SEPARATOR . 'editorial-book.vibe',
+    "You are an editorial book agent.\nFavor concise, publication-ready prose."
+);
+
+$defaultClient = new ExampleProfileClient('default-draft');
+$editorialClient = new ExampleProfileClient('editorial-draft');
+
+$fileProfile = new FillIn(
+    $defaultClient,
+    'Draft intro: {=content profile="profiles/editorial-book.vibe"}'
+);
+$fileProfile->setProfilePaths([$tempRoot]);
+$fileProfile->run();
+
+$namedProfile = new FillIn(
+    $defaultClient,
+    'Draft intro: {=content profile="editorial-fast"}'
+);
+$namedProfile->registerProfileOverride('editorial-fast', [
+    'driver' => $editorialClient,
+    'prompt' => 'You are the fast editorial profile. Prefer sharp structure and clean copy.',
+]);
+$namedProfile->run();
+
+echo json_encode([
+    'file_profile_output' => $fileProfile->output(),
+    'file_profile_prompt' => $defaultClient->prompts[0] ?? '',
+    'named_profile_output' => $namedProfile->output(),
+    'named_profile_prompt' => $editorialClient->prompts[0] ?? '',
+], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;

--- a/src/Automata/LLM/FillIn.php
+++ b/src/Automata/LLM/FillIn.php
@@ -9,16 +9,24 @@ use BlueFission\Parsing\Registry\TagRegistry;
 use BlueFission\Parsing\Registry\RendererRegistry;
 use BlueFission\Parsing\Registry\ExecutorRegistry;
 use BlueFission\Parsing\Registry\PreparerRegistry;
+use BlueFission\Parsing\Registry\GeneratorRegistry;
 use BlueFission\Parsing\Contracts\IRenderableElement;
 use BlueFission\Parsing\Contracts\IExecutableElement;
 use BlueFission\Parsing\Element;
+use BlueFission\Parsing\TagDefinition;
 use BlueFission\Automata\Parsing\Elements\PromptElement;
+use BlueFission\Automata\Parsing\Generators\LLMGenerator;
 use BlueFission\Automata\Parsing\Preparers\LLMPreparer;
 use BlueFission\Automata\Parsing\Preparers\ToolPreparer;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Data\FileSystem;
 use BlueFission\Obj;
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+use RuntimeException;
 
 class FillIn implements IDispatcher
 {
@@ -31,6 +39,9 @@ class FillIn implements IDispatcher
     protected $parser;
     protected array $tools = [];
     protected array $vars = [];
+    protected array $includePaths = [];
+    protected array $profilePaths = [];
+    protected array $profileOverrides = [];
     protected string $output = '';
     /**
      * Optional soft token budget for the rendered prompt, expressed as
@@ -51,13 +62,27 @@ class FillIn implements IDispatcher
     public function setPrompt(string $prompt): void
     {
         TagRegistry::registerDefaults();
+        TagRegistry::register(new TagDefinition(
+            name: 'eval',
+            pattern: '{open}=(.*?)(?:->(\\w+))?(?:\\s+silent=[\'\"]?(true|false)[\'\"]?)?{close}',
+            attributes: ['*'],
+            interface: IRenderableElement::class,
+            class: PromptElement::class
+        ));
         RendererRegistry::registerDefaults();
         ExecutorRegistry::registerDefaults();
         PreparerRegistry::registerDefaults();
         PreparerRegistry::register(new LLMPreparer($this), [EvalElement::class]);
 
+        $generator = new LLMGenerator();
+        $generator->setDriver($this->llm);
+        $generator->setProfileResolver(fn (string $profile, Element $element): array => $this->resolveProfile($profile, $element));
+        GeneratorRegistry::set($generator);
+
         $this->parser = new Parser($prompt);
+        $generator->registerEchoes($this->parser);
         $this->parser->setVariables($this->vars);
+        $this->parser->setIncludePaths($this->includePaths);
         $this->echo($this->parser, [Event::STARTED, Event::SENT, Event::ERROR, Event::RECEIVED, Event::COMPLETE]);
         $this->template = $prompt;
     }
@@ -73,9 +98,70 @@ class FillIn implements IDispatcher
         $this->tools[$name] = $tool;
     }
 
+    public function setIncludePaths(array $paths): void
+    {
+        $this->includePaths = $paths;
+        if ($this->parser) {
+            $this->parser->setIncludePaths($paths);
+        }
+    }
+
+    public function setProfilePaths(array $paths): void
+    {
+        $this->profilePaths = $paths;
+    }
+
+    public function registerProfileOverride(string $name, mixed $profile): void
+    {
+        $this->profileOverrides[$name] = $profile;
+    }
+
+    public function registerProfile(string $name, mixed $profile): void
+    {
+        $this->registerProfileOverride($name, $profile);
+    }
+
     public function getLLM()
     {
         return $this->llm;
+    }
+
+    public function resolveProfile(string $profile, ?Element $element = null): array
+    {
+        $profile = Str::trim($profile);
+        if ($profile === '') {
+            throw new RuntimeException('Profile attribute was provided but no profile name or path was given.');
+        }
+
+        $definition = $this->profileOverrides[$profile] ?? null;
+        if (is_callable($definition)) {
+            $definition = $definition($profile, $element, $this);
+        }
+
+        $resolved = [
+            'name' => $profile,
+            'driver' => $this->llm,
+            'prompt' => '',
+            'path' => null,
+        ];
+
+        if ($definition !== null) {
+            $resolved = $this->mergeProfileDefinition($resolved, $definition, $profile);
+        } else {
+            $resolved['path'] = $this->resolveProfilePath($profile);
+        }
+
+        if ($resolved['path']) {
+            $resolved['prompt'] = $resolved['prompt'] !== ''
+                ? $resolved['prompt']
+                : $this->readProfileContents($resolved['path']);
+        }
+
+        if ($resolved['prompt'] === '' && $resolved['driver'] === $this->llm && $definition === null) {
+            throw new RuntimeException("Unable to resolve generation profile '{$profile}'.");
+        }
+
+        return $resolved;
     }
 
     /**
@@ -114,5 +200,90 @@ class FillIn implements IDispatcher
     public function output(): string
     {
         return $this->output;
+    }
+
+    protected function mergeProfileDefinition(array $resolved, mixed $definition, string $profile): array
+    {
+        if (Arr::is($definition)) {
+            if (isset($definition['driver']) && Val::is($definition['driver']) && method_exists($definition['driver'], 'generate')) {
+                $resolved['driver'] = $definition['driver'];
+            }
+
+            if (isset($definition['prompt']) && Val::isNotNull($definition['prompt'])) {
+                $resolved['prompt'] = (string)$definition['prompt'];
+            }
+
+            if (isset($definition['path']) && Val::isNotNull($definition['path'])) {
+                $resolved['path'] = $this->resolveProfilePath((string)$definition['path']);
+            }
+
+            return $resolved;
+        }
+
+        if (Val::is($definition) && method_exists($definition, 'generate')) {
+            $resolved['driver'] = $definition;
+            return $resolved;
+        }
+
+        if (Str::is($definition)) {
+            $resolved['path'] = $this->resolveProfilePath($definition, false);
+            if (!$resolved['path']) {
+                $resolved['prompt'] = $definition;
+            }
+            return $resolved;
+        }
+
+        throw new RuntimeException("Invalid profile override registered for '{$profile}'.");
+    }
+
+    protected function resolveProfilePath(string $profile, bool $failIfMissing = true): ?string
+    {
+        $candidates = [];
+        $profile = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $profile);
+
+        if ($this->isAbsolutePath($profile)) {
+            $candidates[] = $profile;
+        } else {
+            $searchPaths = array_merge($this->profilePaths, $this->includePaths);
+            foreach ($searchPaths as $base) {
+                $base = rtrim((string)$base, '\\/');
+                if ($base === '') {
+                    continue;
+                }
+                $candidates[] = $base . DIRECTORY_SEPARATOR . $profile;
+            }
+
+            $candidates[] = $profile;
+        }
+
+        foreach ($candidates as $candidate) {
+            $filesystem = new FileSystem($candidate);
+            if ($filesystem->exists($candidate)) {
+                return rtrim((string)$filesystem->path(), '\\/') . DIRECTORY_SEPARATOR . basename($candidate);
+            }
+        }
+
+        if ($failIfMissing) {
+            throw new RuntimeException("Unable to resolve profile file '{$profile}'.");
+        }
+
+        return null;
+    }
+
+    protected function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        return (bool)preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) || Str::pos($path, DIRECTORY_SEPARATOR) === 0;
+    }
+
+    protected function readProfileContents(string $path): string
+    {
+        $filesystem = new FileSystem($path);
+        $filesystem->read();
+
+        return (string)$filesystem->contents();
     }
 }

--- a/src/Automata/Parsing/Elements/PromptElement.php
+++ b/src/Automata/Parsing/Elements/PromptElement.php
@@ -34,4 +34,14 @@ class PromptElement extends EvalElement implements IExecutableElement, IRenderab
 
         return $this->description;
     }
+
+    public function render(): string
+    {
+        $silent = $this->getAttribute('silent');
+        if ($silent === 'true' || $silent === true) {
+            return '';
+        }
+
+        return (string)$this->value;
+    }
 }

--- a/src/Automata/Parsing/Generators/LLMGenerator.php
+++ b/src/Automata/Parsing/Generators/LLMGenerator.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Parsing\Generators;
 
+use BlueFission\Automata\LLM\Reply;
 use BlueFission\Parsing\Contracts\IGenerator;
 use BlueFission\Parsing\Element;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -10,7 +11,9 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Behavioral\Dispatches;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Collections\Collection;
+use BlueFission\Arr;
 use BlueFission\Str;
+use BlueFission\Val;
 use Exception;
 
 class LLMGenerator implements IGenerator, IDispatcher {
@@ -21,10 +24,16 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
     protected array $buffer = [];
     protected $llm;
+    protected $profileResolver = null;
 
     public function setDriver($llm): void
     {
         $this->llm = $llm;
+    }
+
+    public function setProfileResolver(?callable $resolver): void
+    {
+        $this->profileResolver = $resolver;
     }
 
     public function __construct() {
@@ -109,11 +118,18 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
     protected function generateFromLLM(Element $element, array $config): void
     {
-        if (!$this->llm) {
+        $profile = $this->resolveProfile($element);
+        $driver = $profile['driver'] ?? $this->llm;
+
+        if (!$driver) {
             throw new Exception("No LLM assigned to Element");
         }
 
         $prompt = $this->gatherPromptContext($element);
+        $profilePrompt = Str::trim((string)($profile['prompt'] ?? ''));
+        if ($profilePrompt !== '') {
+            $prompt = $profilePrompt . "\n\n" . $prompt;
+        }
 
         $options = $element->getAttribute('options');
 
@@ -129,12 +145,13 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
         $this->dispatch(Event::SENT, new Meta(when: State::RUNNING, data: [
             'placeholder' => $element->getTag(),
-            'config' => $config
+            'config' => $config,
+            'profile' => $profile['name'] ?? null,
         ], src: $this));
 
         $pattern = $element->getAttribute('pattern') ?? (isset($options) && count($options) > 0 ? '/\b(' . implode('|', array_map('preg_quote', $options)) . ')\b/xi' : null);
-        
-        $this->llm->generate($prompt, $config, function($output) use ($config, $target, $options, $pattern, $element) {
+
+        $reply = $driver->generate($prompt, $config, function($output) use ($config, $target, $options, $pattern, $element) {
             $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: [
                 'placeholder' => $element->getTag(),
                 'value' => $output
@@ -170,11 +187,13 @@ class LLMGenerator implements IGenerator, IDispatcher {
                 return false;
             }
         });
+
+        $this->consumeReply($reply, $target, $element, $options, $pattern);
     }
 
     protected function matchPrefixOption(string $buffer, array $options): ?string
     {
-        $buffer = strtolower(trim($buffer));
+        $buffer = Str::lower(Str::trim($buffer));
         
         foreach ($options as $option) {
             if (stripos($option, $buffer) === 0) {
@@ -188,26 +207,80 @@ class LLMGenerator implements IGenerator, IDispatcher {
     protected function gatherPromptContext(Element $element): string
     {
         $closed = $element->getAttribute('closed') === 'true';
-
-        if (!$closed) {
-            $element = $element;
-            $match = '';
-            $body = $element->getMatch();
-            $context = '';
-            // $context = $this->getTop()?->getContent();
-            while ($element->getTag() != '__ROOT__') {
-                $match = $element->getMatch();
-                $tempbody = $element->getContent();
-                $element = $element->getParent();
-                $context = $element->getContent();
-                $context = Str::replace($context, $match, $body);
-                $body = $tempbody;
-            }
-
-            // split the text by the first occurence of the element
-            $context = explode($element->getMatch(), $context, 2)[0] ?? '';
+        if ($closed) {
+            return '';
         }
 
-        return (string)$context;
+        $root = $element->getRoot();
+        $context = $root ? $root->getContent() : '';
+        $match = $element->getMatch();
+
+        if (Str::is($context) && Str::is($match)) {
+            $position = Str::pos($context, $match);
+            if ($position !== false) {
+                return (string)Str::sub($context, 0, $position);
+            }
+        }
+
+        return '';
+    }
+
+    protected function resolveProfile(Element $element): array
+    {
+        $profile = $element->getAttribute('profile');
+        if (!$profile) {
+            return [
+                'name' => null,
+                'driver' => $this->llm,
+                'prompt' => '',
+            ];
+        }
+
+        if (!$this->profileResolver) {
+            throw new Exception("No profile resolver configured for '{$profile}'.");
+        }
+
+        $resolved = call_user_func($this->profileResolver, (string)$profile, $element);
+        if (!Arr::is($resolved)) {
+            throw new Exception("Profile resolver must return an array for '{$profile}'.");
+        }
+
+        $resolved['name'] = $resolved['name'] ?? (string)$profile;
+        $resolved['driver'] = $resolved['driver'] ?? $this->llm;
+        $resolved['prompt'] = $resolved['prompt'] ?? '';
+
+        return $resolved;
+    }
+
+    protected function consumeReply($reply, string $target, Element $element, ?array $options, ?string $pattern): void
+    {
+        if (!isset($this->buffer[$target]) || $this->buffer[$target] !== '') {
+            return;
+        }
+
+        if (!$reply instanceof Reply) {
+            return;
+        }
+
+        $messages = $reply->messages()->toArray();
+        $last = end($messages);
+        if (!Str::is($last) || Str::trim($last) === '') {
+            return;
+        }
+
+        $output = Str::trim($last);
+        if (!empty($options) && !$this->matchPrefixOption($output, $options) && !in_array($output, $options, true)) {
+            return;
+        }
+
+        if (!empty($pattern) && !preg_match($pattern, $output)) {
+            return;
+        }
+
+        $this->buffer[$target] = $output;
+        $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: [
+            'placeholder' => $element->getTag(),
+            'value' => $output
+        ], src: $this));
     }
 }

--- a/tests/Automata/LLM/FillInProfileTest.php
+++ b/tests/Automata/LLM/FillInProfileTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace BlueFission\Tests\Automata\LLM;
+
+use BlueFission\Automata\LLM\Clients\IClient;
+use BlueFission\Automata\LLM\FillIn;
+use BlueFission\Automata\LLM\Reply;
+use PHPUnit\Framework\TestCase;
+
+class RecordingClient implements IClient
+{
+    public array $prompts = [];
+    private string $response;
+
+    public function __construct(string $response)
+    {
+        $this->response = $response;
+    }
+
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $this->prompts[] = (string)$input;
+
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        if ($callback) {
+            $callback($this->response);
+        }
+
+        return $reply;
+    }
+
+    public function complete($input, $config = []): Reply
+    {
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        return $reply;
+    }
+
+    public function respond($input, $config = []): Reply
+    {
+        $reply = new Reply();
+        $reply->addMessage($this->response, true);
+
+        return $reply;
+    }
+}
+
+class ReplyOnlyClient extends RecordingClient
+{
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $this->prompts[] = (string)$input;
+
+        $reply = new Reply();
+        $reply->addMessage('reply-only', true);
+
+        return $reply;
+    }
+}
+
+class FillInProfileTest extends TestCase
+{
+    public function testFillInUsesReplyOutputWhenClientDoesNotStream(): void
+    {
+        $client = new ReplyOnlyClient('unused');
+        $fillIn = new FillIn($client, 'Hello {=content}');
+
+        $fillIn->run();
+
+        $this->assertSame('Hello reply-only', $fillIn->output());
+        $this->assertCount(1, $client->prompts);
+        $this->assertSame('Hello ', $client->prompts[0]);
+    }
+
+    public function testProfileFileIsPrependedToPromptContext(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'automata_fillin_' . uniqid();
+        $profiles = $dir . DIRECTORY_SEPARATOR . 'profiles';
+        mkdir($profiles, 0777, true);
+        file_put_contents($profiles . DIRECTORY_SEPARATOR . 'editorial-book.vibe', 'You are an editorial book agent.');
+
+        $client = new RecordingClient('profiled');
+        $fillIn = new FillIn($client, 'Hello {=content profile="profiles/editorial-book.vibe"}');
+        $fillIn->setProfilePaths([$dir]);
+
+        $fillIn->run();
+
+        $this->assertSame('Hello profiled', $fillIn->output());
+        $this->assertCount(1, $client->prompts);
+        $this->assertStringStartsWith("You are an editorial book agent.\n\nHello ", $client->prompts[0]);
+    }
+
+    public function testNamedProfileOverrideCanSwapGenerationDriver(): void
+    {
+        $default = new RecordingClient('default');
+        $editor = new RecordingClient('editor');
+
+        $fillIn = new FillIn($default, 'Hello {=content profile="editorial"}');
+        $fillIn->registerProfileOverride('editorial', [
+            'driver' => $editor,
+            'prompt' => 'You are the editorial profile.',
+        ]);
+
+        $fillIn->run();
+
+        $this->assertSame('Hello editor', $fillIn->output());
+        $this->assertCount(0, $default->prompts);
+        $this->assertCount(1, $editor->prompts);
+        $this->assertStringStartsWith("You are the editorial profile.\n\nHello ", $editor->prompts[0]);
+    }
+}

--- a/tests/Examples/VibeProfileFillInExampleTest.php
+++ b/tests/Examples/VibeProfileFillInExampleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BlueFission\Tests\Examples;
+
+use PHPUnit\Framework\TestCase;
+
+class VibeProfileFillInExampleTest extends TestCase
+{
+    public function testVibeProfileFillInExampleRuns(): void
+    {
+        $cmd = 'php examples/generic/vibe_profile_fillin.php';
+        exec($cmd, $output, $code);
+
+        $this->assertSame(0, $code, 'Example should exit cleanly.');
+
+        $json = json_decode(implode("\n", $output), true);
+
+        $this->assertIsArray($json);
+        $this->assertSame('Draft intro: default-draft', $json['file_profile_output'] ?? null);
+        $this->assertStringStartsWith("You are an editorial book agent.\nFavor concise, publication-ready prose.\n\nDraft intro: ", $json['file_profile_prompt'] ?? '');
+        $this->assertSame('Draft intro: editorial-draft', $json['named_profile_output'] ?? null);
+        $this->assertStringStartsWith('You are the fast editorial profile. Prefer sharp structure and clean copy.', $json['named_profile_prompt'] ?? '');
+    }
+}


### PR DESCRIPTION
## Summary

This adds Automata-side support for declarative `profile` selection on generation/eval tags so Vibe templates can choose reusable prompt/agent profiles without runner-side prompt assembly.

## What Changed

- register an Automata `PromptElement` + `LLMGenerator` path for eval generation tags
- support element-level `profile` resolution in generation
- allow file-backed `.vibe` profiles via `setProfilePaths([...])`
- allow named overrides via `registerProfileOverride(...)` / `registerProfile(...)`
- allow profile overrides to swap the generation driver and/or inject prompt text
- support reply-style clients that return `Reply` objects without streaming callbacks
- render generated prompt values directly from `PromptElement`
- add unit coverage, runnable example, and docs

## Example

```txt
{=content profile="profiles/editorial-book.vibe"}
```

Host bootstrap reference:
`examples/generic/vibe_profile_fillin.php`

## Tests

```bash
vendor/bin/phpunit --do-not-cache-result tests/Automata/LLM tests/Automata/Parsing tests/Examples/VibeProfileFillInExampleTest.php
```

## Notes

- current behavior is unchanged when `profile` is absent
- unresolved profiles fail with a clear resolution error
- file-backed and named-override profile flows are both covered
