### PR TITLE
Retrofit worldview adapters and examples

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,6 +57,40 @@ The Intelligence Hub builds on `Automata\Intelligence` by:
 - Aggregating outputs into structured insights plus a gestalt summary
   suitable for an application or LLM coordinator.
 
+### 2.1.1 Carrier-First Adapter Layer
+
+Automata's worldview-facing abstractions should follow Develation's actual
+"single signature" architecture:
+
+- `Val` / `Arr` provide value and structured-state carriers.
+- `Obj` provides a common object carrier over an internal `$_data` bag.
+- `Data` / `IData` provide the same carrier semantics plus read/write/delete
+  lifecycle for store-backed state.
+
+Automata should not collapse these into one concrete worldview class. Instead,
+it should layer small adapters over the carrier types and let utilities depend
+on those adapters only where it is functionally useful.
+
+Current adapter layer:
+
+- `Automata\Adapters\CarrierAdapter` wraps `Obj`.
+- `Automata\Adapters\StateAdapter` wraps array/`Arr`/`Obj`/`IData` state.
+- `Automata\Adapters\StoreAdapter` wraps `IData`.
+
+Current evaluator surface:
+
+- `Automata\Support\Evaluates` normalizes `Func`-backed invocation and
+  `Num`-backed score coercion for modules that expose configurable
+  assessors/fitness hooks.
+- `Path`, `DecisionTree`, `Genetic`, `Feedback`, `Intelligence`, and `Engine`
+  are the first consumers of that evaluator surface.
+- This keeps extension points aligned with Develation primitives instead of
+  inventing parallel callback and scoring conventions inside Automata.
+
+This keeps shared signatures stable while preserving different internal
+mechanics across runtime objects, stores, simulations, and comprehension
+systems.
+
 ### 2.2 Strategy Layer
 
 **Key modules:**
@@ -131,6 +165,17 @@ Responsibilities:
   simulation.
 - Contribute data structures and algorithms that tie directly into memory and
   comprehension.
+
+These modules should consume carrier-backed adapters selectively rather than
+inherit a shared worldview implementation. For example:
+
+- `Simulation` can accept adapter-backed state without becoming a `Domain`.
+- `DecisionTree` accepts injected `Func` assessors over carrier-backed state.
+- `Path` accepts state-aware `Func` fitness/assessment hooks without depending
+  on `Simulation` or `Comprehension`.
+- `Genetic`, `Feedback`, `Intelligence`, and `Engine` now reuse the same
+  `Func`/`Num`/`Arr`/`Str` conventions for mutation, scoring, classification,
+  and runtime budgeting.
 
 ### 2.6 Memory, ABS, and Comprehension Layer
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Data Science**: Basic machine learning functionalities alongside data manipulation, preparation, and visualization tools.
 - **Input Management**: Sophisticated input type detection and handling, ensuring that data flows seamlessly through processing pipelines.
 - **Modular Connectivity**: Connect module outputs to other module inputs, creating flexible and dynamic pipeline chains for complex data processing tasks.
+- **Carrier-Backed Adapters**: Normalize runtime state over Develation `Arr`, `Obj`, and `IData` carriers without forcing unrelated modules into one implementation.
+- **Develation-Native Evaluation Seams**: Core orchestration modules now accept DevElation `Func` evaluators and prefer `Num`, `Arr`, and `Str` helpers for shared numeric, collection, and string handling where that materially improves interoperability.
 
 ## Using GOFAI and Modern ML Techniques
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -56,6 +56,38 @@ not a replacement for its collections or behavior system. When there is overlap
 (e.g., collections), Automata’s versions are tailored for heavy AI use and large
 data sets.
 
+### 2.1 Carrier Signature and Adapters
+
+Develation's practical "single signature" is carrier-based:
+
+- `Val` / `Arr` for values and structured state
+- `Obj` for object-backed state via `field()` / `assign()` / `toArray()`
+- `Data` / `IData` for store-backed state with `read()` / `write()` /
+  `contents()`
+
+Automata should build on that carrier signature rather than forcing unrelated
+utilities into one worldview superclass. The preferred pattern is:
+
+- use prototype traits only on carriers that actually benefit from them
+- use adapters when a utility only needs a normalized state/object/store surface
+- keep mechanics injectable so utilities share data shape, not internal logic
+
+Initial adapter layer in Automata:
+
+- `CarrierAdapter` for `Obj`
+- `StateAdapter` for array/`Arr`/`Obj`/`IData`
+- `StoreAdapter` for `IData`
+
+Evaluation and orchestration seams that previously depended on raw PHP
+callables and ad hoc scalar helpers should prefer Develation-native surfaces
+when practical:
+
+- `Func` for strategy hooks, assessors, classifiers, providers, and fitness
+  callbacks
+- `Num` for score normalization, budgets, mutation math, and timing math
+- `Arr` / `Collection` for carrier-aligned list and map transforms
+- `Str` for normalization of labels and identifiers
+
 ## 3. Core Concepts
 
 ### 3.1 Intelligence Engine
@@ -195,6 +227,14 @@ Goals:
   - legal actions,
   - payoffs and utilities.
 - Enable agents (human or automated) to experiment with strategies and payoffs.
+
+Simulation should be able to run against carrier-backed state without implying
+that simulation is the canonical domain implementation. Runtime state may come
+from plain arrays, `Arr`, `Obj`, or `IData` via adapters.
+
+Decision, pathing, genetic, feedback, and intelligence utilities should follow
+the same pattern: consume adapter-backed state and DevElation-native evaluator
+objects without requiring one canonical domain implementation.
 
 ### 3.9 Genetic Algorithms
 
@@ -455,6 +495,8 @@ Future directions:
   latency, cost, and stability over time.
 - Decouple php-ml behind model interfaces/wrappers and allow alternative ML
   backends (Rubix, optional Python bridges) without changing Automata APIs.
+- Add injected assessors and adapter-aware utility hooks for modules that
+  benefit from worldview state without forcing broad cross-module coupling.
 
 ## 6. Example Specifications
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,16 @@ Notable examples:
 
 - `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an activity.
 - `examples/anomaly_logistics_requests.php` – KNN-based anomaly scoring over logistics requests.
-- `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
+- `examples/graph_routing_logistics.php` – route planning with `Func` fitness plus state-aware assessment.
+- `examples/graph_route_allocation_logistics.php` – route allocation where the fitness hook can see asset and demand context.
+- `examples/decision_tree_dispatch_policy.php` – decision trees with shared method state and injected assessors.
+- `examples/carrier_backed_simulation.php` – simulation over object-backed state via the carrier adapter seam.
+- `examples/entity_condition_worldview.php` – worldview-oriented `Entity` and `Condition` snapshot/explain contracts.
+- `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
+- `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
 
 Additional examples will be added as modules are fleshed out and tested.
+
+Many branch-local examples load `examples/bootstrap.php` so they execute against
+the worktree source rather than another checkout.
 

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/tests/bootstrap.php';
+
+function automata_example_require(string ...$relativePaths): void
+{
+    $srcRoot = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
+
+    foreach ($relativePaths as $relativePath) {
+        $normalized = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $relativePath);
+        require_once $srcRoot . $normalized;
+    }
+}

--- a/examples/carrier_adapters_basic.php
+++ b/examples/carrier_adapters_basic.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../tests/bootstrap.php';
+
+use BlueFission\Obj;
+use BlueFission\Automata\Adapters\CarrierAdapter;
+use BlueFission\Automata\Adapters\StateAdapter;
+
+$carrier = new class extends Obj {
+};
+$carrier->assign([
+    'status' => 'draft',
+    'metrics' => [
+        'load' => 2,
+    ],
+]);
+
+$carrierAdapter = new CarrierAdapter($carrier);
+$stateAdapter = StateAdapter::wrap($carrier);
+$stateAdapter
+    ->set('metrics.load', 5)
+    ->set('metrics.health', 'watch')
+    ->set('status', 'ready')
+    ->sync();
+
+echo json_encode([
+    'carrier_snapshot' => $carrierAdapter->snapshot(),
+    'state_snapshot' => $stateAdapter->snapshot(),
+    'carrier_status' => $carrierAdapter->field('status'),
+], JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/carrier_backed_simulation.php
+++ b/examples/carrier_backed_simulation.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/bootstrap.php';
+automata_example_require('Automata/Simulation/Simulation.php');
+
+use BlueFission\Obj;
+use BlueFission\Num;
+use BlueFission\Automata\Simulation\Simulation;
+use BlueFission\Automata\Simulation\ISimulatable;
+
+class QueuePressureEntity implements ISimulatable
+{
+    public function step(int $tick, array &$worldState): void
+    {
+        $queue = $worldState['queue'] ?? 0;
+        $processed = ($tick % 2 === 0) ? 1 : 2;
+
+        $queue = Num::add($queue, 3);
+        $queue = Num::max(0, Num::sub($queue, $processed));
+
+        $worldState['queue'] = $queue;
+        $worldState['status'] = $queue > 4 ? 'congested' : 'stable';
+    }
+}
+
+$state = new class extends Obj {
+};
+$state->assign([
+    'queue' => 1,
+    'status' => 'stable',
+]);
+
+$simulation = new Simulation(4);
+$simulation->addEntity(new QueuePressureEntity());
+
+$timeline = $simulation->run($state);
+
+echo json_encode([
+    'timeline' => $timeline,
+    'final_state' => $state->toArray(),
+], JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/decision_tree_dispatch_policy.php
+++ b/examples/decision_tree_dispatch_policy.php
@@ -2,8 +2,15 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
+automata_example_require(
+    'Automata/DecisionTree/INode.php',
+    'Automata/DecisionTree/BaseMethod.php',
+    'Automata/DecisionTree/Node.php',
+    'Automata/DecisionTree/DepthFirstTraceMethod.php'
+);
 
+use BlueFission\Func;
 use BlueFission\Automata\DecisionTree\DecisionTree;
 use BlueFission\Automata\DecisionTree\Node;
 use BlueFission\Automata\DecisionTree\DepthFirstTraceMethod;
@@ -14,12 +21,13 @@ use BlueFission\Automata\DecisionTree\DepthFirstTraceMethod;
  * This example builds a small policy tree for handling
  * incoming requests and demonstrates how to obtain both
  * a decision and an explanation trace using
- * DepthFirstTraceMethod.
+ * DepthFirstTraceMethod with shared runtime state plus
+ * an injected assessor.
  */
 
-$eval = function (array $value, array $children): float {
+$eval = new Func(function (array $value): float {
     return (float)($value['score'] ?? 0.0);
-};
+});
 
 $root = new Node([
     'id' => 'root',
@@ -67,10 +75,41 @@ $evacCritical->addChild($escalateAir);
 $tree = new DecisionTree();
 $tree->setRoot($root);
 
-$method = new DepthFirstTraceMethod();
+$method = (new DepthFirstTraceMethod())
+    ->setState([
+        'resources' => [
+            'airlift_ready' => false,
+            'ground_units' => 3,
+        ],
+        'request' => [
+            'severity' => 'critical',
+            'people_at_risk' => 42,
+        ],
+    ])
+    ->setAssessor(new Func(function (array $value, array $children, array $state): float {
+        $score = (float)($value['score'] ?? 0.0);
+
+        if (($value['decision'] ?? null) === 'escalate_to_airlift' && !($state['resources']['airlift_ready'] ?? false)) {
+            $score -= 5.0;
+        }
+
+        if (($value['decision'] ?? null) === 'accept_ground_dispatch' && ($state['resources']['ground_units'] ?? 0) > 0) {
+            $score += 2.0;
+        }
+
+        if (($state['request']['severity'] ?? null) === 'critical' && str_contains((string)($value['decision'] ?? ''), 'dispatch')) {
+            $score += 1.0;
+        }
+
+        return $score;
+    }));
 $decision = $tree->decide($method);
 
 echo "=== Dispatch Policy Decision Tree Example ===\n\n";
+echo "Method state:\n";
+echo "- airlift_ready: false\n";
+echo "- ground_units: 3\n";
+echo "- request severity: critical\n\n";
 
 echo "Decision: " . ($decision['decision'] ?? 'unknown') . "\n\n";
 

--- a/examples/disaster_response/simulation_world/run.php
+++ b/examples/disaster_response/simulation_world/run.php
@@ -3,10 +3,13 @@
 declare(strict_types=1);
 
 use BlueFission\DevElation;
+use BlueFission\Num;
+use BlueFission\Obj;
 use BlueFission\Automata\Simulation\Simulation;
 use BlueFission\Automata\Simulation\ISimulatable;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
+automata_example_require('Automata/Simulation/Simulation.php');
 
 $seed = 123;
 foreach ($argv as $arg) {
@@ -31,9 +34,9 @@ class RoadConditionEntity implements ISimulatable
         $index = $worldState['road_condition_index'] ?? 1.0;
 
         if ($tick < 5) {
-            $index += 0.5;
+            $index = Num::add($index, 0.5);
         } elseif ($tick >= 10) {
-            $index = max(0.0, $index - 0.5);
+            $index = Num::max(0.0, Num::sub($index, 0.5));
         }
 
         $worldState['road_condition_index'] = $index;
@@ -47,7 +50,7 @@ class DemandEntity implements ISimulatable
         $base = $worldState['demand_level'] ?? 0.0;
         $increment = ($tick < 8) ? 5.0 : 2.0;
 
-        $worldState['demand_level'] = $base + $increment;
+        $worldState['demand_level'] = Num::add($base, $increment);
     }
 }
 
@@ -56,16 +59,19 @@ $sim   = new Simulation($ticks);
 $sim->addEntity(new RoadConditionEntity());
 $sim->addEntity(new DemandEntity());
 
-$initial = [
+$state = new class extends Obj {
+};
+$state->assign([
     'road_condition_index' => 1.0,
-    'demand_level'         => 0.0,
-];
+    'demand_level' => 0.0,
+]);
 
-$log = $sim->run($initial);
+$log = $sim->run($state);
 
 echo json_encode([
     'seed' => $seed,
     'ticks' => $ticks,
     'timeline' => $log,
+    'final_state' => $state->toArray(),
 ], JSON_PRETTY_PRINT) . PHP_EOL;
 

--- a/examples/entity_condition_worldview.php
+++ b/examples/entity_condition_worldview.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/bootstrap.php';
+automata_example_require(
+    'Automata/Comprehension/Entity.php',
+    'Automata/Goal/Condition.php'
+);
+
+use BlueFission\Automata\Comprehension\Entity;
+use BlueFission\Automata\Goal\Condition;
+
+$entity = new Entity('Warehouse A', 'Regional warehouse', ['category' => 'place']);
+$entity
+    ->addLabel('place')
+    ->addLabel('storage')
+    ->defineDimension('x', ['kind' => 'absolute', 'unit' => 'km'])
+    ->defineDimension('time', ['kind' => 'relative', 'unit' => 'minutes'])
+    ->coordinate('x', 12)
+    ->coordinate('time', 5)
+    ->relate('supplies', 'Hospital A', ['distance_km' => 12])
+    ->record('status', ['condition' => 'operational']);
+
+$condition = new Condition([
+    'path' => 'coordinates.x',
+    'operator' => 'gte',
+    'value' => 10,
+    'weight' => 2,
+]);
+
+echo json_encode([
+    'entity_summary' => $entity->explain(),
+    'entity' => $entity->snapshot(),
+    'condition_summary' => $condition->explain(),
+    'condition' => $condition->snapshot(),
+    'matches_entity' => $condition->matches($entity->snapshot()),
+], JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/generic/disaster_response/sim/ResponderPlayer.php
+++ b/examples/generic/disaster_response/sim/ResponderPlayer.php
@@ -10,12 +10,13 @@ use Examples\DisasterResponse\Sim\Position;
 class ResponderPlayer extends Player
 {
     private ?string $lastDecision = null;
-    private Position $position;
+    private Position $gridPosition;
 
     public function __construct(string $name, Position $position)
     {
         parent::__construct($name);
-        $this->position = $position;
+        $this->gridPosition = $position;
+        parent::position($position->toArray());
     }
 
     public function decide()
@@ -31,9 +32,20 @@ class ResponderPlayer extends Player
         return $this->lastDecision;
     }
 
-    public function position(): Position
+    public function position(mixed $position = null): mixed
     {
-        return $this->position;
+        if (func_num_args() === 0) {
+            return $this->gridPosition;
+        }
+
+        if (!$position instanceof Position) {
+            throw new \InvalidArgumentException('ResponderPlayer position expects a Position instance.');
+        }
+
+        $this->gridPosition = $position;
+        parent::position($position->toArray());
+
+        return $this;
     }
 
     public function move(Position $position, Grid $grid): bool
@@ -42,7 +54,7 @@ class ResponderPlayer extends Player
             return false;
         }
 
-        $this->position = $position;
+        $this->position($position);
         return true;
     }
 }

--- a/examples/generic/intelligence_engine_insights.php
+++ b/examples/generic/intelligence_engine_insights.php
@@ -1,15 +1,17 @@
 <?php
 
-require dirname(__DIR__, 2) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
+automata_example_require(
+    'Automata/Intelligence.php',
+    'Automata/Engine.php'
+);
 
 use BlueFission\Automata\Engine;
 use BlueFission\Automata\InputType;
 use BlueFission\Automata\Context;
-use BlueFission\Automata\Intent\Intent;
-use BlueFission\Automata\Intent\KeywordIntentAnalyzer;
-use BlueFission\Automata\Analysis\KeywordTopicAnalyzer;
-use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
 use BlueFission\Automata\Strategy\IStrategy;
+use BlueFission\Func;
+use BlueFission\Str;
 
 class EchoInsightStrategy implements IStrategy
 {
@@ -45,60 +47,43 @@ $engine->registerStrategyProfile(new EchoInsightStrategy(), 'echo', [
     'weight' => 2,
 ]);
 
-$modelDir = dirname(__DIR__, 2) . '/artifacts/models/';
 $context = new Context();
 $context->set('channel', 'example');
 
-$intents = [
-    'support' => new Intent('support', 'Support', [
-        'keywords' => [
-            ['word' => 'help', 'priority' => 1],
-            ['word' => 'error', 'priority' => 0.9],
-            ['word' => 'issue', 'priority' => 0.8],
-        ],
-    ]),
-    'billing' => new Intent('billing', 'Billing', [
-        'keywords' => [
-            ['word' => 'invoice', 'priority' => 1],
-            ['word' => 'payment', 'priority' => 0.9],
-            ['word' => 'charge', 'priority' => 0.8],
-        ],
-    ]),
-];
-
-$topics = [
-    'technical' => [
-        ['text' => 'error', 'weight' => 1],
-        ['text' => 'crash', 'weight' => 0.8],
-        ['text' => 'bug', 'weight' => 0.7],
-    ],
-    'billing' => [
-        ['text' => 'invoice', 'weight' => 1],
-        ['text' => 'payment', 'weight' => 0.9],
-        ['text' => 'refund', 'weight' => 0.6],
-    ],
-];
-
 $engine->setContext($context);
-$engine->setIntentCatalog($intents);
-$engine->registerIntentAnalyzer(
-    new KeywordIntentAnalyzer(new NaiveBayesTextClassification(), $modelDir)
-);
-$topicAnalyzer = new KeywordTopicAnalyzer(new NaiveBayesTextClassification(), $modelDir);
-$engine->registerContextProvider(function ($payload) use ($context, $topics, $topicAnalyzer) {
-    return $topicAnalyzer->analyze((string)$payload, $context, $topics);
-});
+$engine->setIntentCatalog([
+    'support' => 'Support',
+    'billing' => 'Billing',
+]);
+$engine->registerIntentAnalyzer(new Func(function ($payload) {
+    $text = strtolower((string)$payload);
 
-$engine->registerStructureClassifier(function ($payload) {
-    return ['structure' => 'plain_text', 'length' => strlen((string)$payload)];
-});
+    if (str_contains($text, 'invoice') || str_contains($text, 'payment')) {
+        return ['billing' => 0.95];
+    }
 
-$engine->registerContextProvider(function () {
-    return ['source' => 'example'];
-});
+    if (str_contains($text, 'help') || str_contains($text, 'error')) {
+        return ['support' => 0.9];
+    }
+
+    return ['general' => 0.4];
+}));
+
+$engine->registerStructureClassifier(new Func(function ($payload) {
+    return ['structure' => 'plain_text', 'length' => Str::len((string)$payload)];
+}));
+
+$engine->registerContextProvider(new Func(function ($payload) {
+    $text = strtolower((string)$payload);
+
+    return [
+        'source' => 'example',
+        'topic' => str_contains($text, 'invoice') ? 'billing' : 'support',
+    ];
+}));
 
 $report = $engine->analyzeWithAttention('My invoice failed and I need help fixing this error.', [
     'strategy_budget' => 1,
 ]);
 
-print_r($report);
+echo json_encode($report, JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/graph_route_allocation_logistics.php
+++ b/examples/graph_route_allocation_logistics.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
+automata_example_require('Automata/Path/RouteAllocator.php');
 
+use BlueFission\Func;
 use BlueFission\Automata\Path\Graph;
 use BlueFission\Automata\Path\Node;
 use BlueFission\Automata\Path\RouteAllocator;
@@ -18,7 +20,8 @@ use BlueFission\Automata\Path\RouteAllocator;
  *   and via Highway-Loop (lower risk, higher capacity).
  *
  * We allocate flow while respecting edge capacities and
- * preferring safer routes.
+ * preferring safer routes, with a fitness hook that can
+ * see the asset and demand context.
  */
 
 function buildLogisticsGraph(): Graph
@@ -50,7 +53,7 @@ function buildLogisticsGraph(): Graph
 
 $graph = buildLogisticsGraph();
 
-$fitness = function (array $edge): float {
+$fitness = new Func(function (array $edge, array $asset, array $demand): float {
     if (!empty($edge['blocked'])) {
         return (float)(PHP_INT_MAX / 4);
     }
@@ -58,8 +61,11 @@ $fitness = function (array $edge): float {
     $time = $edge['time'] ?? 0;
     $risk = $edge['risk'] ?? 0;
 
-    return (float)($time + $risk * 20);
-};
+    $urgencyPenalty = (($demand['priority'] ?? 0) >= 10 && $time > 25) ? 10.0 : 0.0;
+    $capacityBias = (($asset['capacity'] ?? 0.0) >= 4.0) ? -5.0 : 0.0;
+
+    return (float)($time + $risk * 20 + $urgencyPenalty + $capacityBias);
+});
 
 $allocator = new RouteAllocator($graph, $fitness);
 
@@ -82,6 +88,7 @@ $edgeCapacities = [
 $allocations = $allocator->allocate($assets, $demands, $edgeCapacities);
 
 echo "=== Graph Route Allocation Logistics Example ===\n\n";
+echo "Fitness hook considers: edge risk/time, demand priority, and asset capacity.\n\n";
 
 foreach ($allocations as $alloc) {
     $assetId = $alloc['asset_id'];

--- a/examples/graph_routing_logistics.php
+++ b/examples/graph_routing_logistics.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
+automata_example_require('Automata/Path/RoutePlanner.php');
 
+use BlueFission\Func;
+use BlueFission\Obj;
 use BlueFission\Automata\Path\Graph;
 use BlueFission\Automata\Path\Node;
 use BlueFission\Automata\Path\RoutePlanner;
@@ -15,8 +18,9 @@ use BlueFission\Automata\Path\RoutePlanner;
  * - Hub-1 needs to reach Hospital-A.
  * - Two routes exist: via Bridge-1 (faster but high risk) and via Highway-Loop
  *   (slower but safer).
- * - We compute best routes under a time + risk fitness function and then
- *   simulate blocked edges to demonstrate rerouting.
+ * - We compute best routes under a time + risk fitness function.
+ * - We then apply a state-aware assessor that penalizes risky edges more
+ *   aggressively during rain-sensitive medical runs.
  */
 
 function buildLogisticsGraph(bool $blockHighway = false): Graph
@@ -58,23 +62,55 @@ function buildLogisticsGraph(bool $blockHighway = false): Graph
     return $graph;
 }
 
-$fitness = function (array $edge): int {
+$worldState = new class extends Obj {
+};
+$worldState->assign([
+    'weather' => 'rain',
+    'mission' => 'medical',
+]);
+
+$fitness = new Func(function (array $edge): int {
     if (!empty($edge['blocked'])) {
-        return PHP_INT_MAX / 4;
+        return intdiv(PHP_INT_MAX, 4);
     }
 
     $time = $edge['time'] ?? 0;
     $risk = $edge['risk'] ?? 0;
 
     return $time + $risk * 20;
-};
+});
+
+$assessor = new Func(function (array $edge, array $state, array $context): int {
+    if (!empty($edge['blocked'])) {
+        return intdiv(PHP_INT_MAX, 4);
+    }
+
+    $time = $edge['time'] ?? 0;
+    $risk = $edge['risk'] ?? 0;
+    $score = $time + $risk * 20;
+
+    if (($state['weather'] ?? null) === 'rain' && $risk >= 4) {
+        $score += 25;
+    }
+
+    if (($context['priority'] ?? null) === 'life_safety' && $time > 25) {
+        $score += 10;
+    }
+
+    return $score;
+});
 
 echo "=== Graph Routing Logistics Example ===\n\n";
+echo "World state:\n";
+echo "- weather: " . $worldState->field('weather') . "\n";
+echo "- mission: " . $worldState->field('mission') . "\n\n";
 
 echo "Baseline world (no blocked edges):\n";
 $graph = buildLogisticsGraph(false);
-$planner = new RoutePlanner($graph, $fitness);
-$route = $planner->plan('Hub-1', 'Hospital-A');
+$planner = new RoutePlanner($graph, $fitness, $worldState, $assessor);
+$route = $planner->plan('Hub-1', 'Hospital-A', [
+    'priority' => 'life_safety',
+]);
 
 if ($route) {
     echo "- Planned path: " . implode(' -> ', $route->getPath()) . "\n";
@@ -85,8 +121,10 @@ if ($route) {
 
 echo "World with highway route blocked:\n";
 $graphBlocked = buildLogisticsGraph(true);
-$plannerBlocked = new RoutePlanner($graphBlocked, $fitness);
-$routeBlocked = $plannerBlocked->plan('Hub-1', 'Hospital-A');
+$plannerBlocked = new RoutePlanner($graphBlocked, $fitness, $worldState, $assessor);
+$routeBlocked = $plannerBlocked->plan('Hub-1', 'Hospital-A', [
+    'priority' => 'life_safety',
+]);
 
 if ($routeBlocked) {
     echo "- Planned path: " . implode(' -> ', $routeBlocked->getPath()) . "\n";

--- a/examples/jenss_agent_adapter.php
+++ b/examples/jenss_agent_adapter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/tests/bootstrap.php';
+require_once dirname(__DIR__) . '/src/Automata/GameTheory/Player.php';
+
+use BlueFission\Automata\GameTheory\Player;
+use BlueFission\Automata\Goal\Initiative;
+
+$agent = new Player('Continuity Lead');
+$strategy = new class {
+    public function decide(Player $player): array
+    {
+        return [
+            'action' => 'reroute',
+            'confidence' => 0.82,
+            'explanation' => 'Route B preserves continuity with acceptable delay.',
+        ];
+    }
+};
+
+$agent
+    ->role('operator')
+    ->scope('circumstantial')
+    ->awareness('local')
+    ->efficacy('can_make_now')
+    ->addGoal(new Initiative(['name' => 'Maintain service']))
+    ->addCriterion('continuity', 2, 'stability')
+    ->addCriterion('safety', 3, 'risk')
+    ->addStrategy('decision_tree', 1, 'routing')
+    ->addStrategy('simulation', 2, 'planning')
+    ->record('observation', ['event' => 'bridge closure'])
+    ->setStrategy($strategy);
+
+$decision = $agent->decide();
+
+echo json_encode([
+    'decision' => $decision,
+    'summary' => $agent->explain(),
+    'agent' => $agent->snapshot(),
+], JSON_PRETTY_PRINT) . PHP_EOL;

--- a/src/Automata/Adapters/CarrierAdapter.php
+++ b/src/Automata/Adapters/CarrierAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BlueFission\Automata\Adapters;
+
+use BlueFission\Obj;
+
+/**
+ * Thin adapter over a DevElation Obj carrier.
+ *
+ * This preserves the underlying carrier mechanics and only normalizes field
+ * access plus snapshot export for downstream utilities.
+ */
+class CarrierAdapter
+{
+    public function __construct(private Obj $carrier)
+    {
+    }
+
+    public function carrier(): Obj
+    {
+        return $this->carrier;
+    }
+
+    public function field(string $field, mixed $value = null): mixed
+    {
+        if (func_num_args() === 1) {
+            return $this->carrier->field($field);
+        }
+
+        $this->carrier->field($field, $value);
+
+        return $this;
+    }
+
+    public function assign(array|object $data): self
+    {
+        $this->carrier->assign($data);
+
+        return $this;
+    }
+
+    public function snapshot(): array
+    {
+        return $this->carrier->toArray();
+    }
+}

--- a/src/Automata/Adapters/StateAdapter.php
+++ b/src/Automata/Adapters/StateAdapter.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace BlueFission\Automata\Adapters;
+
+use BlueFission\Arr;
+use BlueFission\Data\IData;
+use BlueFission\IVal;
+use BlueFission\Obj;
+use InvalidArgumentException;
+
+/**
+ * Normalizes shared runtime state across arrays, Arr, Obj, and IData carriers.
+ *
+ * This adapter intentionally does not impose worldview semantics; it only
+ * provides a common state read/write signature over the carrier layer.
+ */
+class StateAdapter
+{
+    private Arr $state;
+
+    public function __construct(private mixed $source = [])
+    {
+        $this->state = new Arr($this->seedState($source));
+    }
+
+    public static function wrap(mixed $source = []): self
+    {
+        return new self($source);
+    }
+
+    public function source(): mixed
+    {
+        return $this->source;
+    }
+
+    public function state(): Arr
+    {
+        return $this->state;
+    }
+
+    public function get(string|array|null $path = null, mixed $default = null): mixed
+    {
+        if ($path === null) {
+            return $this->snapshot();
+        }
+
+        return Arr::getPath($this->snapshot(), $path, $default);
+    }
+
+    public function set(string|array $path, mixed $value): self
+    {
+        $state = $this->snapshot();
+        $segments = is_array($path) ? $path : explode('.', $path);
+        $lastIndex = count($segments) - 1;
+
+        if (empty($segments)) {
+            return $this;
+        }
+
+        $cursor = &$state;
+
+        foreach ($segments as $index => $segment) {
+            if ($segment === '' || $segment === null) {
+                continue;
+            }
+
+            if (!is_array($cursor)) {
+                $cursor = [];
+            }
+
+            if ($index === $lastIndex) {
+                $cursor[$segment] = $this->normalizeValue($value);
+                break;
+            }
+
+            if (!array_key_exists($segment, $cursor) || !is_array($cursor[$segment])) {
+                $cursor[$segment] = [];
+            }
+
+            $cursor = &$cursor[$segment];
+        }
+
+        $this->state->val($state);
+
+        return $this;
+    }
+
+    public function merge(array $state): self
+    {
+        $merged = array_replace_recursive($this->snapshot(), $this->normalizeValue($state));
+        $this->state->val($merged);
+
+        return $this;
+    }
+
+    public function snapshot(): array
+    {
+        return $this->state->toArray();
+    }
+
+    public function sync(): mixed
+    {
+        $snapshot = $this->snapshot();
+
+        if ($this->source instanceof Arr) {
+            $this->source->val($snapshot);
+            return $this->source;
+        }
+
+        if ($this->source instanceof IData) {
+            if (method_exists($this->source, 'contents')) {
+                $this->source->contents($snapshot);
+            }
+
+            if (method_exists($this->source, 'assign')) {
+                $this->source->assign($snapshot);
+            }
+
+            return $this->source;
+        }
+
+        if ($this->source instanceof Obj) {
+            $this->source->assign($snapshot);
+            return $this->source;
+        }
+
+        $this->source = $snapshot;
+
+        return $snapshot;
+    }
+
+    private function seedState(mixed $source): array
+    {
+        if ($source instanceof Arr) {
+            return $source->toArray();
+        }
+
+        if ($source instanceof IData) {
+            $contents = $this->normalizeValue($source->contents());
+            if (!empty($contents)) {
+                return is_array($contents) ? $contents : [];
+            }
+
+            $data = $this->normalizeValue($source->data());
+            return is_array($data) ? $data : [];
+        }
+
+        if ($source instanceof Obj) {
+            return $source->toArray();
+        }
+
+        if (is_array($source)) {
+            return $this->normalizeValue($source);
+        }
+
+        if ($source === null) {
+            return [];
+        }
+
+        throw new InvalidArgumentException('StateAdapter expects an array, Arr, Obj, or IData carrier.');
+    }
+
+    private function normalizeValue(mixed $value): mixed
+    {
+        if ($value instanceof Arr) {
+            return $value->toArray();
+        }
+
+        if ($value instanceof IVal) {
+            return $value->val();
+        }
+
+        if (is_array($value)) {
+            $normalized = [];
+
+            foreach ($value as $key => $item) {
+                $normalized[$key] = $this->normalizeValue($item);
+            }
+
+            return $normalized;
+        }
+
+        if (is_object($value)) {
+            if (method_exists($value, 'snapshot')) {
+                return $value->snapshot();
+            }
+
+            if (method_exists($value, 'toArray')) {
+                return $value->toArray();
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Automata/Adapters/StoreAdapter.php
+++ b/src/Automata/Adapters/StoreAdapter.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BlueFission\Automata\Adapters;
+
+use BlueFission\Arr;
+use BlueFission\Data\IData;
+use BlueFission\IVal;
+
+/**
+ * Thin adapter over an IData store carrier.
+ *
+ * This keeps persistence mechanics in the store itself while exposing a stable
+ * snapshot-oriented surface to runtime utilities.
+ */
+class StoreAdapter
+{
+    public function __construct(private IData $store)
+    {
+    }
+
+    public function store(): IData
+    {
+        return $this->store;
+    }
+
+    public function read(): self
+    {
+        $this->store->read();
+
+        return $this;
+    }
+
+    public function write(?array $data = null): self
+    {
+        if ($data !== null) {
+            $this->contents($data);
+
+            if (method_exists($this->store, 'assign')) {
+                $this->store->assign($data);
+            }
+        }
+
+        $this->store->write();
+
+        return $this;
+    }
+
+    public function contents(mixed $contents = null): mixed
+    {
+        if (func_num_args() === 0) {
+            return $this->store->contents();
+        }
+
+        $this->store->contents($contents);
+
+        return $this;
+    }
+
+    public function data(): mixed
+    {
+        return $this->store->data();
+    }
+
+    public function status(?string $message = null): mixed
+    {
+        return $this->store->status($message);
+    }
+
+    public function snapshot(): array
+    {
+        $contents = $this->normalize($this->store->contents());
+        if (!empty($contents) && is_array($contents)) {
+            return $contents;
+        }
+
+        $data = $this->normalize($this->store->data());
+
+        return is_array($data) ? $data : [];
+    }
+
+    private function normalize(mixed $value): mixed
+    {
+        if ($value instanceof Arr) {
+            return $value->toArray();
+        }
+
+        if ($value instanceof IVal) {
+            return $value->val();
+        }
+
+        if (is_array($value)) {
+            $normalized = [];
+
+            foreach ($value as $key => $item) {
+                $normalized[$key] = $this->normalize($item);
+            }
+
+            return $normalized;
+        }
+
+        if (is_object($value) && method_exists($value, 'toArray')) {
+            return $value->toArray();
+        }
+
+        return $value;
+    }
+}

--- a/src/Automata/Comprehension/Entity.php
+++ b/src/Automata/Comprehension/Entity.php
@@ -1,30 +1,84 @@
 <?php
 namespace BlueFission\Automata\Comprehension;
 
-class Entity {
+use BlueFission\Collections\Collection;
+use BlueFission\Obj;
+use BlueFission\Prototypes\Entity as PrototypeEntity;
+use BlueFission\Prototypes\Position;
+use BlueFission\Prototypes\Proto;
 
-	protected string $_name;
-	protected ?string $_description;
-	protected mixed $_meta;
+class Entity extends Obj
+{
+	use Proto {
+		explain as protected prototypeExplain;
+		snapshot as protected prototypeSnapshot;
+	}
+	use PrototypeEntity;
+	use Position;
 
 	public function __construct( string $name, ?string $description = null, $meta = null ) {
-		$this->_name = $name;
-		$this->_description = $description;
-		$this->_meta = $meta;
+		parent::__construct();
+
+		$this->protoId($name);
+		$this->name($name);
+		$this->reactive(true);
+
+		if ($description !== null) {
+			$this->description($description);
+		}
+
+		if ($meta !== null) {
+			$this->meta($meta);
+		}
 	}
 
-	public function name(): string
+	public function description(?string $description = null): mixed
 	{
-		return $this->_name;
+		if (func_num_args() === 0) {
+			$value = $this->property('description');
+			return $value === null ? null : (string)$value;
+		}
+
+		$this->property('description', $description);
+		return $this;
 	}
 
-	public function description(): ?string
+	public function meta(mixed $meta = null): mixed
 	{
-		return $this->_description;
+		if (func_num_args() === 0) {
+			return $this->property('meta');
+		}
+
+		$this->property('meta', $meta);
+		return $this;
 	}
 
-	public function meta()
+	public function explain(): string
 	{
-		return $this->_meta;
+		$parts = [
+			$this->name(),
+			$this->description(),
+			'entity[' . ($this->protoId() ?: $this->name() ?: 'unidentified') . ']',
+			'labels=' . count($this->labels()),
+			'relations=' . count($this->relations()),
+			'history=' . count($this->history()),
+		];
+
+		$summary = implode(' | ', (new Collection($parts))
+			->filter(fn ($part) => $part !== null && $part !== '')
+			->contents());
+		$this->summary($summary);
+
+		return $summary;
+	}
+
+	public function snapshot(): array
+	{
+		$snapshot = $this->prototypeSnapshot();
+		$snapshot['description'] = $this->description();
+		$snapshot['meta'] = $this->meta();
+		$snapshot['summary'] = $this->summary() ?: 'entity[' . ($this->protoId() ?: $this->name() ?: 'unidentified') . ']';
+
+		return $snapshot;
 	}
 }

--- a/src/Automata/DecisionTree/BaseMethod.php
+++ b/src/Automata/DecisionTree/BaseMethod.php
@@ -2,6 +2,8 @@
 
 namespace BlueFission\Automata\DecisionTree;
 
+use BlueFission\Automata\Adapters\StateAdapter;
+use BlueFission\Func;
 use BlueFission\Obj;
 use BlueFission\Behavioral\Dispatches;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -20,6 +22,9 @@ use BlueFission\Behavioral\Behaviors\Event;
 abstract class BaseMethod extends Obj implements IMethod
 {
     use Dispatches;
+
+    protected ?StateAdapter $stateAdapter = null;
+    protected ?Func $assessor = null;
 
     /**
      * Traverse the tree starting from the given root node.
@@ -47,7 +52,10 @@ abstract class BaseMethod extends Obj implements IMethod
      */
     protected function visitNode(INode $node): void
     {
-        $this->dispatch(new Event('decision_tree.node_visited', ['node' => $node]));
+        $this->dispatch(new Event('decision_tree.node_visited', [
+            'node' => $node,
+            'state' => $this->stateAdapter?->snapshot() ?? [],
+        ]));
     }
 
     /**
@@ -63,6 +71,35 @@ abstract class BaseMethod extends Obj implements IMethod
      */
     protected function decisionSelected(INode $node): void
     {
-        $this->dispatch(new Event('decision_tree.decision_selected', ['node' => $node]));
+        $this->dispatch(new Event('decision_tree.decision_selected', [
+            'node' => $node,
+            'state' => $this->stateAdapter?->snapshot() ?? [],
+        ]));
+    }
+
+    public function setState(mixed $state): static
+    {
+        $this->stateAdapter = StateAdapter::wrap($state);
+
+        return $this;
+    }
+
+    public function state(): ?StateAdapter
+    {
+        return $this->stateAdapter;
+    }
+
+    public function setAssessor(Func|callable $assessor): static
+    {
+        $this->assessor = $assessor instanceof Func ? $assessor : new Func($assessor);
+
+        return $this;
+    }
+
+    protected function evaluateNode(INode $node): float|int
+    {
+        $state = $this->stateAdapter?->snapshot() ?? [];
+
+        return $node->evaluate($state, $this->assessor);
     }
 }

--- a/src/Automata/DecisionTree/BreadthFirstMethod.php
+++ b/src/Automata/DecisionTree/BreadthFirstMethod.php
@@ -16,7 +16,7 @@ class BreadthFirstMethod extends BaseMethod
     {
         $queue = new Arr([$root]);
         $bestNode = $root;
-        $bestScore = $root->evaluate();
+        $bestScore = $this->evaluateNode($root);
 
         while ($queue->isNotEmpty()) {
             $currentNode = $queue->_shift();
@@ -26,7 +26,7 @@ class BreadthFirstMethod extends BaseMethod
 
             $this->visitNode($currentNode);
 
-            $score = $currentNode->evaluate();
+            $score = $this->evaluateNode($currentNode);
             if ($score > $bestScore) {
                 $bestNode = $currentNode;
                 $bestScore = $score;

--- a/src/Automata/DecisionTree/DepthFirstMethod.php
+++ b/src/Automata/DecisionTree/DepthFirstMethod.php
@@ -18,7 +18,7 @@ class DepthFirstMethod extends BaseMethod {
         // Use Arr as a LIFO stack for depth-first traversal.
         $stack = new Arr([$root]);
         $bestNode = $root;
-        $bestScore = $root->evaluate();
+        $bestScore = $this->evaluateNode($root);
 
         while ($stack->isNotEmpty()) {
             // Pop the last-pushed node to explore as deep as possible.
@@ -29,7 +29,7 @@ class DepthFirstMethod extends BaseMethod {
 
             $this->visitNode($currentNode);
 
-            $score = $currentNode->evaluate();
+            $score = $this->evaluateNode($currentNode);
             if ($score > $bestScore) {
                 $bestNode = $currentNode;
                 $bestScore = $score;

--- a/src/Automata/DecisionTree/DepthFirstTraceMethod.php
+++ b/src/Automata/DecisionTree/DepthFirstTraceMethod.php
@@ -36,7 +36,7 @@ class DepthFirstTraceMethod extends BaseMethod
         // Each stack element: [node, pathToParent]
         $stack = new Arr([[$root, []]]);
         $bestNode = $root;
-        $bestScore = $root->evaluate();
+        $bestScore = $this->evaluateNode($root);
         $this->trace = [$root];
 
         while ($stack->isNotEmpty()) {
@@ -52,16 +52,20 @@ class DepthFirstTraceMethod extends BaseMethod
 
             $this->visitNode($currentNode);
 
-            $score = $currentNode->evaluate();
+            $score = $this->evaluateNode($currentNode);
             if ($score > $bestScore) {
                 $bestNode = $currentNode;
                 $bestScore = $score;
-                $this->trace = array_merge($pathToParent, [$currentNode]);
+                $trace = new Arr($pathToParent);
+                $trace->push($currentNode);
+                $this->trace = $trace->toArray();
             }
 
             $children = $currentNode->getChildren();
             if (!empty($children)) {
-                $newPath = array_merge($pathToParent, [$currentNode]);
+                $newPathBag = new Arr($pathToParent);
+                $newPathBag->push($currentNode);
+                $newPath = $newPathBag->toArray();
                 foreach ($children as $child) {
                     $stack->push([$child, $newPath]);
                 }

--- a/src/Automata/DecisionTree/INode.php
+++ b/src/Automata/DecisionTree/INode.php
@@ -1,9 +1,11 @@
 <?php
 namespace BlueFission\Automata\DecisionTree;
 
+use BlueFission\Func;
+
 interface INode {
     public function getValue(): array;
     public function getChildren(): array;
     public function addChild(INode $child): void;
-    public function evaluate(): int;
+    public function evaluate(array $state = [], Func|callable|null $assessor = null): int|float;
 }

--- a/src/Automata/DecisionTree/LeafOnlyBestMethod.php
+++ b/src/Automata/DecisionTree/LeafOnlyBestMethod.php
@@ -31,7 +31,7 @@ class LeafOnlyBestMethod extends BaseMethod
             $isLeaf = empty($children);
 
             if ($isLeaf) {
-                $score = $currentNode->evaluate();
+                $score = $this->evaluateNode($currentNode);
                 if ($bestScore === null || $score > $bestScore) {
                     $bestNode = $currentNode;
                     $bestScore = $score;

--- a/src/Automata/DecisionTree/Node.php
+++ b/src/Automata/DecisionTree/Node.php
@@ -1,14 +1,19 @@
 <?php
 namespace BlueFission\Automata\DecisionTree;
 
+use BlueFission\Automata\Support\Evaluates;
+use BlueFission\Func;
+
 class Node implements INode {
+    use Evaluates;
+
     private $_value;
     private $_children = [];
-    private $_evaluationFunction;
+    private Func $_evaluationFunction;
 
-    public function __construct(array $value, callable $evaluationFunction) {
+    public function __construct(array $value, Func|callable $evaluationFunction) {
         $this->_value = $value;
-        $this->_evaluationFunction = $evaluationFunction;
+        $this->_evaluationFunction = $this->asFunc($evaluationFunction);
     }
 
     public function getValue(): array {
@@ -23,8 +28,16 @@ class Node implements INode {
         $this->_children[] = $child;
     }
 
-    public function evaluate(): int {
-        $function = $this->_evaluationFunction;
-        return $function($this->_value, $this->_children);
+    public function evaluate(array $state = [], Func|callable|null $assessor = null): int|float {
+        if ($assessor) {
+            $assessed = $this->invokeFunc($assessor, [$this->_value, $this->_children, $state, $this]);
+            if ($assessed !== null) {
+                return $this->numericValue($assessed);
+            }
+        }
+
+        $score = $this->invokeFunc($this->_evaluationFunction, [$this->_value, $this->_children, $state, $this]);
+
+        return $this->numericValue($score);
     }
 }

--- a/src/Automata/Engine.php
+++ b/src/Automata/Engine.php
@@ -1,6 +1,8 @@
 <?php
 namespace BlueFission\Automata;
 
+use BlueFission\Func;
+use BlueFission\Num;
 use BlueFission\Automata\Intelligence;
 use BlueFission\Behavioral\Behaviors\Action;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -160,7 +162,7 @@ class Engine extends Intelligence implements ISphere {
 	// }
 
 	public function getTransactionSize() {
-		$this->_transaction_size = pow(self::TRANSACTION_BASE_SIZE * $this->_level, self::TRANSACTION_MULTIPLIER);
+		$this->_transaction_size = Num::pow(self::TRANSACTION_BASE_SIZE * $this->_level, self::TRANSACTION_MULTIPLIER);
 		return $this->_transaction_size;
 	}
 
@@ -177,14 +179,14 @@ class Engine extends Intelligence implements ISphere {
 				- ($ru["ru_utime.tv_sec"]*1000 + intval($ru["ru_utime.tv_usec"]/1000));
 		} else {
 			$this->_stoptime = microtime(true);
-			$start = is_numeric($this->_starttime) ? $this->_starttime : $this->_stoptime;
+			$start = Num::isValid($this->_starttime) ? $this->_starttime : $this->_stoptime;
 			$this->_totaltime = ($this->_stoptime - $start);
 		}
 
-		if ( !is_numeric($this->_avgtime) || $this->_avgtime <= 0 ) {
+		if ( !Num::isValid($this->_avgtime) || $this->_avgtime <= 0 ) {
 			$this->_avgtime = $this->_totaltime;
 		} else {
-			$this->_avgtime = ($this->_avgtime + $this->_totaltime) / 2;
+			$this->_avgtime = Num::divide(Num::add($this->_avgtime, $this->_totaltime), 2);
 		}
 	}
 
@@ -299,13 +301,13 @@ class Engine extends Intelligence implements ISphere {
 		$this->_inputs->add($input, $inputName);
 		$this->_inputs->add($sense, $senseName);
 
-		$input->when(Event::COMPLETE, function ($behavior, $args = null) use ($sense) {
+		$input->when(Event::COMPLETE, new Func(function ($behavior, $args = null) use ($sense) {
 			$sense->invoke($behavior->context);
-		});
+		}));
 
-		$sense->when('DoEnhance', function ($behavior, $args = null) {
+		$sense->when('DoEnhance', new Func(function ($behavior, $args = null) {
 			$this->dispatch('OnEnhance', $behavior->context);
-		});
+		}));
 
 		return $this;
 	}

--- a/src/Automata/Feedback/FeedbackItem.php
+++ b/src/Automata/Feedback/FeedbackItem.php
@@ -5,6 +5,7 @@ namespace BlueFission\Automata\Feedback;
 use BlueFission\Obj;
 use BlueFission\Automata\Context;
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 
 abstract class FeedbackItem extends Obj
 {
@@ -44,6 +45,6 @@ abstract class FeedbackItem extends Obj
     public function timestamp(): float
     {
         $timestamp = $this->field('timestamp');
-        return is_numeric($timestamp) ? (float)$timestamp : 0.0;
+        return Num::isValid($timestamp) ? (float)$timestamp : 0.0;
     }
 }

--- a/src/Automata/Feedback/FeedbackRegistry.php
+++ b/src/Automata/Feedback/FeedbackRegistry.php
@@ -4,6 +4,7 @@ namespace BlueFission\Automata\Feedback;
 
 use BlueFission\Automata\Collections\OrganizedCollection;
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 
 class FeedbackRegistry
 {
@@ -27,6 +28,6 @@ class FeedbackRegistry
     public function score(string $subject): float
     {
         $value = $this->_signals->weight($subject);
-        return is_numeric($value) ? (float)$value : 0.0;
+        return Num::isValid($value) ? (float)$value : 0.0;
     }
 }

--- a/src/Automata/Feedback/Projection.php
+++ b/src/Automata/Feedback/Projection.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Automata\Feedback;
 
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 
 class Projection extends FeedbackItem
 {
@@ -20,7 +21,7 @@ class Projection extends FeedbackItem
     public function expiresAt(): float
     {
         $expiresAt = $this->field('expires_at');
-        return is_numeric($expiresAt) ? (float)$expiresAt : 0.0;
+        return Num::isValid($expiresAt) ? (float)$expiresAt : 0.0;
     }
 
     public function isExpired(float $now = null): bool

--- a/src/Automata/Feedback/Strategies/ContextSimilarityStrategy.php
+++ b/src/Automata/Feedback/Strategies/ContextSimilarityStrategy.php
@@ -2,9 +2,11 @@
 
 namespace BlueFission\Automata\Feedback\Strategies;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Feedback\IAssessmentStrategy;
 use BlueFission\Automata\Feedback\Projection;
 use BlueFission\Automata\Feedback\Observation;
+use BlueFission\Num;
 
 class ContextSimilarityStrategy implements IAssessmentStrategy
 {
@@ -17,7 +19,7 @@ class ContextSimilarityStrategy implements IAssessmentStrategy
             return 0.0;
         }
 
-        $sharedKeys = array_intersect(array_keys($projectionContext), array_keys($observationContext));
+        $sharedKeys = Arr::intersect(Arr::keys($projectionContext), Arr::keys($observationContext));
         if (empty($sharedKeys)) {
             return 0.0;
         }
@@ -29,7 +31,7 @@ class ContextSimilarityStrategy implements IAssessmentStrategy
             }
         }
 
-        return $matches / max(1, count($sharedKeys));
+        return $matches / Num::max(1, count($sharedKeys));
     }
 
     public function name(): string

--- a/src/Automata/Feedback/Strategies/LabelOverlapStrategy.php
+++ b/src/Automata/Feedback/Strategies/LabelOverlapStrategy.php
@@ -2,9 +2,11 @@
 
 namespace BlueFission\Automata\Feedback\Strategies;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Feedback\IAssessmentStrategy;
 use BlueFission\Automata\Feedback\Projection;
 use BlueFission\Automata\Feedback\Observation;
+use BlueFission\Num;
 
 class LabelOverlapStrategy implements IAssessmentStrategy
 {
@@ -17,8 +19,8 @@ class LabelOverlapStrategy implements IAssessmentStrategy
             return 0.0;
         }
 
-        $overlap = array_intersect($projectionTags, $observationTags);
-        $score = count($overlap) / max(1, count($projectionTags));
+        $overlap = Arr::intersect($projectionTags, $observationTags);
+        $score = count($overlap) / Num::max(1, count($projectionTags));
 
         return (float)$score;
     }

--- a/src/Automata/GameTheory/Player.php
+++ b/src/Automata/GameTheory/Player.php
@@ -2,49 +2,164 @@
 namespace BlueFission\Automata\GameTheory;
 
 use BlueFission\Behavioral\StateMachine;
+use BlueFission\Collections\Collection;
+use BlueFission\DevElation as Dev;
+use BlueFission\Func;
+use BlueFission\Obj;
+use BlueFission\Prototypes\Agent as PrototypeAgent;
+use BlueFission\Prototypes\Proto;
+use BlueFission\Str;
 
-class Player {
+class Player extends Obj
+{
     use StateMachine;
-
-    private $name;
-    private $strategy;
-
-    public function __construct($name) {
-        $this->name = $name;
+    use Proto {
+        explain as protected prototypeExplain;
+        snapshot as protected prototypeSnapshot;
+    }
+    use PrototypeAgent {
+        decide as protected prototypeDecide;
     }
 
-    public function getName() {
-        return $this->name;
+    private mixed $strategy = null;
+
+    public function __construct($name)
+    {
+        parent::__construct();
+
+        $name = Str::trim((string)$name);
+
+        $this->protoId($name);
+        $this->name($name);
+        $this->kind('agent');
+        $this->summary("agent[{$name}]");
     }
 
-    public function setStrategy($strategy) {
+    public function getName(): string
+    {
+        return (string)$this->name();
+    }
+
+    public function setStrategy($strategy): self
+    {
         $this->strategy = $strategy;
+
+        $name = is_object($strategy) ? get_class($strategy) : Str::trim((string)$strategy);
+        if ($name !== '' && !$this->hasStrategyDescriptor($name)) {
+            $this->addStrategy($name);
+        }
+
+        return $this;
     }
 
-    public function getStrategy() {
+    public function getStrategy()
+    {
         return $this->strategy;
     }
 
-    public function decide() {
-        return $this->strategy->decide($this);
+    public function decide()
+    {
+        if (!$this->strategy) {
+            return null;
+        }
+
+        $decision = $this->strategy->decide($this);
+        $this->prototypeDecide($decision);
+
+        Dev::do('automata.gametheory.player.decision_made', [
+            'player' => $this,
+            'decision' => $decision,
+        ]);
+
+        return $decision;
     }
 
-    public function addAction($stateName, $actionName, callable $action, array $allowedStates, array $deniedStates) {
-        $this->behavior($stateName, function() use ($actionName, $allowedStates, $deniedStates) {
+    public function adoptDecision(mixed $decision): self
+    {
+        $this->prototypeDecide($decision);
+
+        return $this;
+    }
+
+    public function addAction($stateName, $actionName, Func|callable $action, array $allowedStates, array $deniedStates)
+    {
+        $this->behavior($stateName, new Func(function() use ($actionName, $allowedStates, $deniedStates) {
             $this->allows($actionName, $allowedStates);
             $this->denies($actionName, $deniedStates);
-        });
+        }));
 
-        $this->action($actionName, $action);
+        $this->action($actionName, $action instanceof Func ? $action : new Func($action));
     }
 
-    public function addState($stateName) {
-        $this->behavior($stateName, function() {});
+    public function addState($stateName)
+    {
+        $this->behavior($stateName, new Func(function() {}));
     }
 
-    public function changeState($stateName) {
+    public function changeState($stateName)
+    {
         if ($this->can($stateName)) {
             $this->dispatch($stateName);
         }
+    }
+
+    public function lastDecision(): mixed
+    {
+        return $this->prototypeSnapshot()['lastDecision'] ?? null;
+    }
+
+    public function explain(): string
+    {
+        $parts = [
+            'agent[' . ($this->protoId() ?: $this->name() ?: 'unidentified') . ']',
+            $this->role() !== '' ? "role={$this->role()}" : null,
+            $this->scope() !== '' ? "scope={$this->scope()}" : null,
+            $this->awareness() !== '' ? "awareness={$this->awareness()}" : null,
+            $this->efficacy() !== '' ? "efficacy={$this->efficacy()}" : null,
+            'goals=' . count($this->goals()),
+            'criteria=' . count($this->criteria()),
+            'strategies=' . count($this->strategies()),
+            'history=' . count($this->history()),
+            $this->strategy ? 'activeStrategy=' . (is_object($this->strategy) ? get_class($this->strategy) : (string)$this->strategy) : null,
+        ];
+
+        $summary = implode(' | ', (new Collection($parts))
+            ->filter(fn ($part) => $part !== null && $part !== '')
+            ->contents());
+        $this->summary($summary);
+
+        return $summary;
+    }
+
+    public function snapshot(): array
+    {
+        $snapshot = $this->prototypeSnapshot();
+        $snapshot['role'] = $this->role();
+        $snapshot['scope'] = $this->scope();
+        $snapshot['awareness'] = $this->awareness();
+        $snapshot['efficacy'] = $this->efficacy();
+        $snapshot['autonomy'] = $this->autonomy();
+        $snapshot['control'] = $this->control();
+        $snapshot['goalCount'] = count($this->goals());
+        $snapshot['criterionCount'] = count($this->criteria());
+        $snapshot['strategyCount'] = count($this->strategies());
+        $snapshot['historyCount'] = count($this->history());
+        $snapshot['activeStrategy'] = $this->strategy
+            ? (is_object($this->strategy) ? get_class($this->strategy) : (string)$this->strategy)
+            : null;
+        $snapshot['summary'] = $this->summary() ?: 'agent[' . ($this->protoId() ?: $this->name() ?: 'unidentified') . ']';
+
+        return $snapshot;
+    }
+
+    private function hasStrategyDescriptor(string $name): bool
+    {
+        foreach ($this->strategies() as $strategy) {
+            if (($strategy['name'] ?? null) === $name) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Automata/Genetic/Genetic.php
+++ b/src/Automata/Genetic/Genetic.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Automata\Genetic;
 
 use BlueFission\Behavioral\Configurable;
+use BlueFission\Num;
 
 trait Genetic
 {
@@ -43,8 +44,8 @@ trait Genetic
 
     protected function mutateValue($value, $pressure)
     {
-        if (is_numeric($value)) {
-            $value += $pressure * $this->_mutationRate;
+        if (Num::isValid($value)) {
+            $value = Num::add($value, $pressure * $this->_mutationRate);
         } elseif (is_bool($value)) {
             $value = mt_rand() / mt_getrandmax() < $this->_mutationRate ? !$value : $value;
         } elseif (is_string($value)) {

--- a/src/Automata/Genetic/Population.php
+++ b/src/Automata/Genetic/Population.php
@@ -2,9 +2,14 @@
 namespace BlueFission\Automata\Genetic;
 
 use BlueFission\Arr;
+use BlueFission\Automata\Support\Evaluates;
 use BlueFission\DevElation as Dev;
+use BlueFission\Func;
+use BlueFission\Num;
 
 class Population {
+    use Evaluates;
+
     private $_individuals;
 
     public function __construct(array $individuals = []) {
@@ -19,26 +24,30 @@ class Population {
      * Uses Arr::val() to avoid relying on offsetSet([]) semantics,
      * which can be problematic with certain internal configurations.
      */
-    public function initialize(int $size, callable $initializer): void {
+    public function initialize(int $size, Func|callable $initializer): void {
         $current = $this->_individuals->val();
+        $initializer = $this->asFunc($initializer);
 
-        for ($i = 0; $i < $size; $i++) {
-            $current[] = $initializer();
+        for ($i = 0; $i < $size; $i = Num::increment($i)) {
+            $current[] = $this->invokeFunc($initializer, [$i, $current, $this]);
         }
 
         $this->_individuals->val($current);
         Dev::do('automata.genetic.population.initialize.action1', ['initialized' => $this->_individuals->val()]);
     }
 
-    public function mutate(callable $mutator): void {
+    public function mutate(Func|callable $mutator): void {
+        $mutator = $this->asFunc($mutator);
+
         foreach ($this->_individuals as $individual) {
-            $mutator($individual);
+            $this->invokeFunc($mutator, [$individual, $this]);
         }
         Dev::do('automata.genetic.population.mutate.action1', ['mutated' => $this->_individuals->val()]);
     }
 
-    public function selection(callable $selector): self {
-        $newIndividuals = $selector($this->_individuals->val());
+    public function selection(Func|callable $selector): self {
+        $selector = $this->asFunc($selector);
+        $newIndividuals = $this->invokeFunc($selector, [$this->_individuals->val(), $this]);
         $newIndividuals = Dev::apply('automata.genetic.population.selection.1', $newIndividuals);
         Dev::do('automata.genetic.population.selection.action1', ['selected' => $newIndividuals]);
         return new self($newIndividuals);

--- a/src/Automata/Genetic/RandomMutation.php
+++ b/src/Automata/Genetic/RandomMutation.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Automata\Genetic;
 
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 
 /**
  * Simple numeric mutation operator that nudges scalar fields by a small random delta.
@@ -28,9 +29,9 @@ class RandomMutation extends Mutation
 
         foreach ($fields as $key => $value) {
             $roll = mt_rand() / mt_getrandmax();
-            if ($roll < $this->_mutationRate && is_numeric($value)) {
+            if ($roll < $this->_mutationRate && Num::isValid($value)) {
                 $delta = (mt_rand() / mt_getrandmax() * 2.0) - 1.0;
-                $individual->field($key, $value + $delta);
+                $individual->field($key, Num::add($value, $delta));
             }
         }
 

--- a/src/Automata/Goal/Condition.php
+++ b/src/Automata/Goal/Condition.php
@@ -2,6 +2,72 @@
 
 namespace BlueFission\Automata\Goal;
 
+use BlueFission\Prototypes\HasConditions;
+use BlueFission\Prototypes\Proto;
+
 class Condition extends InitiativeObject
 {
+    use Proto {
+        explain as protected prototypeExplain;
+        snapshot as protected prototypeSnapshot;
+    }
+    use HasConditions {
+        normalizeConditionRecord as protected prototypeNormalizeConditionRecord;
+        prototypeEvaluateConditionRecord as protected prototypeEvaluateCondition;
+    }
+
+    public function snapshot(): array
+    {
+        $normalized = $this->prototypeNormalizeConditionRecord([
+            'name' => $this->field('name') ?? $this->field('path') ?? $this->field('attribute') ?? 'condition',
+            'path' => $this->field('path') ?? $this->field('attribute'),
+            'expected' => $this->field('expected') ?? $this->field('value'),
+            'value' => $this->field('value'),
+            'operator' => $this->field('operator') ?? 'eq',
+            'weight' => $this->field('weight') ?? 1,
+            'meta' => $this->field('meta') ?? [],
+            'confidence' => $this->field('confidence') ?? 1.0,
+        ]);
+
+        $snapshot = $this->prototypeSnapshot();
+        $snapshot['kind'] = 'condition';
+        $snapshot['name'] = (string)$normalized['name'];
+        $snapshot['path'] = $normalized['path'] ?? null;
+        $snapshot['operator'] = $normalized['operator'] ?? 'eq';
+        $snapshot['expected'] = $normalized['expected'] ?? null;
+        $snapshot['value'] = $snapshot['expected'];
+        $snapshot['weight'] = $this->field('weight') ?? 1;
+        $snapshot['meta'] = $this->field('meta') ?? [];
+        $snapshot['confidence'] = (float)($normalized['confidence'] ?? 1.0);
+
+        return $snapshot;
+    }
+
+    public function matches(array $context): bool
+    {
+        $record = $this->snapshot();
+
+        return $this->prototypeEvaluateCondition([
+            'name' => $record['name'],
+            'path' => $record['path'],
+            'expected' => $record['expected'],
+            'operator' => $record['operator'],
+            'confidence' => $record['confidence'],
+        ], $context);
+    }
+
+    public function explain(): string
+    {
+        $record = $this->snapshot();
+        $summary = sprintf(
+            'condition[%s] %s %s',
+            $record['name'],
+            $record['path'] ?? '(self)',
+            $record['operator']
+        );
+
+        $this->summary($summary);
+
+        return $summary;
+    }
 }

--- a/src/Automata/Intelligence.php
+++ b/src/Automata/Intelligence.php
@@ -2,9 +2,14 @@
 
 namespace BlueFission\Automata;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 use BlueFission\DevElation;
+use BlueFission\Automata\Support\Evaluates;
 use BlueFission\Automata\Collections\OrganizedCollection;
 use BlueFission\Automata\Sensory\Input;
 use BlueFission\Automata\Strategy\IStrategy;
@@ -24,6 +29,7 @@ use BlueFission\Behavioral\Behaviors\Behavior;
 class Intelligence extends Obj
 {
     use Dispatches;
+    use Evaluates;
 
     protected OrganizedCollection $_strategies; // Collection of strategies with weights
     protected float $_minThreshold; // Minimum accuracy threshold for a strategy
@@ -85,7 +91,7 @@ class Intelligence extends Obj
             'weight' => null,
         ];
 
-        $profile = array_merge($defaults, $profile);
+        $profile = $this->mergeMap($defaults, $profile);
 
         $this->registerStrategy($strategy, $name);
         $this->_strategyProfiles[$name] = $profile;
@@ -97,13 +103,15 @@ class Intelligence extends Obj
     }
 
     /**
-     * Register an intent analyzer (callable or IAnalyzer implementation).
+     * Register an intent analyzer (Func/callable or IAnalyzer implementation).
      *
-     * @param callable|IAnalyzer $analyzer
+     * @param Func|callable|IAnalyzer $analyzer
      */
     public function registerIntentAnalyzer($analyzer): void
     {
-        $this->_intentAnalyzers[] = $analyzer;
+        $this->_intentAnalyzers[] = $analyzer instanceof Func || $analyzer instanceof IAnalyzer
+            ? $analyzer
+            : $this->asFunc($analyzer);
     }
 
     /**
@@ -111,9 +119,9 @@ class Intelligence extends Obj
      *
      * @param callable $classifier
      */
-    public function registerStructureClassifier(callable $classifier): void
+    public function registerStructureClassifier(Func|callable $classifier): void
     {
-        $this->_structureClassifiers[] = $classifier;
+        $this->_structureClassifiers[] = $this->asFunc($classifier);
     }
 
     /**
@@ -121,9 +129,9 @@ class Intelligence extends Obj
      *
      * @param callable $provider
      */
-    public function registerContextProvider(callable $provider): void
+    public function registerContextProvider(Func|callable $provider): void
     {
-        $this->_contextProviders[] = $provider;
+        $this->_contextProviders[] = $this->asFunc($provider);
     }
 
     /**
@@ -307,9 +315,9 @@ class Intelligence extends Obj
      *
      * @param callable $listener The listener function
      */
-    public function onPrediction(callable $listener)
+    public function onPrediction(Func|callable $listener)
     {
-        $this->behavior(self::PREDICTION_EVENT, $listener);
+        $this->behavior(self::PREDICTION_EVENT, $listener instanceof Func ? $listener : new Func($listener));
     }
 
     /**
@@ -326,7 +334,7 @@ class Intelligence extends Obj
 
         foreach ($segments as $segment) {
             $segmentInsights = $this->analyzeSegment($segment, $options);
-            $insights = array_merge($insights, $segmentInsights);
+            $insights = $this->appendList($insights, $segmentInsights);
         }
 
         $gestalt = $this->buildGestalt($segments, $insights);
@@ -354,7 +362,7 @@ class Intelligence extends Obj
         $strategies = $this->resolveStrategiesForType($segment['type']);
         $budget = $this->resolveStrategyBudget(count($strategies), $options);
 
-        $selected = array_slice($strategies, 0, $budget);
+        $selected = Arr::slice($strategies, 0, $budget);
         $insights = [];
 
         foreach ($selected as $strategyMeta) {
@@ -432,19 +440,19 @@ class Intelligence extends Obj
 
         if (isset($options['strategy_budget'])) {
             $budget = (int)$options['strategy_budget'];
-            return max(1, min($strategyCount, $budget));
+            return Num::max(1, Num::min($strategyCount, $budget));
         }
 
         if (isset($options['attention_score'])) {
             $score = (float)$options['attention_score'];
-            $score = max(0.0, min(1.0, $score));
-            $budget = (int)max(1, ceil($score * $strategyCount));
+            $score = Num::max(0.0, Num::min(1.0, $score));
+            $budget = (int)Num::max(1, ceil($score * $strategyCount));
 
             if (isset($options['max_strategy_budget'])) {
-                $budget = min($budget, (int)$options['max_strategy_budget']);
+                $budget = Num::min($budget, (int)$options['max_strategy_budget']);
             }
             if (isset($options['min_strategy_budget'])) {
-                $budget = max($budget, (int)$options['min_strategy_budget']);
+                $budget = Num::max($budget, (int)$options['min_strategy_budget']);
             }
 
             return $budget;
@@ -455,8 +463,8 @@ class Intelligence extends Obj
 
     private function segmentInput($input, array $options): array
     {
-        if (isset($options['segmenter']) && is_callable($options['segmenter'])) {
-            $segments = call_user_func($options['segmenter'], $input, $options);
+        if (isset($options['segmenter']) && ($options['segmenter'] instanceof Func || is_callable($options['segmenter']))) {
+            $segments = $this->invokeFunc($options['segmenter'], [$input, $options, $this]);
             return $this->normalizeSegments($segments, $options);
         }
 
@@ -472,7 +480,7 @@ class Intelligence extends Obj
         if (is_array($input)) {
             if ($this->isAssociative($input) && isset($input['segments']) && is_array($input['segments'])) {
                 $items = $input['segments'];
-                $baseMeta = array_merge($baseMeta, $input['meta'] ?? []);
+                $baseMeta = $this->mergeMap($baseMeta, $input['meta'] ?? []);
             } elseif ($this->isAssociative($input) && (array_key_exists('payload', $input) || array_key_exists('type', $input))) {
                 $items = [$input];
             } else {
@@ -490,14 +498,14 @@ class Intelligence extends Obj
             if (is_array($item) && (array_key_exists('payload', $item) || array_key_exists('type', $item))) {
                 $payload = $item['payload'] ?? ($item['content'] ?? $item);
                 $type = $item['type'] ?? null;
-                $meta = array_merge($meta, $item['meta'] ?? []);
+                $meta = $this->mergeMap($meta, $item['meta'] ?? []);
             }
 
             $type = $type ?: ($this->getType($payload) ?? InputType::TEXT);
 
-            if (isset($options['segment_meta']) && is_callable($options['segment_meta'])) {
-                $extraMeta = (array)call_user_func($options['segment_meta'], $payload, $type, $index, $meta);
-                $meta = array_merge($meta, $extraMeta);
+            if (isset($options['segment_meta']) && ($options['segment_meta'] instanceof Func || is_callable($options['segment_meta']))) {
+                $extraMeta = (array)$this->invokeFunc($options['segment_meta'], [$payload, $type, $index, $meta, $this]);
+                $meta = $this->mergeMap($meta, $extraMeta);
             }
 
             $meta = $this->applyClassifiers($payload, $type, $meta, $options);
@@ -519,8 +527,8 @@ class Intelligence extends Obj
         $intents = $options['intents'] ?? $this->_intents;
 
         $intentSignals = [];
-        if (isset($options['intent_classifier']) && is_callable($options['intent_classifier'])) {
-            $intentSignals[] = call_user_func($options['intent_classifier'], $payload, $type, $meta, $context, $intents);
+        if (isset($options['intent_classifier']) && ($options['intent_classifier'] instanceof Func || is_callable($options['intent_classifier']))) {
+            $intentSignals[] = $this->invokeFunc($options['intent_classifier'], [$payload, $type, $meta, $context, $intents, $this]);
         }
 
         foreach ($this->_intentAnalyzers as $analyzer) {
@@ -532,22 +540,22 @@ class Intelligence extends Obj
         }
 
         $structureSignals = [];
-        if (isset($options['structure_classifier']) && is_callable($options['structure_classifier'])) {
-            $structureSignals[] = call_user_func($options['structure_classifier'], $payload, $type, $meta);
+        if (isset($options['structure_classifier']) && ($options['structure_classifier'] instanceof Func || is_callable($options['structure_classifier']))) {
+            $structureSignals[] = $this->invokeFunc($options['structure_classifier'], [$payload, $type, $meta, $context, $this]);
         }
         foreach ($this->_structureClassifiers as $classifier) {
-            $structureSignals[] = call_user_func($classifier, $payload, $type, $meta);
+            $structureSignals[] = $this->invokeFunc($classifier, [$payload, $type, $meta, $context, $this]);
         }
         if (!empty($structureSignals)) {
             $meta['structure'] = $structureSignals;
         }
 
         $contextSignals = [];
-        if (isset($options['context_provider']) && is_callable($options['context_provider'])) {
-            $contextSignals[] = call_user_func($options['context_provider'], $payload, $type, $meta);
+        if (isset($options['context_provider']) && ($options['context_provider'] instanceof Func || is_callable($options['context_provider']))) {
+            $contextSignals[] = $this->invokeFunc($options['context_provider'], [$payload, $type, $meta, $context, $this]);
         }
         foreach ($this->_contextProviders as $provider) {
-            $contextSignals[] = call_user_func($provider, $payload, $type, $meta);
+            $contextSignals[] = $this->invokeFunc($provider, [$payload, $type, $meta, $context, $this]);
         }
         if (!empty($contextSignals)) {
             $meta['context'] = $contextSignals;
@@ -562,8 +570,8 @@ class Intelligence extends Obj
             return $analyzer->analyze((string)$payload, $context, $intents);
         }
 
-        if (is_callable($analyzer)) {
-            return call_user_func($analyzer, $payload, $context, $intents);
+        if ($analyzer instanceof Func || is_callable($analyzer)) {
+            return $this->invokeFunc($analyzer, [$payload, $context, $intents, $this]);
         }
 
         return null;
@@ -603,7 +611,7 @@ class Intelligence extends Obj
         }
 
         arsort($strategyScores);
-        $topStrategies = array_slice(array_keys($strategyScores), 0, 3);
+        $topStrategies = $this->topKeys($strategyScores, 3);
 
         $intentScores = $this->aggregateSignals($segments, 'intent');
         $structureScores = $this->aggregateSignals($segments, 'structure');
@@ -618,9 +626,9 @@ class Intelligence extends Obj
             'intent_scores' => $intentScores,
             'structure_scores' => $structureScores,
             'context_scores' => $contextScores,
-            'top_intents' => array_slice(array_keys($intentScores), 0, 3),
-            'top_structures' => array_slice(array_keys($structureScores), 0, 3),
-            'top_context' => array_slice(array_keys($contextScores), 0, 3),
+            'top_intents' => $this->topKeys($intentScores, 3),
+            'top_structures' => $this->topKeys($structureScores, 3),
+            'top_context' => $this->topKeys($contextScores, 3),
         ];
     }
 
@@ -630,7 +638,7 @@ class Intelligence extends Obj
             return false;
         }
 
-        return array_keys($value) !== range(0, count($value) - 1);
+        return Arr::keys($value) !== range(0, count($value) - 1);
     }
 
     private function aggregateSignals(array $segments, string $metaKey): array
@@ -650,7 +658,7 @@ class Intelligence extends Obj
             foreach ($signals as $signal) {
                 $entries = $this->normalizeSignal($signal);
                 foreach ($entries as $label => $score) {
-                    $label = trim((string)$label);
+                    $label = Str::trim((string)$label);
                     if ($label === '') {
                         continue;
                     }
@@ -680,7 +688,7 @@ class Intelligence extends Obj
 
                 $entries = [];
                 foreach ($signal as $key => $value) {
-                    if (is_numeric($value)) {
+                    if (Num::isValid($value)) {
                         $entries[$key] = (float)$value;
                     } elseif (is_scalar($value)) {
                         $label = $this->formatScalarSignal($key, $value);
@@ -696,7 +704,7 @@ class Intelligence extends Obj
                 if (is_scalar($value)) {
                     $entries[(string)$value] = 1.0;
                 } elseif (is_array($value) && $this->isAssociative($value)) {
-                    $entries = array_merge($entries, $this->normalizeSignal($value));
+                    $entries = $this->mergeMap($entries, $this->normalizeSignal($value));
                 }
             }
 
@@ -712,11 +720,11 @@ class Intelligence extends Obj
 
     private function normalizeScore($score, string $label): float
     {
-        if (is_numeric($score)) {
+        if (Num::isValid($score)) {
             return (float)$score;
         }
 
-        if (is_scalar($score) && trim((string)$score) !== '') {
+        if (is_scalar($score) && Str::trim((string)$score) !== '') {
             return 1.0;
         }
 
@@ -738,6 +746,37 @@ class Intelligence extends Obj
      */
     protected function calculateScore(float $accuracy, float $executionTime): float
     {
-        return $accuracy / (1 + $executionTime);
+        return Num::divide($accuracy, Num::add(1, $executionTime));
+    }
+
+    private function mergeMap(array $base, array ...$segments): array
+    {
+        $merged = new Arr($base);
+
+        foreach ($segments as $segment) {
+            foreach ($segment as $key => $value) {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged->toArray();
+    }
+
+    private function appendList(array $base, array ...$segments): array
+    {
+        $merged = new Arr($base);
+
+        foreach ($segments as $segment) {
+            foreach ($segment as $value) {
+                $merged->push($value);
+            }
+        }
+
+        return $merged->toArray();
+    }
+
+    private function topKeys(array $values, int $limit): array
+    {
+        return Arr::slice(Arr::keys($values), 0, $limit);
     }
 }

--- a/src/Automata/Path/RouteAllocator.php
+++ b/src/Automata/Path/RouteAllocator.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Automata\Path;
 
+use BlueFission\Automata\Support\Evaluates;
+use BlueFission\Func;
+use BlueFission\Num;
 use BlueFission\Obj;
 use BlueFission\DevElation as Dev;
 use BlueFission\Behavioral\Dispatches;
@@ -25,21 +28,21 @@ use BlueFission\Behavioral\Behaviors\Event;
 class RouteAllocator extends Obj
 {
     use Dispatches;
+    use Evaluates;
 
     protected Graph $graph;
 
-    /** @var callable */
-    protected $fitness;
+    protected Func $fitness;
 
     /**
      * @param Graph    $graph
-     * @param callable $fitness function(array $edgeAttributes): int|float
+     * @param callable|Func $fitness function(array $edgeAttributes): int|float
      */
-    public function __construct(Graph $graph, callable $fitness)
+    public function __construct(Graph $graph, Func|callable $fitness)
     {
         parent::__construct();
         $this->graph = $graph;
-        $this->fitness = $fitness;
+        $this->fitness = $this->asFunc($fitness);
     }
 
     /**
@@ -63,7 +66,6 @@ class RouteAllocator extends Obj
             'edgeCapacities' => $edgeCapacities,
         ]);
 
-        $fitness = $this->fitness;
         $allocations = [];
         $used = []; // edgeKey => usedAmount
 
@@ -92,7 +94,9 @@ class RouteAllocator extends Obj
                     continue;
                 }
 
-                $path = $this->graph->shortestPath($start, $end, $fitness);
+                $path = $this->graph->shortestPath($start, $end, fn ($edge) => $this->numericValue(
+                    $this->invokeFunc($this->fitness, [$edge, $asset, $demand, $this])
+                ));
                 if (empty($path)) {
                     continue;
                 }
@@ -103,7 +107,7 @@ class RouteAllocator extends Obj
                     continue;
                 }
 
-                $amount = min($remainingDemand, $remainingAsset, $residual);
+                $amount = Num::min(Num::min($remainingDemand, $remainingAsset), $residual);
                 if ($amount <= 0.0) {
                     continue;
                 }
@@ -161,7 +165,7 @@ class RouteAllocator extends Obj
 
             $capacity = (float)($edgeCapacities[$key] ?? 0.0);
             $already = (float)($used[$key] ?? 0.0);
-            $residual = max(0.0, $capacity - $already);
+            $residual = Num::max(0.0, $capacity - $already);
 
             if ($minResidual === null || $residual < $minResidual) {
                 $minResidual = $residual;

--- a/src/Automata/Path/RoutePlanner.php
+++ b/src/Automata/Path/RoutePlanner.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Automata\Path;
 
+use BlueFission\Automata\Adapters\StateAdapter;
+use BlueFission\Automata\Support\Evaluates;
+use BlueFission\Func;
 use BlueFission\Obj;
 use BlueFission\Behavioral\Dispatches;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -24,21 +27,50 @@ use BlueFission\Behavioral\Behaviors\Event;
 class RoutePlanner extends Obj
 {
     use Dispatches;
+    use Evaluates;
 
     protected Graph $graph;
 
-    /** @var callable */
-    protected $fitness;
+    protected Func $fitness;
+    protected ?Func $assessor = null;
+    protected ?StateAdapter $stateAdapter = null;
 
     /**
      * @param Graph    $graph
-     * @param callable $fitness function(array $edgeAttributes): int|float
+     * @param callable|Func $fitness function(array $edgeAttributes): int|float
      */
-    public function __construct(Graph $graph, callable $fitness)
+    public function __construct(Graph $graph, Func|callable $fitness, mixed $state = null, Func|callable|null $assessor = null)
     {
         parent::__construct();
         $this->graph = $graph;
-        $this->fitness = $fitness;
+        $this->fitness = $this->asFunc($fitness);
+
+        if ($state !== null) {
+            $this->setState($state);
+        }
+
+        if ($assessor !== null) {
+            $this->setAssessor($assessor);
+        }
+    }
+
+    public function setState(mixed $state): self
+    {
+        $this->stateAdapter = StateAdapter::wrap($state);
+
+        return $this;
+    }
+
+    public function state(): ?StateAdapter
+    {
+        return $this->stateAdapter;
+    }
+
+    public function setAssessor(Func|callable $assessor): self
+    {
+        $this->assessor = $this->asFunc($assessor);
+
+        return $this;
     }
 
     /**
@@ -53,27 +85,38 @@ class RoutePlanner extends Obj
      * @param string $end
      * @return Route|null
      */
-    public function plan(string $start, string $end): ?Route
+    public function plan(string $start, string $end, array $context = []): ?Route
     {
-        $path = $this->graph->shortestPath($start, $end, $this->fitness);
+        $path = $this->graph->shortestPath($start, $end, function ($edge) use ($start, $end, $context) {
+            return $this->edgeCost($edge, [
+                'start' => $start,
+                'end' => $end,
+            ] + $context);
+        });
 
         if (empty($path)) {
             $this->dispatch(new Event('graph.route_unreachable', [
                 'start' => $start,
                 'end' => $end,
+                'state' => $this->stateAdapter?->snapshot() ?? [],
+                'context' => $context,
             ]));
             return null;
         }
 
         $cost = 0;
-        $fitness = $this->fitness;
 
         for ($i = 0; $i < count($path) - 1; $i++) {
             $edge = $this->graph->getEdgeAttributes($path[$i], $path[$i + 1]);
             if (!is_array($edge)) {
                 continue;
             }
-            $edgeCost = $fitness($edge);
+            $edgeCost = $this->edgeCost($edge, [
+                'start' => $start,
+                'end' => $end,
+                'from' => $path[$i],
+                'to' => $path[$i + 1],
+            ] + $context);
             if ($edgeCost < 0) {
                 continue;
             }
@@ -86,8 +129,26 @@ class RoutePlanner extends Obj
             'start' => $start,
             'end' => $end,
             'route' => $route,
+            'state' => $this->stateAdapter?->snapshot() ?? [],
+            'context' => $context,
         ]));
 
         return $route;
+    }
+
+    protected function edgeCost(array $edge, array $context = []): float|int
+    {
+        $state = $this->stateAdapter?->snapshot() ?? [];
+
+        if ($this->assessor instanceof Func) {
+            $score = $this->invokeFunc($this->assessor, [$edge, $state, $context, $this]);
+            if ($score !== null) {
+                return $this->numericValue($score);
+            }
+        }
+
+        $score = $this->invokeFunc($this->fitness, [$edge, $state, $context, $this]);
+
+        return $this->numericValue($score);
     }
 }

--- a/src/Automata/Simulation/Simulation.php
+++ b/src/Automata/Simulation/Simulation.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Simulation;
 
+use BlueFission\Automata\Adapters\StateAdapter;
 use BlueFission\Arr;
 use BlueFission\DevElation as Dev;
 
@@ -46,21 +47,21 @@ class Simulation
     /**
      * Run the simulation from an initial world state.
      *
-     * @param array $initialState
+     * @param mixed $initialState
      * @return array<int,array> Per-tick snapshots of the world state.
      */
-    public function run(array $initialState = []): array
+    public function run(mixed $initialState = []): array
     {
         $initialState = Dev::apply('automata.simulation.simulation.run.1', $initialState);
         Dev::do('automata.simulation.simulation.run.action1', ['initialState' => $initialState]);
 
-        $world = new Arr($initialState);
+        $world = StateAdapter::wrap($initialState);
         $log   = [];
 
         $entities = $this->_entities->val();
 
         for ($tick = 0; $tick < $this->_ticks; $tick++) {
-            $state = $world->val();
+            $state = $world->snapshot();
 
             foreach ($entities as $entity) {
                 if ($entity instanceof ISimulatable) {
@@ -69,9 +70,11 @@ class Simulation
             }
 
             $state['tick'] = $tick;
-            $world->val($state);
+            $world->merge($state);
             $log[] = $state;
         }
+
+        $world->sync();
 
         $log = Dev::apply('automata.simulation.simulation.run.2', $log);
         Dev::do('automata.simulation.simulation.run.action2', ['log' => $log]);

--- a/src/Automata/Support/Evaluates.php
+++ b/src/Automata/Support/Evaluates.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BlueFission\Automata\Support;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Str;
+
+trait Evaluates
+{
+    protected function asFunc(Func|callable $function): Func
+    {
+        return $function instanceof Func ? $function : new Func($function);
+    }
+
+    protected function invokeFunc(Func|callable $function, array $arguments): mixed
+    {
+        $macro = $this->asFunc($function);
+        $accepted = count($macro->expects());
+
+        if ($accepted <= 0) {
+            return $macro->call();
+        }
+
+        return $macro->call(...Arr::slice($arguments, 0, $accepted));
+    }
+
+    protected function numericValue(mixed $value, float|int $default = 0): float|int
+    {
+        if (!Num::isValid($value)) {
+            return $default;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        $value = Str::trim((string)$value);
+
+        if (preg_match('/^-?\d+$/', $value) === 1) {
+            return (int)$value;
+        }
+
+        return (float)$value;
+    }
+}

--- a/tests/Automata/Adapters/CarrierAdapterTest.php
+++ b/tests/Automata/Adapters/CarrierAdapterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Adapters;
+
+use BlueFission\Automata\Adapters\CarrierAdapter;
+use BlueFission\Obj;
+use PHPUnit\Framework\TestCase;
+
+class CarrierAdapterTest extends TestCase
+{
+    public function testCarrierAdapterWrapsObjFieldAccess(): void
+    {
+        $carrier = new class extends Obj {
+        };
+
+        $adapter = new CarrierAdapter($carrier);
+        $adapter
+            ->field('name', 'Transit Domain')
+            ->field('meta', ['priority' => 'high'])
+            ->assign(['status' => 'ready']);
+
+        $this->assertSame('Transit Domain', $carrier->field('name'));
+        $this->assertSame('ready', $adapter->field('status'));
+        $this->assertSame('high', $adapter->snapshot()['meta']['priority']);
+    }
+}

--- a/tests/Automata/Adapters/StateAdapterTest.php
+++ b/tests/Automata/Adapters/StateAdapterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Adapters;
+
+use BlueFission\Automata\Adapters\StateAdapter;
+use BlueFission\Obj;
+use PHPUnit\Framework\TestCase;
+
+class StateAdapterTest extends TestCase
+{
+    public function testStateAdapterReadsAndWritesObjBackedState(): void
+    {
+        $carrier = new class extends Obj {
+        };
+
+        $carrier->assign([
+            'world' => [
+                'risk' => 2,
+                'zone' => 'north',
+            ],
+            'status' => 'ready',
+        ]);
+
+        $adapter = new StateAdapter($carrier);
+
+        $this->assertSame(2, $adapter->get('world.risk'));
+
+        $adapter
+            ->set('world.risk', 1)
+            ->set('world.last_update', 'tick-3')
+            ->sync();
+
+        $world = $carrier->field('world');
+
+        $this->assertSame(1, $world['risk']);
+        $this->assertSame('tick-3', $world['last_update']);
+    }
+}

--- a/tests/Automata/Adapters/StoreAdapterTest.php
+++ b/tests/Automata/Adapters/StoreAdapterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Adapters;
+
+use BlueFission\Automata\Adapters\StoreAdapter;
+use BlueFission\Data\Storage\Local;
+use PHPUnit\Framework\TestCase;
+
+class StoreAdapterTest extends TestCase
+{
+    public function testStoreAdapterWrapsLocalStorageWithoutChangingStoreMechanics(): void
+    {
+        $store = new Local();
+        $store->activate();
+
+        $adapter = new StoreAdapter($store);
+        $adapter
+            ->contents([
+                'domain' => [
+                    'name' => 'regional-grid',
+                    'state' => 'stable',
+                ],
+            ])
+            ->write()
+            ->read();
+
+        $snapshot = $adapter->snapshot();
+
+        $this->assertSame('regional-grid', $snapshot['domain']['name']);
+        $this->assertSame('stable', $snapshot['domain']['state']);
+    }
+}

--- a/tests/Automata/Comprehension/EntityAdapterTest.php
+++ b/tests/Automata/Comprehension/EntityAdapterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Comprehension;
+
+use BlueFission\Automata\Comprehension\Entity;
+use PHPUnit\Framework\TestCase;
+
+class EntityAdapterTest extends TestCase
+{
+    public function testEntityProvidesSnapshotAndExplainContract(): void
+    {
+        $entity = new Entity('Warehouse A', 'Regional warehouse', ['category' => 'place']);
+        $entity
+            ->addLabel('place')
+            ->addLabel('storage')
+            ->defineDimension('x', ['kind' => 'absolute', 'unit' => 'km'])
+            ->defineDimension('time', ['kind' => 'relative', 'unit' => 'minutes'])
+            ->coordinate('x', 12)
+            ->coordinate('time', 5)
+            ->relate('supplies', 'Hospital A', ['distance_km' => 12])
+            ->record('status', ['condition' => 'operational']);
+
+        $snapshot = $entity->snapshot();
+
+        $this->assertSame('Warehouse A', $snapshot['name']);
+        $this->assertSame('Regional warehouse', $snapshot['description']);
+        $this->assertSame(['category' => 'place'], $snapshot['meta']);
+        $this->assertCount(2, $snapshot['labels']);
+        $this->assertCount(1, $snapshot['relations']);
+        $this->assertCount(1, $snapshot['history']);
+        $this->assertSame(12, $snapshot['coordinates']['x']);
+        $this->assertSame('minutes', $snapshot['dimensions']['time']['unit']);
+        $this->assertStringContainsString('Warehouse A', $entity->explain());
+    }
+}

--- a/tests/Automata/GameTheory/PlayerAdapterTest.php
+++ b/tests/Automata/GameTheory/PlayerAdapterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BlueFission\Tests\Automata\GameTheory;
+
+use BlueFission\Automata\GameTheory\Player;
+use BlueFission\Automata\Goal\Initiative;
+use PHPUnit\Framework\TestCase;
+
+class PlayerAdapterTest extends TestCase
+{
+    public function testPlayerTracksInterpreterFriendlyDecisionState(): void
+    {
+        $player = new Player('Continuity Lead');
+        $strategy = new class {
+            public function decide(Player $player): array
+            {
+                return ['action' => 'reroute', 'confidence' => 0.82];
+            }
+        };
+
+        $player
+            ->role('operator')
+            ->scope('circumstantial')
+            ->awareness('local')
+            ->efficacy('can_make_now')
+            ->addGoal(new Initiative(['name' => 'Maintain service']))
+            ->addCriterion('continuity', 2, 'stability')
+            ->addStrategy('decision_tree', 1, 'routing')
+            ->record('input_observed', ['source' => 'sensor'])
+            ->setStrategy($strategy);
+
+        $decision = $player->decide();
+
+        $snapshot = $player->snapshot();
+
+        $this->assertSame('Continuity Lead', $snapshot['name']);
+        $this->assertSame('operator', $snapshot['role']);
+        $this->assertSame(1, $snapshot['goalCount']);
+        $this->assertSame(1, $snapshot['criterionCount']);
+        $this->assertSame(2, $snapshot['strategyCount']);
+        $this->assertSame(2, $snapshot['historyCount']);
+        $this->assertSame(['action' => 'reroute', 'confidence' => 0.82], $decision);
+        $this->assertSame(['action' => 'reroute', 'confidence' => 0.82], $snapshot['lastDecision']);
+        $this->assertSame(get_class($strategy), $snapshot['activeStrategy']);
+        $this->assertStringContainsString('Continuity Lead', $player->explain());
+    }
+}

--- a/tests/Automata/Goal/ConditionTest.php
+++ b/tests/Automata/Goal/ConditionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Goal;
+
+use BlueFission\Automata\Goal\Condition;
+use PHPUnit\Framework\TestCase;
+
+class ConditionTest extends TestCase
+{
+    public function testConditionMatchesNestedContextValues(): void
+    {
+        $condition = new Condition([
+            'path' => 'metrics.risk',
+            'operator' => 'lte',
+            'value' => 2,
+            'weight' => 3,
+        ]);
+
+        $this->assertTrue($condition->matches([
+            'metrics' => ['risk' => 2],
+        ]));
+
+        $this->assertSame('metrics.risk', $condition->snapshot()['path']);
+        $this->assertSame(2, $condition->snapshot()['expected']);
+        $this->assertStringContainsString('metrics.risk', $condition->explain());
+    }
+}

--- a/tests/Automata/Simulation/SimulationTest.php
+++ b/tests/Automata/Simulation/SimulationTest.php
@@ -5,6 +5,7 @@ namespace BlueFission\Tests\Automata\Simulation;
 use PHPUnit\Framework\TestCase;
 use BlueFission\Automata\Simulation\Simulation;
 use BlueFission\Automata\Simulation\ISimulatable;
+use BlueFission\Obj;
 
 class CounterEntity implements ISimulatable
 {
@@ -28,6 +29,22 @@ class SimulationTest extends TestCase
         $final = end($log);
         $this->assertSame(5, $final['counter']);
         $this->assertSame(4, $final['tick']);
+    }
+
+    public function testSimulationCanAdvanceObjectBackedState(): void
+    {
+        $state = new class extends Obj {
+        };
+        $state->assign(['counter' => 0]);
+
+        $sim = new Simulation(3);
+        $sim->addEntity(new CounterEntity());
+
+        $log = $sim->run($state);
+
+        $this->assertCount(3, $log);
+        $this->assertSame(3, $state->field('counter'));
+        $this->assertSame(2, $state->field('tick'));
     }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'BlueFission\\';
+    if (strpos($class, $prefix) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, strlen($prefix));
+    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
+    $candidate = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $relativePath;
+
+    if (is_file($candidate)) {
+        require_once $candidate;
+    }
+}, true, true);
+
+$autoloadCandidates = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(__DIR__, 3) . '/vendor/autoload.php',
+];
+
+foreach ($autoloadCandidates as $candidate) {
+    if (is_file($candidate)) {
+        require $candidate;
+        break;
+    }
+}


### PR DESCRIPTION
Intent summary

- Retrofit Automata's worldview-facing seams to use carrier-backed adapters and DevElation-native `Func`, `Num`, `Arr`, and `Str` primitives where practical.
- Update existing examples and add new ones so the adapter and evaluator behavior is directly runnable from the feature worktree.

User stories / acceptance criteria

- As an Automata integrator, I can pass runtime state through carrier-backed adapters without forcing one domain superclass or coupling utility groups together.
- As an Automata integrator, I can provide evaluator, classifier, assessor, and fitness hooks through DevElation-backed seams across pathing, decision trees, genetic, feedback, intelligence, engine, and simulation flows.
- As a DevElation-aligned consumer, I can inspect prototype-backed player, entity, and condition objects through stable `snapshot()` and `explain()` contracts.
- As a library user, I can run examples from the feature worktree that demonstrate carrier-backed simulation, entity-condition worldview flows, routing and allocation assessment, and intelligence-engine orchestration.

Key files changed

- `src/Automata/Adapters/CarrierAdapter.php`
- `src/Automata/Adapters/StateAdapter.php`
- `src/Automata/Adapters/StoreAdapter.php`
- `src/Automata/Support/Evaluates.php`
- `src/Automata/GameTheory/Player.php`
- `src/Automata/Comprehension/Entity.php`
- `src/Automata/Goal/Condition.php`
- `src/Automata/Path/RoutePlanner.php`
- `src/Automata/Path/RouteAllocator.php`
- `src/Automata/DecisionTree/*`
- `src/Automata/Genetic/*`
- `src/Automata/Feedback/*`
- `src/Automata/Simulation/Simulation.php`
- `src/Automata/Intelligence.php`
- `src/Automata/Engine.php`
- `examples/*`
- `README.md`
- `SPEC.md`
- `ARCHITECTURE.md`

How to test

- `./vendor/bin/phpunit --bootstrap .worktrees/feature-jenss-worldview-adapters/tests/bootstrap.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Adapters/CarrierAdapterTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Adapters/StateAdapterTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Adapters/StoreAdapterTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Comprehension/EntityAdapterTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Comprehension/HolosceneLogTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/DecisionTree/DecisionTreeTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/DecisionTree/DispatchPolicyTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Feedback/AssessorTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Feedback/StrategyTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/GameTheory/GameTheoryTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/GameTheory/PlayerAdapterTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Genetic/GeneticExampleTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Genetic/GeneticPopulationTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Goal/ConditionTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/IntelligenceClassifierTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/IntelligenceInsightTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/IntelligenceTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Path/RouteAllocatorTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Path/RoutePlannerTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/Simulation/SimulationTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/EngineAttentionTest.php .worktrees/feature-jenss-worldview-adapters/tests/Automata/EngineClassifyTest.php .worktrees/feature-jenss-worldview-adapters/tests/Examples/DisasterResponse/Sim/ResponderStrategyTest.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/graph_routing_logistics.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/graph_route_allocation_logistics.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/decision_tree_dispatch_policy.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/carrier_backed_simulation.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/entity_condition_worldview.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/carrier_adapters_basic.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/generic/intelligence_engine_insights.php`
- `php .worktrees/feature-jenss-worldview-adapters/examples/disaster_response/simulation_world/run.php --seed=123`
- `php .worktrees/feature-jenss-worldview-adapters/examples/jenss_agent_adapter.php`

QA checklist

- [x] Focused worldview and adapter PHPUnit suite passes
- [x] Updated and new examples run from the feature worktree
- [x] Docs updated for the carrier-first and DevElation-native evaluator pattern
- [x] Monte Carlo worktree left untouched

Approval conditions

- Human review of worldview trait adoption points in `Player`, `Entity`, and `Condition`
- Human review of the example bootstrap approach for worktree-local execution
- Human review that the route assessment override semantics are acceptable
