### PR TITLE
Add Monte Carlo search and tree search

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,7 +146,7 @@ Responsibilities:
   workloads.
 - Maintain ordering, priority, and weighting semantics where needed.
 
-### 2.5 Analysis, Expert, Feature, Game, Genetic, and Graph Layers
+### 2.5 Analysis, Expert, Feature, Game, Genetic, Monte Carlo, and Graph Layers
 
 **Key folders:**
 
@@ -155,6 +155,7 @@ Responsibilities:
 - `Feature` – feature engineering and transformation.
 - `GameTheory` – game models, players, and strategies.
 - `Genetic` – genetic algorithms and fitness‑driven search.
+- `MonteCarlo` – stochastic rollout search and MCTS planners.
 - `Path` – graph structures and traversal algorithms.
 
 Responsibilities:
@@ -176,6 +177,19 @@ inherit a shared worldview implementation. For example:
 - `Genetic`, `Feedback`, `Intelligence`, and `Engine` now reuse the same
   `Func`/`Num`/`Arr`/`Str` conventions for mutation, scoring, classification,
   and runtime budgeting.
+The Monte Carlo layer specifically provides:
+
+- Callback-driven rollout search for noisy action evaluation.
+- A reusable deterministic random source for reproducible simulation budgets.
+- MCTS over user-defined state/action transitions, enabling sequential planning
+  without coupling the library to one environment model.
+
+The Monte Carlo layer specifically provides:
+
+- Callback-driven rollout search for noisy action evaluation.
+- A reusable deterministic random source for reproducible simulation budgets.
+- MCTS over user-defined state/action transitions, enabling sequential planning
+  without coupling the library to one environment model.
 
 ### 2.6 Memory, ABS, and Comprehension Layer
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -190,6 +190,13 @@ The Monte Carlo layer specifically provides:
 - A reusable deterministic random source for reproducible simulation budgets.
 - MCTS over user-defined state/action transitions, enabling sequential planning
   without coupling the library to one environment model.
+- DevElation-style configuration and event hooks so search loops can participate
+  in larger orchestration, observability, and adaptive-attention flows.
+
+This layer is also expected to compose later with upstream Develation
+`prototypes/` traits for worldview primitives such as `Proto`, `Position`,
+`Blueprint`, and `Agent`, rather than defining those concepts independently in
+Automata.
 
 ### 2.6 Memory, ABS, and Comprehension Layer
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Game Theory**: Analyze competitive environments according to the choices of decision-makers for strategic planning and simulations.
 - **Scenario Modeling**: Inspired by NetLogo, it supports agent-based models for simulating interactions and processes within complex systems.
 - **Genetic Algorithms**: Implement evolutionary algorithms that mimic natural selection for solving optimization problems.
+- **Monte Carlo Search**: Rank candidate actions under uncertainty using repeated seeded rollouts and per-action reward statistics.
+- **Monte Carlo Tree Search (MCTS)**: Explore sequential decisions with UCT-style selection, simulation, and backpropagation.
 - **Path & Graphs**: Manage, analyze, and manipulate structures represented graphically including networks of nodes and edges.
 - **Anomaly Detection**: Score behavioral activity, fingerprints, and context to flag unusual or risky patterns.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
@@ -33,6 +35,13 @@ To get started with `bluefission/automata`, clone the repository and include it 
 
 ```bash
 git clone https://github.com/bluefission/automata.git
+```
+
+Monte Carlo examples:
+
+```bash
+php examples/monte_carlo_route_planning.php
+php examples/monte_carlo_tree_search_dispatch.php
 ```
 
 ## Contributing

--- a/SPEC.md
+++ b/SPEC.md
@@ -250,7 +250,32 @@ It is a natural complement to:
 - Strategy selection (evolving ensembles).
 - Hyperparameter search for other models.
 
-### 3.10 Analysis, Classification, and Decision Trees
+### 3.10 Monte Carlo Search and Tree Search
+
+The `MonteCarlo` module provides:
+
+- Budgeted stochastic evaluation of candidate actions or states.
+- Deterministic seeded rollouts for reproducible tests and examples.
+- Tree search over sequential decisions using Monte Carlo Tree Search (MCTS).
+
+Goals:
+
+- Make it easy to evaluate competing actions when the environment is noisy or
+  partially simulated.
+- Reuse the same rollout primitives for direct action ranking and for MCTS.
+- Support callback-driven integration with game, simulation, path, and
+  strategy-oriented modules without forcing a single state representation.
+
+Core expectations:
+
+- Monte Carlo search should report visits, total reward, mean reward, and best
+  observed reward for each candidate action.
+- MCTS should implement selection, expansion, simulation, and backpropagation
+  with a configurable exploration/exploitation balance.
+- The subsystem should remain simple enough to serve as a planning primitive
+  for logistics, dispatch, and other decision-heavy examples.
+
+### 3.11 Analysis, Classification, and Decision Trees
 
 The `Analysis` folder is focused on **classification**:
 
@@ -258,7 +283,7 @@ The `Analysis` folder is focused on **classification**:
   reusable classifiers with clear interfaces.
 - Support for building ensembles from multiple classifiers.
 
-### 3.11 Anomaly and Behavioral Risk
+### 3.12 Anomaly and Behavioral Risk
 
 The `Anomaly` module provides a toolkit for fraud and anomaly detection:
 
@@ -276,7 +301,7 @@ The `DecisionTree` folder:
 - Should provide a canonical, well‑tested implementation of decision trees in
   the library.
 
-### 3.11 LLM and External Model Integration
+### 3.13 LLM and External Model Integration
 
 The `LLM` module integrates:
 
@@ -290,7 +315,7 @@ Intent:
   - e.g., use an LLM to configure an expert system or Bayesian classifier, then
     route matching intents to the smaller model.
 
-### 3.12 Intelligence Hub (Multi-Strategy Insights)
+### 3.14 Intelligence Hub (Multi-Strategy Insights)
 
 The Intelligence Hub extends the core `Intelligence` orchestrator to:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -274,6 +274,17 @@ Core expectations:
   with a configurable exploration/exploitation balance.
 - The subsystem should remain simple enough to serve as a planning primitive
   for logistics, dispatch, and other decision-heavy examples.
+- The subsystem should follow DevElation-style behavior/config patterns so
+  rollout engines can be observed, budgeted, and composed into larger
+  intelligence loops.
+
+Worldview dependency:
+
+- Higher-order abstractions for `Proto`, `Position`, `Blueprint`, and `Agent`
+  should live upstream in Develation and be consumable here once stabilized.
+- Automata should treat those as worldview primitives that shape data typing,
+  feature extraction, simulation state, and JenSS-facing semantics without
+  hard-coding one domain model.
 
 ### 3.11 Analysis, Classification, and Decision Trees
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,9 @@ Notable examples:
 - `examples/entity_condition_worldview.php` – worldview-oriented `Entity` and `Condition` snapshot/explain contracts.
 - `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
 - `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
+- `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
+- `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action ranking over uncertain route outcomes.
+- `examples/monte_carlo_tree_search_dispatch.php` – MCTS planning over a small sequential dispatch decision tree.
 
 Additional examples will be added as modules are fleshed out and tested.
 

--- a/examples/monte_carlo_route_planning.php
+++ b/examples/monte_carlo_route_planning.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+$autoloadCandidates = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(__DIR__, 3) . '/vendor/autoload.php',
+];
+
+foreach ($autoloadCandidates as $candidate) {
+    if (is_file($candidate)) {
+        require $candidate;
+        break;
+    }
+}
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'BlueFission\\';
+    if (strpos($class, $prefix) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, strlen($prefix));
+    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
+    $candidate = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $relativePath;
+
+    if (is_file($candidate)) {
+        require_once $candidate;
+    }
+});
+
+use BlueFission\Automata\MonteCarlo\Search;
+use BlueFission\Automata\MonteCarlo\RandomSource;
+
+$search = new Search(30, 21);
+
+$result = $search->evaluate(['hold', 'reroute', 'airlift'], function (string $action, RandomSource $random): float {
+    $routes = [
+        'hold' => ['reward' => 2.0, 'variance' => 1],
+        'reroute' => ['reward' => 6.0, 'variance' => 2],
+        'airlift' => ['reward' => 5.0, 'variance' => 3],
+    ];
+
+    $profile = $routes[$action];
+    $noise = $random->nextInt(-$profile['variance'], $profile['variance']);
+
+    return $profile['reward'] + $noise;
+});
+
+echo json_encode([
+    'best_action' => $result->getBestAction(),
+    'statistics' => $result->toArray(),
+], JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/monte_carlo_route_planning.php
+++ b/examples/monte_carlo_route_planning.php
@@ -2,39 +2,22 @@
 
 declare(strict_types=1);
 
-$autoloadCandidates = [
-    dirname(__DIR__) . '/vendor/autoload.php',
-    dirname(__DIR__, 3) . '/vendor/autoload.php',
-];
+require_once __DIR__ . '/bootstrap.php';
 
-foreach ($autoloadCandidates as $candidate) {
-    if (is_file($candidate)) {
-        require $candidate;
-        break;
-    }
-}
-
-spl_autoload_register(function (string $class): void {
-    $prefix = 'BlueFission\\';
-    if (strpos($class, $prefix) !== 0) {
-        return;
-    }
-
-    $relative = substr($class, strlen($prefix));
-    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
-    $candidate = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $relativePath;
-
-    if (is_file($candidate)) {
-        require_once $candidate;
-    }
-});
+automata_example_require(
+    'Automata/MonteCarlo/Search.php',
+    'Automata/MonteCarlo/RandomSource.php',
+    'Automata/MonteCarlo/ActionStatistics.php',
+    'Automata/MonteCarlo/SearchResult.php'
+);
 
 use BlueFission\Automata\MonteCarlo\Search;
 use BlueFission\Automata\MonteCarlo\RandomSource;
+use BlueFission\Func;
 
 $search = new Search(30, 21);
 
-$result = $search->evaluate(['hold', 'reroute', 'airlift'], function (string $action, RandomSource $random): float {
+$result = $search->evaluate(['hold', 'reroute', 'airlift'], new Func(function (string $action, RandomSource $random): float {
     $routes = [
         'hold' => ['reward' => 2.0, 'variance' => 1],
         'reroute' => ['reward' => 6.0, 'variance' => 2],
@@ -45,7 +28,7 @@ $result = $search->evaluate(['hold', 'reroute', 'airlift'], function (string $ac
     $noise = $random->nextInt(-$profile['variance'], $profile['variance']);
 
     return $profile['reward'] + $noise;
-});
+}));
 
 echo json_encode([
     'best_action' => $result->getBestAction(),

--- a/examples/monte_carlo_tree_search_dispatch.php
+++ b/examples/monte_carlo_tree_search_dispatch.php
@@ -2,40 +2,23 @@
 
 declare(strict_types=1);
 
-$autoloadCandidates = [
-    dirname(__DIR__) . '/vendor/autoload.php',
-    dirname(__DIR__, 3) . '/vendor/autoload.php',
-];
+require_once __DIR__ . '/bootstrap.php';
 
-foreach ($autoloadCandidates as $candidate) {
-    if (is_file($candidate)) {
-        require $candidate;
-        break;
-    }
-}
-
-spl_autoload_register(function (string $class): void {
-    $prefix = 'BlueFission\\';
-    if (strpos($class, $prefix) !== 0) {
-        return;
-    }
-
-    $relative = substr($class, strlen($prefix));
-    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
-    $candidate = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $relativePath;
-
-    if (is_file($candidate)) {
-        require_once $candidate;
-    }
-});
+automata_example_require(
+    'Automata/MonteCarlo/TreeSearch.php',
+    'Automata/MonteCarlo/TreeSearchNode.php',
+    'Automata/MonteCarlo/TreeSearchResult.php',
+    'Automata/MonteCarlo/RandomSource.php'
+);
 
 use BlueFission\Automata\MonteCarlo\TreeSearch;
+use BlueFission\Func;
 
 $search = new TreeSearch(60, 1.1, 3, 8);
 
 $result = $search->search(
     ['depth' => 0, 'path' => ''],
-    function (array $state): array {
+    new Func(function (array $state): array {
         if (($state['depth'] ?? 0) >= 2) {
             return [];
         }
@@ -45,23 +28,23 @@ $result = $search->search(
         }
 
         return ['finish'];
-    },
-    function (array $state, string $action): array {
+    }),
+    new Func(function (array $state, string $action): array {
         return [
             'depth' => ($state['depth'] ?? 0) + 1,
             'path' => trim(($state['path'] ?? '') . '/' . $action, '/'),
         ];
-    },
-    function (array $state): bool {
+    }),
+    new Func(function (array $state): bool {
         return ($state['depth'] ?? 0) >= 2;
-    },
-    function (array $state): float {
+    }),
+    new Func(function (array $state): float {
         return match ($state['path'] ?? '') {
             'slow_safe/finish' => 9.0,
             'fast_risky/finish' => 3.0,
             default => 0.0,
         };
-    }
+    })
 );
 
 echo json_encode($result->toArray(), JSON_PRETTY_PRINT) . PHP_EOL;

--- a/examples/monte_carlo_tree_search_dispatch.php
+++ b/examples/monte_carlo_tree_search_dispatch.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+$autoloadCandidates = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(__DIR__, 3) . '/vendor/autoload.php',
+];
+
+foreach ($autoloadCandidates as $candidate) {
+    if (is_file($candidate)) {
+        require $candidate;
+        break;
+    }
+}
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'BlueFission\\';
+    if (strpos($class, $prefix) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, strlen($prefix));
+    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
+    $candidate = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $relativePath;
+
+    if (is_file($candidate)) {
+        require_once $candidate;
+    }
+});
+
+use BlueFission\Automata\MonteCarlo\TreeSearch;
+
+$search = new TreeSearch(60, 1.1, 3, 8);
+
+$result = $search->search(
+    ['depth' => 0, 'path' => ''],
+    function (array $state): array {
+        if (($state['depth'] ?? 0) >= 2) {
+            return [];
+        }
+
+        if (($state['path'] ?? '') === '') {
+            return ['slow_safe', 'fast_risky'];
+        }
+
+        return ['finish'];
+    },
+    function (array $state, string $action): array {
+        return [
+            'depth' => ($state['depth'] ?? 0) + 1,
+            'path' => trim(($state['path'] ?? '') . '/' . $action, '/'),
+        ];
+    },
+    function (array $state): bool {
+        return ($state['depth'] ?? 0) >= 2;
+    },
+    function (array $state): float {
+        return match ($state['path'] ?? '') {
+            'slow_safe/finish' => 9.0,
+            'fast_risky/finish' => 3.0,
+            default => 0.0,
+        };
+    }
+);
+
+echo json_encode($result->toArray(), JSON_PRETTY_PRINT) . PHP_EOL;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true">
   <testsuites>
     <testsuite name="BlueFission Automata Test Suite">
       <directory suffix=".php">./tests/</directory>

--- a/src/Automata/MonteCarlo/ActionStatistics.php
+++ b/src/Automata/MonteCarlo/ActionStatistics.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class ActionStatistics
+{
+    private $action;
+    private int $visits = 0;
+    private float $totalReward = 0.0;
+    private float $bestReward = -INF;
+
+    public function __construct($action)
+    {
+        $this->action = $action;
+    }
+
+    public function record(float $reward): void
+    {
+        $this->visits++;
+        $this->totalReward += $reward;
+        $this->bestReward = max($this->bestReward, $reward);
+    }
+
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    public function getVisits(): int
+    {
+        return $this->visits;
+    }
+
+    public function getTotalReward(): float
+    {
+        return $this->totalReward;
+    }
+
+    public function getMeanReward(): float
+    {
+        if ($this->visits === 0) {
+            return 0.0;
+        }
+
+        return $this->totalReward / $this->visits;
+    }
+
+    public function getBestReward(): float
+    {
+        if ($this->visits === 0) {
+            return 0.0;
+        }
+
+        return $this->bestReward;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'action' => $this->action,
+            'visits' => $this->getVisits(),
+            'total_reward' => $this->getTotalReward(),
+            'mean_reward' => $this->getMeanReward(),
+            'best_reward' => $this->getBestReward(),
+        ];
+    }
+}

--- a/src/Automata/MonteCarlo/ActionStatistics.php
+++ b/src/Automata/MonteCarlo/ActionStatistics.php
@@ -2,6 +2,8 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Num;
+
 class ActionStatistics
 {
     private $action;
@@ -17,8 +19,8 @@ class ActionStatistics
     public function record(float $reward): void
     {
         $this->visits++;
-        $this->totalReward += $reward;
-        $this->bestReward = max($this->bestReward, $reward);
+        $this->totalReward = (float)Num::add($this->totalReward, $reward);
+        $this->bestReward = (float)Num::max($this->bestReward, $reward);
     }
 
     public function getAction()
@@ -42,7 +44,7 @@ class ActionStatistics
             return 0.0;
         }
 
-        return $this->totalReward / $this->visits;
+        return (float)Num::divide($this->totalReward, $this->visits);
     }
 
     public function getBestReward(): float

--- a/src/Automata/MonteCarlo/RandomSource.php
+++ b/src/Automata/MonteCarlo/RandomSource.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
+use BlueFission\Num;
+
 class RandomSource
 {
     private int $state;
@@ -29,15 +32,18 @@ class RandomSource
             return $min;
         }
 
-        return $min + (int)floor($this->nextFloat() * (($max - $min) + 1));
+        $span = (float)Num::add(Num::sub($max, $min), 1);
+        $offset = (int)Num::int(Num::multiply($this->nextFloat(), $span));
+
+        return (int)Num::add($min, $offset);
     }
 
     public function pick(array $items)
     {
-        if (empty($items)) {
+        if (Arr::size($items) === 0) {
             throw new \InvalidArgumentException('Cannot pick from an empty array.');
         }
 
-        return $items[$this->nextInt(0, count($items) - 1)];
+        return $items[$this->nextInt(0, Arr::size($items) - 1)];
     }
 }

--- a/src/Automata/MonteCarlo/RandomSource.php
+++ b/src/Automata/MonteCarlo/RandomSource.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class RandomSource
+{
+    private int $state;
+
+    public function __construct(?int $seed = null)
+    {
+        $seed = $seed ?? (int)(microtime(true) * 1000000);
+        $this->state = $seed & 0x7fffffff;
+    }
+
+    public function nextFloat(): float
+    {
+        $this->state = (int)(($this->state * 1103515245 + 12345) & 0x7fffffff);
+
+        return $this->state / 2147483647;
+    }
+
+    public function nextInt(int $min, int $max): int
+    {
+        if ($max < $min) {
+            throw new \InvalidArgumentException('Maximum must be greater than or equal to minimum.');
+        }
+
+        if ($min === $max) {
+            return $min;
+        }
+
+        return $min + (int)floor($this->nextFloat() * (($max - $min) + 1));
+    }
+
+    public function pick(array $items)
+    {
+        if (empty($items)) {
+            throw new \InvalidArgumentException('Cannot pick from an empty array.');
+        }
+
+        return $items[$this->nextInt(0, count($items) - 1)];
+    }
+}

--- a/src/Automata/MonteCarlo/Search.php
+++ b/src/Automata/MonteCarlo/Search.php
@@ -2,15 +2,20 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Behavioral\IDispatcher;
+use BlueFission\Collections\Collection;
+use BlueFission\Func;
+use BlueFission\Automata\Support\Evaluates;
 
 class Search implements IConfigurable, IDispatcher
 {
     use Configurable {
         Configurable::__construct as private __configConstruct;
     }
+    use Evaluates;
 
     public const EVENT_SEARCH_STARTED = 'automata.montecarlo.search.started';
     public const EVENT_ROLLOUT_COMPLETED = 'automata.montecarlo.search.rollout_completed';
@@ -33,9 +38,9 @@ class Search implements IConfigurable, IDispatcher
         ]);
     }
 
-    public function evaluate(array $actions, callable $rollout): SearchResult
+    public function evaluate(array $actions, Func|callable $rollout): SearchResult
     {
-        if (empty($actions)) {
+        if (Arr::size($actions) === 0) {
             throw new \InvalidArgumentException('At least one action is required.');
         }
 
@@ -51,11 +56,16 @@ class Search implements IConfigurable, IDispatcher
             $statistics[$this->actionKey($action)] = new ActionStatistics($action);
         }
 
+        $actionCount = Arr::size($actions);
+
         for ($iteration = 0; $iteration < $this->iterations(); $iteration++) {
-            $action = $actions[$iteration % count($actions)];
+            $action = $actions[$iteration % $actionCount];
             $key = $this->actionKey($action);
             $visit = $statistics[$key]->getVisits() + 1;
-            $reward = (float)$rollout($action, $random, $iteration, $visit);
+            $reward = (float)$this->numericValue(
+                $this->invokeFunc($rollout, [$action, $random, $iteration, $visit, $this]),
+                0.0
+            );
 
             $statistics[$key]->record($reward);
 
@@ -67,8 +77,7 @@ class Search implements IConfigurable, IDispatcher
             ]);
         }
 
-        $ranked = array_values($statistics);
-        usort($ranked, function (ActionStatistics $left, ActionStatistics $right): int {
+        $ranked = (new Collection(array_values($statistics)))->sort(function (ActionStatistics $left, ActionStatistics $right): int {
             $meanOrder = $right->getMeanReward() <=> $left->getMeanReward();
             if ($meanOrder !== 0) {
                 return $meanOrder;
@@ -80,7 +89,7 @@ class Search implements IConfigurable, IDispatcher
             }
 
             return $right->getBestReward() <=> $left->getBestReward();
-        });
+        })->toArray();
 
         $result = new SearchResult($ranked);
 

--- a/src/Automata/MonteCarlo/Search.php
+++ b/src/Automata/MonteCarlo/Search.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class Search
+{
+    private int $iterations;
+    private ?int $seed;
+
+    public function __construct(int $iterations = 100, ?int $seed = null)
+    {
+        if ($iterations < 1) {
+            throw new \InvalidArgumentException('Iterations must be at least 1.');
+        }
+
+        $this->iterations = $iterations;
+        $this->seed = $seed;
+    }
+
+    public function evaluate(array $actions, callable $rollout): SearchResult
+    {
+        if (empty($actions)) {
+            throw new \InvalidArgumentException('At least one action is required.');
+        }
+
+        $random = new RandomSource($this->seed);
+        $statistics = [];
+
+        foreach ($actions as $action) {
+            $statistics[$this->actionKey($action)] = new ActionStatistics($action);
+        }
+
+        for ($iteration = 0; $iteration < $this->iterations; $iteration++) {
+            $action = $actions[$iteration % count($actions)];
+            $key = $this->actionKey($action);
+            $visit = $statistics[$key]->getVisits() + 1;
+            $reward = (float)$rollout($action, $random, $iteration, $visit);
+
+            $statistics[$key]->record($reward);
+        }
+
+        $ranked = array_values($statistics);
+        usort($ranked, function (ActionStatistics $left, ActionStatistics $right): int {
+            $meanOrder = $right->getMeanReward() <=> $left->getMeanReward();
+            if ($meanOrder !== 0) {
+                return $meanOrder;
+            }
+
+            $visitOrder = $right->getVisits() <=> $left->getVisits();
+            if ($visitOrder !== 0) {
+                return $visitOrder;
+            }
+
+            return $right->getBestReward() <=> $left->getBestReward();
+        });
+
+        return new SearchResult($ranked);
+    }
+
+    private function actionKey($action): string
+    {
+        if (is_scalar($action) || $action === null) {
+            return (string)$action;
+        }
+
+        return md5(serialize($action));
+    }
+}

--- a/src/Automata/MonteCarlo/Search.php
+++ b/src/Automata/MonteCarlo/Search.php
@@ -2,10 +2,24 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
-class Search
+use BlueFission\Behavioral\Configurable;
+use BlueFission\Behavioral\IConfigurable;
+use BlueFission\Behavioral\IDispatcher;
+
+class Search implements IConfigurable, IDispatcher
 {
-    private int $iterations;
-    private ?int $seed;
+    use Configurable {
+        Configurable::__construct as private __configConstruct;
+    }
+
+    public const EVENT_SEARCH_STARTED = 'automata.montecarlo.search.started';
+    public const EVENT_ROLLOUT_COMPLETED = 'automata.montecarlo.search.rollout_completed';
+    public const EVENT_SEARCH_COMPLETED = 'automata.montecarlo.search.completed';
+
+    protected array $_config = [
+        'iterations' => 100,
+        'seed' => null,
+    ];
 
     public function __construct(int $iterations = 100, ?int $seed = null)
     {
@@ -13,8 +27,10 @@ class Search
             throw new \InvalidArgumentException('Iterations must be at least 1.');
         }
 
-        $this->iterations = $iterations;
-        $this->seed = $seed;
+        $this->__configConstruct([
+            'iterations' => $iterations,
+            'seed' => $seed,
+        ]);
     }
 
     public function evaluate(array $actions, callable $rollout): SearchResult
@@ -23,20 +39,32 @@ class Search
             throw new \InvalidArgumentException('At least one action is required.');
         }
 
-        $random = new RandomSource($this->seed);
+        $random = new RandomSource($this->seed());
         $statistics = [];
+
+        $this->dispatch(self::EVENT_SEARCH_STARTED, [
+            'actions' => $actions,
+            'iterations' => $this->iterations(),
+        ]);
 
         foreach ($actions as $action) {
             $statistics[$this->actionKey($action)] = new ActionStatistics($action);
         }
 
-        for ($iteration = 0; $iteration < $this->iterations; $iteration++) {
+        for ($iteration = 0; $iteration < $this->iterations(); $iteration++) {
             $action = $actions[$iteration % count($actions)];
             $key = $this->actionKey($action);
             $visit = $statistics[$key]->getVisits() + 1;
             $reward = (float)$rollout($action, $random, $iteration, $visit);
 
             $statistics[$key]->record($reward);
+
+            $this->dispatch(self::EVENT_ROLLOUT_COMPLETED, [
+                'iteration' => $iteration,
+                'action' => $action,
+                'visit' => $visit,
+                'reward' => $reward,
+            ]);
         }
 
         $ranked = array_values($statistics);
@@ -54,7 +82,26 @@ class Search
             return $right->getBestReward() <=> $left->getBestReward();
         });
 
-        return new SearchResult($ranked);
+        $result = new SearchResult($ranked);
+
+        $this->dispatch(self::EVENT_SEARCH_COMPLETED, [
+            'best_action' => $result->getBestAction(),
+            'statistics' => $result->toArray(),
+        ]);
+
+        return $result;
+    }
+
+    public function iterations(): int
+    {
+        return (int)$this->config('iterations');
+    }
+
+    public function seed(): ?int
+    {
+        $seed = $this->config('seed');
+
+        return $seed === null ? null : (int)$seed;
     }
 
     private function actionKey($action): string

--- a/src/Automata/MonteCarlo/SearchResult.php
+++ b/src/Automata/MonteCarlo/SearchResult.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class SearchResult
+{
+    /**
+     * @var ActionStatistics[]
+     */
+    private array $statistics;
+
+    public function __construct(array $statistics)
+    {
+        $this->statistics = $statistics;
+    }
+
+    /**
+     * @return ActionStatistics[]
+     */
+    public function getStatistics(): array
+    {
+        return $this->statistics;
+    }
+
+    public function getBestAction()
+    {
+        $best = $this->getBestStatistics();
+
+        return $best ? $best->getAction() : null;
+    }
+
+    public function getBestStatistics(): ?ActionStatistics
+    {
+        if (empty($this->statistics)) {
+            return null;
+        }
+
+        return $this->statistics[0];
+    }
+
+    public function toArray(): array
+    {
+        return array_map(function (ActionStatistics $statistics): array {
+            return $statistics->toArray();
+        }, $this->statistics);
+    }
+}

--- a/src/Automata/MonteCarlo/SearchResult.php
+++ b/src/Automata/MonteCarlo/SearchResult.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+
 class SearchResult
 {
     /**
@@ -31,7 +34,7 @@ class SearchResult
 
     public function getBestStatistics(): ?ActionStatistics
     {
-        if (empty($this->statistics)) {
+        if (Arr::size($this->statistics) === 0) {
             return null;
         }
 
@@ -40,8 +43,8 @@ class SearchResult
 
     public function toArray(): array
     {
-        return array_map(function (ActionStatistics $statistics): array {
+        return (new Collection($this->statistics))->map(function (ActionStatistics $statistics): array {
             return $statistics->toArray();
-        }, $this->statistics);
+        })->toArray();
     }
 }

--- a/src/Automata/MonteCarlo/TreeSearch.php
+++ b/src/Automata/MonteCarlo/TreeSearch.php
@@ -2,12 +2,27 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
-class TreeSearch
+use BlueFission\Behavioral\Configurable;
+use BlueFission\Behavioral\IConfigurable;
+use BlueFission\Behavioral\IDispatcher;
+
+class TreeSearch implements IConfigurable, IDispatcher
 {
-    private int $iterations;
-    private float $explorationConstant;
-    private int $rolloutDepth;
-    private ?int $seed;
+    use Configurable {
+        Configurable::__construct as private __configConstruct;
+    }
+
+    public const EVENT_SEARCH_STARTED = 'automata.montecarlo.treesearch.started';
+    public const EVENT_NODE_EXPANDED = 'automata.montecarlo.treesearch.node_expanded';
+    public const EVENT_ITERATION_COMPLETED = 'automata.montecarlo.treesearch.iteration_completed';
+    public const EVENT_SEARCH_COMPLETED = 'automata.montecarlo.treesearch.completed';
+
+    protected array $_config = [
+        'iterations' => 100,
+        'exploration_constant' => 1.41421356237,
+        'rollout_depth' => 10,
+        'seed' => null,
+    ];
 
     public function __construct(
         int $iterations = 100,
@@ -23,10 +38,12 @@ class TreeSearch
             throw new \InvalidArgumentException('Rollout depth must be zero or greater.');
         }
 
-        $this->iterations = $iterations;
-        $this->explorationConstant = $explorationConstant;
-        $this->rolloutDepth = $rolloutDepth;
-        $this->seed = $seed;
+        $this->__configConstruct([
+            'iterations' => $iterations,
+            'exploration_constant' => $explorationConstant,
+            'rollout_depth' => $rolloutDepth,
+            'seed' => $seed,
+        ]);
     }
 
     public function search(
@@ -36,10 +53,17 @@ class TreeSearch
         callable $isTerminal,
         callable $reward
     ): TreeSearchResult {
-        $random = new RandomSource($this->seed);
+        $random = new RandomSource($this->seed());
         $root = new TreeSearchNode($initialState, null, null, array_values($legalActions($initialState)));
 
-        for ($iteration = 0; $iteration < $this->iterations; $iteration++) {
+        $this->dispatch(self::EVENT_SEARCH_STARTED, [
+            'initial_state' => $initialState,
+            'iterations' => $this->iterations(),
+            'exploration_constant' => $this->explorationConstant(),
+            'rollout_depth' => $this->rolloutDepth(),
+        ]);
+
+        for ($iteration = 0; $iteration < $this->iterations(); $iteration++) {
             $node = $root;
             $state = $initialState;
 
@@ -58,11 +82,17 @@ class TreeSearch
                 $child = new TreeSearchNode($state, $node, $action, array_values($legalActions($state)));
                 $node->addChild($child);
                 $node = $child;
+
+                $this->dispatch(self::EVENT_NODE_EXPANDED, [
+                    'iteration' => $iteration,
+                    'action' => $action,
+                    'state' => $state,
+                ]);
             }
 
             $simulationState = $state;
             $depth = 0;
-            while (!$isTerminal($simulationState) && $depth < $this->rolloutDepth) {
+            while (!$isTerminal($simulationState) && $depth < $this->rolloutDepth()) {
                 $actions = array_values($legalActions($simulationState));
                 if (empty($actions)) {
                     break;
@@ -79,9 +109,41 @@ class TreeSearch
                 $node->record($score);
                 $node = $node->getParent();
             }
+
+            $this->dispatch(self::EVENT_ITERATION_COMPLETED, [
+                'iteration' => $iteration,
+                'score' => $score,
+                'simulation_state' => $simulationState,
+            ]);
         }
 
-        return new TreeSearchResult($root);
+        $result = new TreeSearchResult($root);
+
+        $this->dispatch(self::EVENT_SEARCH_COMPLETED, $result->toArray());
+
+        return $result;
+    }
+
+    public function iterations(): int
+    {
+        return (int)$this->config('iterations');
+    }
+
+    public function explorationConstant(): float
+    {
+        return (float)$this->config('exploration_constant');
+    }
+
+    public function rolloutDepth(): int
+    {
+        return (int)$this->config('rollout_depth');
+    }
+
+    public function seed(): ?int
+    {
+        $seed = $this->config('seed');
+
+        return $seed === null ? null : (int)$seed;
     }
 
     private function selectChild(TreeSearchNode $node): TreeSearchNode
@@ -96,7 +158,7 @@ class TreeSearch
             }
 
             $score = $child->getMeanReward()
-                + $this->explorationConstant * sqrt(log($parentVisits) / $child->getVisits());
+                + $this->explorationConstant() * sqrt(log($parentVisits) / $child->getVisits());
 
             if ($score > $bestScore) {
                 $bestScore = $score;

--- a/src/Automata/MonteCarlo/TreeSearch.php
+++ b/src/Automata/MonteCarlo/TreeSearch.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class TreeSearch
+{
+    private int $iterations;
+    private float $explorationConstant;
+    private int $rolloutDepth;
+    private ?int $seed;
+
+    public function __construct(
+        int $iterations = 100,
+        float $explorationConstant = 1.41421356237,
+        int $rolloutDepth = 10,
+        ?int $seed = null
+    ) {
+        if ($iterations < 1) {
+            throw new \InvalidArgumentException('Iterations must be at least 1.');
+        }
+
+        if ($rolloutDepth < 0) {
+            throw new \InvalidArgumentException('Rollout depth must be zero or greater.');
+        }
+
+        $this->iterations = $iterations;
+        $this->explorationConstant = $explorationConstant;
+        $this->rolloutDepth = $rolloutDepth;
+        $this->seed = $seed;
+    }
+
+    public function search(
+        $initialState,
+        callable $legalActions,
+        callable $transition,
+        callable $isTerminal,
+        callable $reward
+    ): TreeSearchResult {
+        $random = new RandomSource($this->seed);
+        $root = new TreeSearchNode($initialState, null, null, array_values($legalActions($initialState)));
+
+        for ($iteration = 0; $iteration < $this->iterations; $iteration++) {
+            $node = $root;
+            $state = $initialState;
+
+            while (
+                !$isTerminal($state)
+                && !$node->hasUntriedActions()
+                && !empty($node->getChildren())
+            ) {
+                $node = $this->selectChild($node);
+                $state = $node->getState();
+            }
+
+            if (!$isTerminal($state) && $node->hasUntriedActions()) {
+                $action = $node->takeUntriedAction($random);
+                $state = $transition($state, $action, $random);
+                $child = new TreeSearchNode($state, $node, $action, array_values($legalActions($state)));
+                $node->addChild($child);
+                $node = $child;
+            }
+
+            $simulationState = $state;
+            $depth = 0;
+            while (!$isTerminal($simulationState) && $depth < $this->rolloutDepth) {
+                $actions = array_values($legalActions($simulationState));
+                if (empty($actions)) {
+                    break;
+                }
+
+                $simulationAction = $random->pick($actions);
+                $simulationState = $transition($simulationState, $simulationAction, $random);
+                $depth++;
+            }
+
+            $score = (float)$reward($simulationState);
+
+            while ($node !== null) {
+                $node->record($score);
+                $node = $node->getParent();
+            }
+        }
+
+        return new TreeSearchResult($root);
+    }
+
+    private function selectChild(TreeSearchNode $node): TreeSearchNode
+    {
+        $bestChild = null;
+        $bestScore = -INF;
+        $parentVisits = max(1, $node->getVisits());
+
+        foreach ($node->getChildren() as $child) {
+            if ($child->getVisits() === 0) {
+                return $child;
+            }
+
+            $score = $child->getMeanReward()
+                + $this->explorationConstant * sqrt(log($parentVisits) / $child->getVisits());
+
+            if ($score > $bestScore) {
+                $bestScore = $score;
+                $bestChild = $child;
+            }
+        }
+
+        if ($bestChild === null) {
+            throw new \RuntimeException('Unable to select child from empty node.');
+        }
+
+        return $bestChild;
+    }
+}

--- a/src/Automata/MonteCarlo/TreeSearch.php
+++ b/src/Automata/MonteCarlo/TreeSearch.php
@@ -2,15 +2,20 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Behavioral\IDispatcher;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Automata\Support\Evaluates;
 
 class TreeSearch implements IConfigurable, IDispatcher
 {
     use Configurable {
         Configurable::__construct as private __configConstruct;
     }
+    use Evaluates;
 
     public const EVENT_SEARCH_STARTED = 'automata.montecarlo.treesearch.started';
     public const EVENT_NODE_EXPANDED = 'automata.montecarlo.treesearch.node_expanded';
@@ -48,13 +53,18 @@ class TreeSearch implements IConfigurable, IDispatcher
 
     public function search(
         $initialState,
-        callable $legalActions,
-        callable $transition,
-        callable $isTerminal,
-        callable $reward
+        Func|callable $legalActions,
+        Func|callable $transition,
+        Func|callable $isTerminal,
+        Func|callable $reward
     ): TreeSearchResult {
         $random = new RandomSource($this->seed());
-        $root = new TreeSearchNode($initialState, null, null, array_values($legalActions($initialState)));
+        $root = new TreeSearchNode(
+            $initialState,
+            null,
+            null,
+            array_values(Arr::toArray($this->invokeFunc($legalActions, [$initialState, null, $this])))
+        );
 
         $this->dispatch(self::EVENT_SEARCH_STARTED, [
             'initial_state' => $initialState,
@@ -68,18 +78,23 @@ class TreeSearch implements IConfigurable, IDispatcher
             $state = $initialState;
 
             while (
-                !$isTerminal($state)
+                !(bool)$this->invokeFunc($isTerminal, [$state, $node, $this])
                 && !$node->hasUntriedActions()
-                && !empty($node->getChildren())
+                && Arr::size($node->getChildren()) > 0
             ) {
                 $node = $this->selectChild($node);
                 $state = $node->getState();
             }
 
-            if (!$isTerminal($state) && $node->hasUntriedActions()) {
+            if (!(bool)$this->invokeFunc($isTerminal, [$state, $node, $this]) && $node->hasUntriedActions()) {
                 $action = $node->takeUntriedAction($random);
-                $state = $transition($state, $action, $random);
-                $child = new TreeSearchNode($state, $node, $action, array_values($legalActions($state)));
+                $state = $this->invokeFunc($transition, [$state, $action, $random, $node, $this]);
+                $child = new TreeSearchNode(
+                    $state,
+                    $node,
+                    $action,
+                    array_values(Arr::toArray($this->invokeFunc($legalActions, [$state, $node, $this])))
+                );
                 $node->addChild($child);
                 $node = $child;
 
@@ -92,18 +107,24 @@ class TreeSearch implements IConfigurable, IDispatcher
 
             $simulationState = $state;
             $depth = 0;
-            while (!$isTerminal($simulationState) && $depth < $this->rolloutDepth()) {
-                $actions = array_values($legalActions($simulationState));
-                if (empty($actions)) {
+            while (!(bool)$this->invokeFunc($isTerminal, [$simulationState, $node, $this]) && $depth < $this->rolloutDepth()) {
+                $actions = array_values(Arr::toArray($this->invokeFunc($legalActions, [$simulationState, $node, $this])));
+                if (Arr::size($actions) === 0) {
                     break;
                 }
 
                 $simulationAction = $random->pick($actions);
-                $simulationState = $transition($simulationState, $simulationAction, $random);
+                $simulationState = $this->invokeFunc(
+                    $transition,
+                    [$simulationState, $simulationAction, $random, $node, $this]
+                );
                 $depth++;
             }
 
-            $score = (float)$reward($simulationState);
+            $score = (float)$this->numericValue(
+                $this->invokeFunc($reward, [$simulationState, $node, $this]),
+                0.0
+            );
 
             while ($node !== null) {
                 $node->record($score);
@@ -150,15 +171,23 @@ class TreeSearch implements IConfigurable, IDispatcher
     {
         $bestChild = null;
         $bestScore = -INF;
-        $parentVisits = max(1, $node->getVisits());
+        $parentVisits = (int)Num::max(1, $node->getVisits());
 
         foreach ($node->getChildren() as $child) {
             if ($child->getVisits() === 0) {
                 return $child;
             }
 
-            $score = $child->getMeanReward()
-                + $this->explorationConstant() * sqrt(log($parentVisits) / $child->getVisits());
+            $exploration = (float)Num::multiply(
+                $this->explorationConstant(),
+                Num::sqrt(
+                    Num::divide(
+                        Num::log($parentVisits),
+                        $child->getVisits()
+                    )
+                )
+            );
+            $score = (float)Num::add($child->getMeanReward(), $exploration);
 
             if ($score > $bestScore) {
                 $bestScore = $score;

--- a/src/Automata/MonteCarlo/TreeSearchNode.php
+++ b/src/Automata/MonteCarlo/TreeSearchNode.php
@@ -2,6 +2,10 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\Num;
+
 class TreeSearchNode
 {
     private $state;
@@ -17,7 +21,7 @@ class TreeSearchNode
         $this->state = $state;
         $this->parent = $parent;
         $this->action = $action;
-        $this->untriedActions = array_values($untriedActions);
+        $this->untriedActions = array_values(Arr::toArray($untriedActions));
     }
 
     public function getState()
@@ -50,12 +54,12 @@ class TreeSearchNode
 
     public function hasUntriedActions(): bool
     {
-        return !empty($this->untriedActions);
+        return Arr::size($this->untriedActions) > 0;
     }
 
     public function takeUntriedAction(RandomSource $random)
     {
-        $index = $random->nextInt(0, count($this->untriedActions) - 1);
+        $index = $random->nextInt(0, Arr::size($this->untriedActions) - 1);
         $action = $this->untriedActions[$index];
         array_splice($this->untriedActions, $index, 1);
 
@@ -65,7 +69,7 @@ class TreeSearchNode
     public function record(float $reward): void
     {
         $this->visits++;
-        $this->totalReward += $reward;
+        $this->totalReward = (float)Num::add($this->totalReward, $reward);
     }
 
     public function getVisits(): int
@@ -84,7 +88,7 @@ class TreeSearchNode
             return 0.0;
         }
 
-        return $this->totalReward / $this->visits;
+        return (float)Num::divide($this->totalReward, $this->visits);
     }
 
     public function toArray(): array
@@ -95,9 +99,9 @@ class TreeSearchNode
             'visits' => $this->visits,
             'total_reward' => $this->totalReward,
             'mean_reward' => $this->getMeanReward(),
-            'children' => array_map(function (self $child): array {
+            'children' => (new Collection($this->children))->map(function (self $child): array {
                 return $child->toArray();
-            }, $this->children),
+            })->toArray(),
         ];
     }
 }

--- a/src/Automata/MonteCarlo/TreeSearchNode.php
+++ b/src/Automata/MonteCarlo/TreeSearchNode.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class TreeSearchNode
+{
+    private $state;
+    private $action;
+    private ?self $parent;
+    private array $children = [];
+    private array $untriedActions;
+    private int $visits = 0;
+    private float $totalReward = 0.0;
+
+    public function __construct($state, ?self $parent = null, $action = null, array $untriedActions = [])
+    {
+        $this->state = $state;
+        $this->parent = $parent;
+        $this->action = $action;
+        $this->untriedActions = array_values($untriedActions);
+    }
+
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @return self[]
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function addChild(self $child): void
+    {
+        $this->children[] = $child;
+    }
+
+    public function hasUntriedActions(): bool
+    {
+        return !empty($this->untriedActions);
+    }
+
+    public function takeUntriedAction(RandomSource $random)
+    {
+        $index = $random->nextInt(0, count($this->untriedActions) - 1);
+        $action = $this->untriedActions[$index];
+        array_splice($this->untriedActions, $index, 1);
+
+        return $action;
+    }
+
+    public function record(float $reward): void
+    {
+        $this->visits++;
+        $this->totalReward += $reward;
+    }
+
+    public function getVisits(): int
+    {
+        return $this->visits;
+    }
+
+    public function getTotalReward(): float
+    {
+        return $this->totalReward;
+    }
+
+    public function getMeanReward(): float
+    {
+        if ($this->visits === 0) {
+            return 0.0;
+        }
+
+        return $this->totalReward / $this->visits;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'action' => $this->action,
+            'state' => $this->state,
+            'visits' => $this->visits,
+            'total_reward' => $this->totalReward,
+            'mean_reward' => $this->getMeanReward(),
+            'children' => array_map(function (self $child): array {
+                return $child->toArray();
+            }, $this->children),
+        ];
+    }
+}

--- a/src/Automata/MonteCarlo/TreeSearchResult.php
+++ b/src/Automata/MonteCarlo/TreeSearchResult.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Automata\MonteCarlo;
 
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+
 class TreeSearchResult
 {
     private TreeSearchNode $root;
@@ -20,18 +23,18 @@ class TreeSearchResult
     {
         $children = $this->root->getChildren();
 
-        if (empty($children)) {
+        if (Arr::size($children) === 0) {
             return null;
         }
 
-        usort($children, function (TreeSearchNode $left, TreeSearchNode $right): int {
+        $children = (new Collection($children))->sort(function (TreeSearchNode $left, TreeSearchNode $right): int {
             $visitOrder = $right->getVisits() <=> $left->getVisits();
             if ($visitOrder !== 0) {
                 return $visitOrder;
             }
 
             return $right->getMeanReward() <=> $left->getMeanReward();
-        });
+        })->toArray();
 
         return $children[0]->getAction();
     }

--- a/src/Automata/MonteCarlo/TreeSearchResult.php
+++ b/src/Automata/MonteCarlo/TreeSearchResult.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BlueFission\Automata\MonteCarlo;
+
+class TreeSearchResult
+{
+    private TreeSearchNode $root;
+
+    public function __construct(TreeSearchNode $root)
+    {
+        $this->root = $root;
+    }
+
+    public function getRoot(): TreeSearchNode
+    {
+        return $this->root;
+    }
+
+    public function getBestAction()
+    {
+        $children = $this->root->getChildren();
+
+        if (empty($children)) {
+            return null;
+        }
+
+        usort($children, function (TreeSearchNode $left, TreeSearchNode $right): int {
+            $visitOrder = $right->getVisits() <=> $left->getVisits();
+            if ($visitOrder !== 0) {
+                return $visitOrder;
+            }
+
+            return $right->getMeanReward() <=> $left->getMeanReward();
+        });
+
+        return $children[0]->getAction();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'best_action' => $this->getBestAction(),
+            'root' => $this->root->toArray(),
+        ];
+    }
+}

--- a/tests/Automata/MonteCarlo/SearchTest.php
+++ b/tests/Automata/MonteCarlo/SearchTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BlueFission\Tests\Automata\MonteCarlo;
+
+use BlueFission\Automata\MonteCarlo\RandomSource;
+use BlueFission\Automata\MonteCarlo\Search;
+use PHPUnit\Framework\TestCase;
+
+class SearchTest extends TestCase
+{
+    public function testMonteCarloSearchAggregatesVisitsAndRewards(): void
+    {
+        $search = new Search(9, 12);
+
+        $result = $search->evaluate(['hold', 'reroute', 'airlift'], function (string $action): float {
+            $scores = [
+                'hold' => 1.0,
+                'reroute' => 5.0,
+                'airlift' => 3.0,
+            ];
+
+            return $scores[$action];
+        });
+
+        $stats = $result->toArray();
+
+        $this->assertSame('reroute', $result->getBestAction());
+        $this->assertCount(3, $stats);
+        $this->assertSame(3, $stats[0]['visits']);
+        $this->assertSame(5.0, $stats[0]['mean_reward']);
+        $this->assertSame(15.0, $stats[0]['total_reward']);
+    }
+
+    public function testMonteCarloSearchProvidesDeterministicSeededRandomness(): void
+    {
+        $rollout = function (string $action, RandomSource $random): float {
+            $base = [
+                'stabilize' => 10.0,
+                'deploy' => 20.0,
+            ];
+
+            return $base[$action] + $random->nextInt(0, 2);
+        };
+
+        $first = (new Search(8, 44))->evaluate(['stabilize', 'deploy'], $rollout)->toArray();
+        $second = (new Search(8, 44))->evaluate(['stabilize', 'deploy'], $rollout)->toArray();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testMonteCarloSearchRejectsEmptyActionList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new Search(4))->evaluate([], function (): float {
+            return 0.0;
+        });
+    }
+}

--- a/tests/Automata/MonteCarlo/TreeSearchTest.php
+++ b/tests/Automata/MonteCarlo/TreeSearchTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BlueFission\Tests\Automata\MonteCarlo;
+
+use BlueFission\Automata\MonteCarlo\TreeSearch;
+use PHPUnit\Framework\TestCase;
+
+class TreeSearchTest extends TestCase
+{
+    public function testTreeSearchConvergesOnHighestRewardBranch(): void
+    {
+        $legalActions = function (array $state): array {
+            if (($state['depth'] ?? 0) >= 2) {
+                return [];
+            }
+
+            if (($state['path'] ?? '') === '') {
+                return ['slow_safe', 'fast_risky'];
+            }
+
+            return ['finish'];
+        };
+
+        $transition = function (array $state, string $action): array {
+            $path = trim(($state['path'] ?? '') . '/' . $action, '/');
+
+            return [
+                'depth' => ($state['depth'] ?? 0) + 1,
+                'path' => $path,
+            ];
+        };
+
+        $isTerminal = function (array $state): bool {
+            return ($state['depth'] ?? 0) >= 2;
+        };
+
+        $reward = function (array $state): float {
+            return match ($state['path'] ?? '') {
+                'slow_safe/finish' => 9.0,
+                'fast_risky/finish' => 3.0,
+                default => 0.0,
+            };
+        };
+
+        $search = new TreeSearch(80, 1.2, 3, 99);
+        $result = $search->search(['depth' => 0, 'path' => ''], $legalActions, $transition, $isTerminal, $reward);
+
+        $this->assertSame('slow_safe', $result->getBestAction());
+
+        $root = $result->getRoot();
+        $this->assertGreaterThan(0, $root->getVisits());
+        $this->assertCount(2, $root->getChildren());
+    }
+
+    public function testTreeSearchBackpropagatesRewardThroughVisitedNodes(): void
+    {
+        $search = new TreeSearch(12, 0.5, 0, 7);
+
+        $result = $search->search(
+            ['terminal' => false],
+            function (array $state): array {
+                return ($state['terminal'] ?? false) ? [] : ['resolve'];
+            },
+            function (): array {
+                return ['terminal' => true, 'reward' => 4];
+            },
+            function (array $state): bool {
+                return $state['terminal'] ?? false;
+            },
+            function (array $state): float {
+                return (float)($state['reward'] ?? 0);
+            }
+        );
+
+        $root = $result->getRoot();
+        $child = $root->getChildren()[0];
+
+        $this->assertSame(12, $root->getVisits());
+        $this->assertSame(12, $child->getVisits());
+        $this->assertSame(4.0, $child->getMeanReward());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,16 @@
 <?php
 
+$autoloadCandidates = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(__DIR__, 3) . '/vendor/autoload.php',
+];
+
+foreach ($autoloadCandidates as $candidate) {
+    if (is_file($candidate)) {
+        require $candidate;
+        break;
+    }
+}
 spl_autoload_register(function (string $class): void {
     $prefix = 'BlueFission\\';
     if (strpos($class, $prefix) !== 0) {
@@ -14,15 +25,3 @@ spl_autoload_register(function (string $class): void {
         require_once $candidate;
     }
 }, true, true);
-
-$autoloadCandidates = [
-    dirname(__DIR__) . '/vendor/autoload.php',
-    dirname(__DIR__, 3) . '/vendor/autoload.php',
-];
-
-foreach ($autoloadCandidates as $candidate) {
-    if (is_file($candidate)) {
-        require $candidate;
-        break;
-    }
-}


### PR DESCRIPTION
Intent summary

- Add a dedicated Monte Carlo subsystem for budgeted stochastic action evaluation and Monte Carlo tree search.
- Keep the PR scoped to Monte Carlo only by transplanting the implementation onto current `master` without the unrelated media/LLM branch history.

User stories / acceptance criteria

- As an Automata integrator, I can evaluate candidate actions with repeated stochastic rollouts under a fixed iteration budget.
- As an Automata integrator, I can seed Monte Carlo evaluation for deterministic and reproducible tests.
- As an Automata integrator, I can inspect per-action statistics including visits, total reward, mean reward, and best observed reward.
- As an Automata integrator, I can run Monte Carlo tree search over user-defined legal actions, transitions, terminal checks, and reward functions.
- As a library user, I can run examples that demonstrate both budgeted action ranking and MCTS sequential planning.

Issues addressed

- Closes #7
- Closes #8

Key files changed

- `src/Automata/MonteCarlo/ActionStatistics.php`
- `src/Automata/MonteCarlo/RandomSource.php`
- `src/Automata/MonteCarlo/Search.php`
- `src/Automata/MonteCarlo/SearchResult.php`
- `src/Automata/MonteCarlo/TreeSearch.php`
- `src/Automata/MonteCarlo/TreeSearchNode.php`
- `src/Automata/MonteCarlo/TreeSearchResult.php`
- `tests/Automata/MonteCarlo/SearchTest.php`
- `tests/Automata/MonteCarlo/TreeSearchTest.php`
- `examples/monte_carlo_route_planning.php`
- `examples/monte_carlo_tree_search_dispatch.php`
- `README.md`
- `SPEC.md`
- `ARCHITECTURE.md`
- `examples/README.md`
- `tests/bootstrap.php`
- `phpunit.xml`

How to test

- `./vendor/bin/phpunit --configuration .worktrees/feature-7-monte-carlo-search-and-mcts-clean/phpunit.xml .worktrees/feature-7-monte-carlo-search-and-mcts-clean/tests/Automata/MonteCarlo`
- `php .worktrees/feature-7-monte-carlo-search-and-mcts-clean/examples/monte_carlo_route_planning.php`
- `php .worktrees/feature-7-monte-carlo-search-and-mcts-clean/examples/monte_carlo_tree_search_dispatch.php`

QA checklist

- [x] Monte Carlo PHPUnit suite passes
- [x] Monte Carlo route planning example runs
- [x] Monte Carlo tree search example runs
- [x] PR diff is scoped to Monte Carlo work on top of current `master`

Approval conditions

- Human review that the MCTS callback surface is the right abstraction boundary for downstream planners
- Human review that the Monte Carlo docs/examples are sufficient for issue `#7` and `#8`
- Human review of whether duplicate open issues `#6` and `#9` should be closed separately as duplicates
