### PR TITLE
Add LLM generation observability and usage tracking

### DIFF
--- a/src/Automata/LLM/FillIn.php
+++ b/src/Automata/LLM/FillIn.php
@@ -37,6 +37,7 @@ class FillIn implements IDispatcher
     protected $llm;
     protected $template;
     protected $parser;
+    protected ?LLMGenerator $generator = null;
     protected array $tools = [];
     protected array $vars = [];
     protected array $includePaths = [];
@@ -74,16 +75,20 @@ class FillIn implements IDispatcher
         PreparerRegistry::registerDefaults();
         PreparerRegistry::register(new LLMPreparer($this), [EvalElement::class]);
 
-        $generator = new LLMGenerator();
-        $generator->setDriver($this->llm);
-        $generator->setProfileResolver(fn (string $profile, Element $element): array => $this->resolveProfile($profile, $element));
-        GeneratorRegistry::set($generator);
+        $this->generator = new LLMGenerator();
+        $this->generator->setDriver($this->llm);
+        $this->generator->setProfileResolver(fn (string $profile, Element $element): array => $this->resolveProfile($profile, $element));
+        GeneratorRegistry::set($this->generator);
 
         $this->parser = new Parser($prompt);
-        $generator->registerEchoes($this->parser);
+        $this->generator->registerEchoes($this->parser);
         $this->parser->setVariables($this->vars);
         $this->parser->setIncludePaths($this->includePaths);
-        $this->echo($this->parser, [Event::STARTED, Event::SENT, Event::ERROR, Event::RECEIVED, Event::COMPLETE]);
+        foreach ([Event::STARTED, Event::SENT, Event::ERROR, Event::RECEIVED, Event::COMPLETE] as $behavior) {
+            $this->parser->when($behavior, function ($event, $meta = null) use ($behavior) {
+                $this->dispatch($behavior, $meta);
+            });
+        }
         $this->template = $prompt;
     }
 
@@ -124,6 +129,21 @@ class FillIn implements IDispatcher
     public function getLLM()
     {
         return $this->llm;
+    }
+
+    public function generator(): ?LLMGenerator
+    {
+        return $this->generator;
+    }
+
+    public function usageLedger(): array
+    {
+        return $this->generator ? $this->generator->usageLedger() : [];
+    }
+
+    public function usageTotals(): array
+    {
+        return $this->generator ? $this->generator->usageTotals() : [];
     }
 
     public function resolveProfile(string $profile, ?Element $element = null): array
@@ -182,6 +202,9 @@ class FillIn implements IDispatcher
     public function run(array $config = []): array
     {
         $this->dispatch(Event::STARTED, new Meta(when: State::RUNNING, src: $this));
+        if ($this->generator) {
+            $this->generator->resetUsage();
+        }
 
         $this->output = $this->parser->render();
 
@@ -191,7 +214,9 @@ class FillIn implements IDispatcher
         //  - Support streaming or chunked execution when prompts exceed limits.
 
         $this->dispatch(Event::COMPLETE, new Meta(when: State::RUNNING, data: [
-            'output' => $this->output
+            'output' => $this->output,
+            'usage' => $this->usageTotals(),
+            'output_token_estimate' => $this->estimateTokens($this->output),
         ], src: $this));
 
         return $this->parser->root()->getAllVariables();
@@ -285,5 +310,16 @@ class FillIn implements IDispatcher
         $filesystem->read();
 
         return (string)$filesystem->contents();
+    }
+
+    protected function estimateTokens(string $text): int
+    {
+        $text = Str::trim($text);
+        if ($text === '') {
+            return 0;
+        }
+
+        preg_match_all('/\S+/u', $text, $matches);
+        return max(count($matches[0] ?? []), (int)ceil(Str::len($text) / 4));
     }
 }

--- a/src/Automata/Parsing/Generators/LLMGenerator.php
+++ b/src/Automata/Parsing/Generators/LLMGenerator.php
@@ -23,6 +23,15 @@ class LLMGenerator implements IGenerator, IDispatcher {
     }
 
     protected array $buffer = [];
+    protected array $usageLedger = [];
+    protected array $usageTotals = [
+        'prompt_tokens' => 0,
+        'completion_tokens' => 0,
+        'total_tokens' => 0,
+        'estimated_prompt_tokens' => 0,
+        'estimated_completion_tokens' => 0,
+        'estimated_total_tokens' => 0,
+    ];
     protected $llm;
     protected $profileResolver = null;
 
@@ -34,6 +43,29 @@ class LLMGenerator implements IGenerator, IDispatcher {
     public function setProfileResolver(?callable $resolver): void
     {
         $this->profileResolver = $resolver;
+    }
+
+    public function usageLedger(): array
+    {
+        return $this->usageLedger;
+    }
+
+    public function usageTotals(): array
+    {
+        return $this->usageTotals;
+    }
+
+    public function resetUsage(): void
+    {
+        $this->usageLedger = [];
+        $this->usageTotals = [
+            'prompt_tokens' => 0,
+            'completion_tokens' => 0,
+            'total_tokens' => 0,
+            'estimated_prompt_tokens' => 0,
+            'estimated_completion_tokens' => 0,
+            'estimated_total_tokens' => 0,
+        ];
     }
 
     public function __construct() {
@@ -48,15 +80,17 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
     public function registerEchoes(IDispatcher $parent): void
     {
-        // Whenever this generator sends/receives/errors or flips RUNNING/IDLE,
-        // mirror those events onto the parent dispatcher.
-        $parent->echo($this, [
+        foreach ([
           Event::SENT,
           Event::RECEIVED,
           Event::ERROR,
           State::RUNNING,
           State::IDLE,
-        ]);
+        ] as $behavior) {
+            $this->when($behavior, function ($event, $meta = null) use ($parent, $behavior) {
+                $parent->dispatch($behavior, $meta);
+            });
+        }
     }
 
     public function generate(Element $element): string
@@ -77,14 +111,19 @@ class LLMGenerator implements IGenerator, IDispatcher {
             $this->buffer[$element->getUuid()] = '';
         }
 
+        if (!isset($this->usageLedger[$element->getUuid()])) {
+            $this->usageLedger[$element->getUuid()] = [];
+        }
+
         $retries = 5;
         $attempt = 0;
 
         do {
             $attempt++;
             try {
-                $this->generateFromLLM($element, $config);
+                $generation = $this->generateFromLLM($element, $config, $attempt, $retries);
             } catch (Exception $e) {
+                $generation = null;
                 $this->dispatch(Event::ERROR, new Meta(when: State::RUNNING, data: [
                     'placeholder' => $element->getTag(),
                     'error' => $e->getMessage()
@@ -92,6 +131,7 @@ class LLMGenerator implements IGenerator, IDispatcher {
             }
 
             $output = $this->buffer[$element->getUuid()];
+            $accepted = true;
 
             if ($pattern && !preg_match($pattern, $output)) {
                 // throw new Exception("Generated value '{$output}' does not match required pattern.");
@@ -99,7 +139,23 @@ class LLMGenerator implements IGenerator, IDispatcher {
                     'placeholder' => $element->getTag(),
                     'error' => "Generated value '{$output}' does not match required pattern {$pattern}."
                 ], src: $this));
+                $accepted = false;
                 $this->buffer[$element->getUuid()] = '';
+            }
+
+            if (Arr::is($generation)) {
+                $usage = $generation['usage'] ?? [];
+                $metadata = $generation['metadata'] ?? [];
+                $this->recordUsage($element, $metadata, $usage, $output, $accepted);
+                $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: array_merge(
+                    $metadata,
+                    [
+                        'value' => $output,
+                        'final' => true,
+                        'accepted' => $accepted,
+                        'usage' => $usage,
+                    ]
+                ), src: $this));
             }
 
             if ($attempt >= $retries) {
@@ -116,7 +172,7 @@ class LLMGenerator implements IGenerator, IDispatcher {
         return $this->buffer[$element->getUuid()] ?? '';
     }
 
-    protected function generateFromLLM(Element $element, array $config): void
+    protected function generateFromLLM(Element $element, array $config, int $attempt, int $retries): array
     {
         $profile = $this->resolveProfile($element);
         $driver = $profile['driver'] ?? $this->llm;
@@ -125,7 +181,8 @@ class LLMGenerator implements IGenerator, IDispatcher {
             throw new Exception("No LLM assigned to Element");
         }
 
-        $prompt = $this->gatherPromptContext($element);
+        $context = $this->buildPromptContext($element);
+        $prompt = $context['prompt'];
         $profilePrompt = Str::trim((string)($profile['prompt'] ?? ''));
         if ($profilePrompt !== '') {
             $prompt = $profilePrompt . "\n\n" . $prompt;
@@ -142,21 +199,13 @@ class LLMGenerator implements IGenerator, IDispatcher {
         }
 
         $target = $element->getUuid();
+        $metadata = $this->buildEventMetadata($element, $config, $profile, $context, $attempt, $retries, $prompt);
 
-        $this->dispatch(Event::SENT, new Meta(when: State::RUNNING, data: [
-            'placeholder' => $element->getTag(),
-            'config' => $config,
-            'profile' => $profile['name'] ?? null,
-        ], src: $this));
+        $this->dispatch(Event::SENT, new Meta(when: State::RUNNING, data: $metadata, src: $this));
 
         $pattern = $element->getAttribute('pattern') ?? (isset($options) && count($options) > 0 ? '/\b(' . implode('|', array_map('preg_quote', $options)) . ')\b/xi' : null);
 
-        $reply = $driver->generate($prompt, $config, function($output) use ($config, $target, $options, $pattern, $element) {
-            $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: [
-                'placeholder' => $element->getTag(),
-                'value' => $output
-            ], src: $this));
-
+        $reply = $driver->generate($prompt, $config, function($output) use ($target, $options, $pattern, $element, $metadata, $prompt) {
             if ($element->getUuid() === $target) {
                 if (!isset($this->buffer[$target])) {
                     $this->buffer[$target] = '';
@@ -179,6 +228,17 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
                 $this->buffer[$target] = $output;
 
+                $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: array_merge(
+                    $metadata,
+                    [
+                        'value' => $output,
+                        'chunk' => $output,
+                        'final' => false,
+                        'accepted' => null,
+                        'usage' => $this->normalizeUsage(null, $prompt, $output),
+                    ]
+                ), src: $this));
+
                 // create a pattern variant that cheecks if the existiing output partially matches
                 if (!empty($pattern) && preg_match($pattern, $output)) {
                     return true;
@@ -189,6 +249,11 @@ class LLMGenerator implements IGenerator, IDispatcher {
         });
 
         $this->consumeReply($reply, $target, $element, $options, $pattern);
+
+        return [
+            'metadata' => $metadata,
+            'usage' => $this->normalizeUsage($reply, $prompt, $this->buffer[$target] ?? ''),
+        ];
     }
 
     protected function matchPrefixOption(string $buffer, array $options): ?string
@@ -204,13 +269,217 @@ class LLMGenerator implements IGenerator, IDispatcher {
         return null; // no prefix match
     }
 
-    protected function gatherPromptContext(Element $element): string
+    protected function buildPromptContext(Element $element): array
     {
         $closed = $element->getAttribute('closed') === 'true';
         if ($closed) {
-            return '';
+            return [
+                'prompt' => '',
+                'requested_strategy' => 'none',
+                'strategy' => 'none',
+                'supported' => true,
+                'thread' => $element->getAttribute('thread'),
+                'session' => $element->getAttribute('session'),
+                'max_context_tokens' => 0,
+                'truncated' => false,
+                'estimated_tokens' => 0,
+                'original_estimated_tokens' => 0,
+                'dropped_estimated_tokens' => 0,
+            ];
         }
 
+        $requestedStrategy = Str::lower(Str::trim((string)($element->getAttribute('context_strategy') ?? 'prefix')));
+        $requestedStrategy = $requestedStrategy === '' ? 'prefix' : $requestedStrategy;
+        $supported = in_array($requestedStrategy, ['none', 'prefix', 'windowed-prefix'], true);
+        $strategy = $supported ? $requestedStrategy : 'prefix';
+        $context = '';
+
+        if ($strategy !== 'none') {
+            $root = $element->getRoot();
+            $context = $root ? $root->getContent() : '';
+            $match = $element->getMatch();
+
+            if (Str::is($context) && Str::is($match)) {
+                $position = Str::pos($context, $match);
+                if ($position !== false) {
+                    $context = (string)Str::sub($context, 0, $position);
+                }
+            }
+        }
+
+        $originalEstimatedTokens = $this->estimateTokens($context);
+        $maxContextTokens = $this->normalizePositiveInt($element->getAttribute('max_context_tokens')) ?? 0;
+        $truncated = false;
+
+        if ($context !== '' && $maxContextTokens > 0 && $originalEstimatedTokens > $maxContextTokens) {
+            $truncated = true;
+            $context = $this->truncateToTokenWindow($context, $maxContextTokens);
+        }
+
+        $estimatedTokens = $this->estimateTokens($context);
+
+        return [
+            'prompt' => $context,
+            'requested_strategy' => $requestedStrategy,
+            'strategy' => $strategy,
+            'supported' => $supported,
+            'thread' => $element->getAttribute('thread'),
+            'session' => $element->getAttribute('session'),
+            'max_context_tokens' => $maxContextTokens,
+            'truncated' => $truncated,
+            'estimated_tokens' => $estimatedTokens,
+            'original_estimated_tokens' => $originalEstimatedTokens,
+            'dropped_estimated_tokens' => max(0, $originalEstimatedTokens - $estimatedTokens),
+        ];
+    }
+
+    protected function buildEventMetadata(
+        Element $element,
+        array $config,
+        array $profile,
+        array $context,
+        int $attempt,
+        int $retries,
+        string $prompt
+    ): array {
+        return [
+            'placeholder' => $element->getTag(),
+            'element' => $this->resolveElementName($element),
+            'tag' => $element->getTag(),
+            'label' => $element->getAttribute('label'),
+            'phase' => $element->getAttribute('phase'),
+            'chapter' => $element->getAttribute('chapter'),
+            'section' => $element->getAttribute('section'),
+            'profile' => $profile['name'] ?? null,
+            'attempt' => $attempt,
+            'retries' => $retries,
+            'config' => $config,
+            'thread' => $context['thread'] ?? null,
+            'session' => $context['session'] ?? null,
+            'context' => [
+                'requested_strategy' => $context['requested_strategy'] ?? 'prefix',
+                'strategy' => $context['strategy'] ?? 'prefix',
+                'supported' => $context['supported'] ?? true,
+                'max_context_tokens' => $context['max_context_tokens'] ?? 0,
+                'truncated' => $context['truncated'] ?? false,
+                'estimated_tokens' => $context['estimated_tokens'] ?? 0,
+                'original_estimated_tokens' => $context['original_estimated_tokens'] ?? 0,
+                'dropped_estimated_tokens' => $context['dropped_estimated_tokens'] ?? 0,
+            ],
+            'usage' => $this->normalizeUsage(null, $prompt, ''),
+        ];
+    }
+
+    protected function truncateToTokenWindow(string $context, int $maxTokens): string
+    {
+        if ($context === '' || $maxTokens <= 0) {
+            return $context;
+        }
+
+        $maxCharacters = $maxTokens * 4;
+        if (Str::len($context) <= $maxCharacters) {
+            return $context;
+        }
+
+        return (string)Str::sub($context, -$maxCharacters);
+    }
+
+    protected function normalizePositiveInt($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $int = (int)$value;
+        return $int > 0 ? $int : null;
+    }
+
+    protected function estimateTokens(string $text): int
+    {
+        $text = Str::trim($text);
+        if ($text === '') {
+            return 0;
+        }
+
+        $characters = Str::len($text);
+        preg_match_all('/\S+/u', $text, $matches);
+        $wordCount = count($matches[0] ?? []);
+
+        return max($wordCount, (int)ceil($characters / 4));
+    }
+
+    protected function extractUsage($reply): array
+    {
+        $usage = null;
+
+        if (Val::is($reply) && method_exists($reply, 'usage')) {
+            $usage = $reply->usage();
+        } elseif (Val::is($reply) && property_exists($reply, 'usage')) {
+            $usage = $reply->usage;
+        } elseif (Val::is($reply) && method_exists($reply, 'metadata')) {
+            $metadata = $reply->metadata();
+            $usage = Arr::is($metadata) ? ($metadata['usage'] ?? null) : null;
+        } elseif (Val::is($reply) && method_exists($reply, 'meta')) {
+            $metadata = $reply->meta();
+            $usage = Arr::is($metadata) ? ($metadata['usage'] ?? null) : null;
+        }
+
+        return Arr::is($usage) ? $usage : [];
+    }
+
+    protected function normalizeUsage($reply, string $prompt, string $output): array
+    {
+        $usage = $this->extractUsage($reply);
+
+        $promptTokens = $usage['prompt_tokens'] ?? $usage['input_tokens'] ?? null;
+        $completionTokens = $usage['completion_tokens'] ?? $usage['output_tokens'] ?? $usage['generated_tokens'] ?? null;
+        $totalTokens = $usage['total_tokens'] ?? null;
+
+        if ($totalTokens === null && is_numeric($promptTokens) && is_numeric($completionTokens)) {
+            $totalTokens = (int)$promptTokens + (int)$completionTokens;
+        }
+
+        return [
+            'prompt_tokens' => is_numeric($promptTokens) ? (int)$promptTokens : null,
+            'completion_tokens' => is_numeric($completionTokens) ? (int)$completionTokens : null,
+            'total_tokens' => is_numeric($totalTokens) ? (int)$totalTokens : null,
+            'estimated_prompt_tokens' => $this->estimateTokens($prompt),
+            'estimated_completion_tokens' => $this->estimateTokens($output),
+            'estimated_total_tokens' => $this->estimateTokens($prompt) + $this->estimateTokens($output),
+        ];
+    }
+
+    protected function recordUsage(Element $element, array $metadata, array $usage, string $output, bool $accepted): void
+    {
+        $entry = [
+            'element' => $metadata['element'] ?? $this->resolveElementName($element),
+            'placeholder' => $metadata['placeholder'] ?? $element->getTag(),
+            'label' => $metadata['label'] ?? null,
+            'phase' => $metadata['phase'] ?? null,
+            'chapter' => $metadata['chapter'] ?? null,
+            'section' => $metadata['section'] ?? null,
+            'profile' => $metadata['profile'] ?? null,
+            'attempt' => $metadata['attempt'] ?? 1,
+            'retries' => $metadata['retries'] ?? 1,
+            'thread' => $metadata['thread'] ?? null,
+            'session' => $metadata['session'] ?? null,
+            'context' => $metadata['context'] ?? [],
+            'accepted' => $accepted,
+            'output' => $output,
+            'usage' => $usage,
+        ];
+
+        $this->usageLedger[$element->getUuid()][] = $entry;
+
+        foreach (['prompt_tokens', 'completion_tokens', 'total_tokens', 'estimated_prompt_tokens', 'estimated_completion_tokens', 'estimated_total_tokens'] as $key) {
+            if (isset($usage[$key]) && is_numeric($usage[$key])) {
+                $this->usageTotals[$key] += (int)$usage[$key];
+            }
+        }
+    }
+
+    protected function gatherPromptContext(Element $element): string
+    {
         $root = $element->getRoot();
         $context = $root ? $root->getContent() : '';
         $match = $element->getMatch();
@@ -223,6 +492,16 @@ class LLMGenerator implements IGenerator, IDispatcher {
         }
 
         return '';
+    }
+
+    protected function resolveElementName(Element $element): string
+    {
+        $name = $element->getAttribute('name');
+        if (Str::is($name) && Str::trim($name) !== '') {
+            return (string)$name;
+        }
+
+        return $element->getTag() . '_' . substr(md5($element->getUuid()), 0, 8);
     }
 
     protected function resolveProfile(Element $element): array
@@ -278,9 +557,5 @@ class LLMGenerator implements IGenerator, IDispatcher {
         }
 
         $this->buffer[$target] = $output;
-        $this->dispatch(Event::RECEIVED, new Meta(when: State::RUNNING, data: [
-            'placeholder' => $element->getTag(),
-            'value' => $output
-        ], src: $this));
     }
 }

--- a/tests/Automata/LLM/FillInProfileTest.php
+++ b/tests/Automata/LLM/FillInProfileTest.php
@@ -5,6 +5,8 @@ namespace BlueFission\Tests\Automata\LLM;
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\FillIn;
 use BlueFission\Automata\LLM\Reply;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
 use PHPUnit\Framework\TestCase;
 
 class RecordingClient implements IClient
@@ -61,6 +63,41 @@ class ReplyOnlyClient extends RecordingClient
     }
 }
 
+class UsageReply extends Reply
+{
+    public function __construct(private array $usage = [])
+    {
+        parent::__construct();
+    }
+
+    public function usage(): array
+    {
+        return $this->usage;
+    }
+}
+
+class UsageRecordingClient extends RecordingClient
+{
+    public function __construct(string $response, private array $usage = [])
+    {
+        parent::__construct($response);
+    }
+
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $this->prompts[] = (string)$input;
+
+        $reply = new UsageReply($this->usage);
+        $reply->addMessage('observed', true);
+
+        if ($callback) {
+            $callback('observed');
+        }
+
+        return $reply;
+    }
+}
+
 class FillInProfileTest extends TestCase
 {
     public function testFillInUsesReplyOutputWhenClientDoesNotStream(): void
@@ -110,5 +147,89 @@ class FillInProfileTest extends TestCase
         $this->assertCount(0, $default->prompts);
         $this->assertCount(1, $editor->prompts);
         $this->assertStringStartsWith("You are the editorial profile.\n\nHello ", $editor->prompts[0]);
+    }
+
+    public function testFillInExposesGenerationMetadataAndUsage(): void
+    {
+        $client = new UsageRecordingClient('observed', [
+            'prompt_tokens' => 11,
+            'completion_tokens' => 4,
+            'total_tokens' => 15,
+        ]);
+
+        $fillIn = new FillIn(
+            $client,
+            'Intro preface for the report body {=content profile="editorial" label="Chapter 3 / Section 2" phase="draft" chapter="3" section="2" thread="report-42" session="run-7" context_strategy="windowed-prefix" max_context_tokens="2"}'
+        );
+        $fillIn->registerProfileOverride('editorial', [
+            'prompt' => 'You are the editorial profile.',
+        ]);
+
+        $sent = [];
+        $received = [];
+        $fillIn->when(Event::SENT, function ($behavior, $meta) use (&$sent) {
+            $sent[] = $meta;
+        });
+        $fillIn->when(Event::RECEIVED, function ($behavior, $meta) use (&$received) {
+            $received[] = $meta;
+        });
+
+        $fillIn->run();
+
+        $this->assertNotEmpty($sent);
+        $this->assertNotEmpty($received);
+        $this->assertInstanceOf(Meta::class, $sent[0]);
+
+        $sentData = $sent[0]->data;
+        $this->assertSame('Chapter 3 / Section 2', $sentData['label']);
+        $this->assertSame('draft', $sentData['phase']);
+        $this->assertSame('3', $sentData['chapter']);
+        $this->assertSame('2', $sentData['section']);
+        $this->assertSame('editorial', $sentData['profile']);
+        $this->assertSame(1, $sentData['attempt']);
+        $this->assertSame('report-42', $sentData['thread']);
+        $this->assertSame('run-7', $sentData['session']);
+        $this->assertSame('windowed-prefix', $sentData['context']['strategy']);
+        $this->assertTrue($sentData['context']['truncated']);
+
+        $finalEvents = array_values(array_filter($received, function ($meta) {
+            return $meta instanceof Meta && (($meta->data['final'] ?? false) === true);
+        }));
+
+        $this->assertNotEmpty($finalEvents);
+        $finalData = $finalEvents[0]->data;
+
+        $this->assertSame('observed', $finalData['value']);
+        $this->assertTrue($finalData['accepted']);
+        $this->assertSame(11, $finalData['usage']['prompt_tokens']);
+        $this->assertSame(4, $finalData['usage']['completion_tokens']);
+        $this->assertSame(15, $finalData['usage']['total_tokens']);
+        $this->assertGreaterThan(0, $finalData['usage']['estimated_total_tokens']);
+
+        $ledger = $fillIn->usageLedger();
+        $this->assertCount(1, $ledger);
+        $entries = array_values($ledger)[0];
+        $this->assertCount(1, $entries);
+        $this->assertSame('Chapter 3 / Section 2', $entries[0]['label']);
+        $this->assertTrue($entries[0]['accepted']);
+        $this->assertSame(15, $entries[0]['usage']['total_tokens']);
+
+        $totals = $fillIn->usageTotals();
+        $this->assertSame(11, $totals['prompt_tokens']);
+        $this->assertSame(4, $totals['completion_tokens']);
+        $this->assertSame(15, $totals['total_tokens']);
+        $this->assertGreaterThan(0, $totals['estimated_total_tokens']);
+    }
+
+    public function testContextStrategyNoneSkipsPrefixContext(): void
+    {
+        $client = new RecordingClient('clean');
+        $fillIn = new FillIn($client, 'Preface {=content context_strategy="none"}');
+
+        $fillIn->run();
+
+        $this->assertSame('Preface clean', $fillIn->output());
+        $this->assertCount(1, $client->prompts);
+        $this->assertSame('', $client->prompts[0]);
     }
 }


### PR DESCRIPTION
## Summary

This follows the merged profile bootstrap work with runtime observability and usage accounting for Automata LLM generation.

## What Changed

- preserve `Meta` payloads through the `FillIn` listener path so host runners can inspect real generation events
- enrich `Event::SENT` / `Event::RECEIVED` with generation metadata:
  - `label`, `phase`, `chapter`, `section`
  - resolved `profile`
  - `attempt` / retry ceiling
  - `thread` / `session`
  - explicit context strategy and truncation metadata
- add generation usage accounting:
  - provider usage when available (`prompt_tokens`, `completion_tokens`, `total_tokens`)
  - estimated token counts when provider usage is absent
  - per-element usage ledger via `FillIn::usageLedger()`
  - cumulative totals via `FillIn::usageTotals()`
- support explicit context attrs:
  - `context_strategy="none"`
  - `context_strategy="prefix"`
  - `context_strategy="windowed-prefix"`
  - `max_context_tokens="..."`

## Files

- `src/Automata/LLM/FillIn.php`
- `src/Automata/Parsing/Generators/LLMGenerator.php`
- `tests/Automata/LLM/FillInProfileTest.php`

## Tests

```bash
vendor/bin/phpunit --do-not-cache-result tests/Automata/LLM tests/Automata/Parsing tests/Examples/VibeProfileFillInExampleTest.php
```

## Notes

- provider-backed thread/session reuse is not implemented yet; `thread` and `session` are currently emitted as structured metadata for host orchestration
- `windowed-prefix` currently uses a heuristic token estimate to make truncation explicit and inspectable