### PR TITLE
Add VIBE profile generation and media pipelines

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,12 +102,14 @@ standalone, but integrate through shared `Context`, behaviors, and event hooks.
 **Key modules:**
 
 - `Automata\Sensory` (Input and related classes)
+- `Automata\Media` (ingestion + processing pipelines)
 - Core data structures: `Deq`, `Dict`, `List`, `Pile`, `Pri`, `Vec`
 - `Automata\Collections` (e.g., `OrganizedCollection`)
 
 Responsibilities:
 
 - Ingest raw signals and normalize them for strategies.
+- Normalize file and stream inputs into MediaItems and pipeline results.
 - Provide efficient, AI‑focused data containers for large and/or streaming
   workloads.
 - Maintain ordering, priority, and weighting semantics where needed.
@@ -232,11 +234,12 @@ problems, similar to HTTP controllers for web routes.
 ### 3.5 Intelligence Hub: Multi-Modal Insight Pipeline
 
 1. A host app submits a complex input (PDF, URL, video, or mixed media bundle).
-2. The hub segments the input into slices (text, image, audio, video) and
+2. Media ingestion pipelines normalize file/stream inputs into typed items.
+3. The hub segments the input into slices (text, image, audio, video) and
    attaches metadata like source, format, and provenance.
-3. `Sensory\Sense` evaluates attention and novelty to determine depth/budget.
-4. A ranked list of strategies is applied per segment; outputs are scored.
-5. Insights are aggregated into a gestalt summary for downstream systems,
+4. `Sensory\Sense` evaluates attention and novelty to determine depth/budget.
+5. A ranked list of strategies is applied per segment; outputs are scored.
+6. Insights are aggregated into a gestalt summary for downstream systems,
    including LLM-driven orchestration.
 
 ### 3.6 Classification Gateway + Feedback Loop

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Genetic Algorithms**: Implement evolutionary algorithms that mimic natural selection for solving optimization problems.
 - **Path & Graphs**: Manage, analyze, and manipulate structures represented graphically including networks of nodes and edges.
 - **Anomaly Detection**: Score behavioral activity, fingerprints, and context to flag unusual or risky patterns.
+- **Media Ingestion**: Normalize text, image, audio, video, document, and URL inputs into consistent pipelines.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
 - **Feature Engineering**: Provides robust tools for transforming raw data into features that better represent the underlying processes to predictive models.

--- a/SPEC.md
+++ b/SPEC.md
@@ -330,6 +330,19 @@ The Feedback system provides:
 Feedback objects should be serializable, context-aware, and consumable by
 both runtime systems and training pipelines.
 
+### 3.17 Media Ingestion and Processing
+
+The Media module provides ingestion and processing utilities for:
+
+- Text, image, audio, video, document, and URL inputs.
+- File paths, stream handles, and raw content.
+- Normalization, entity extraction, heuristics, and feature engineering.
+- Pipelines that feed structured segments into `Intelligence`/`Engine`.
+
+Media is designed to stay lightweight and dependency-free by default.
+Advanced capabilities (OCR, ASR, frame extraction) are injected via hooks or
+external adapters rather than hard dependencies.
+
 ## 4. Typical Usage Patterns
 
 Automata is intended to support workflows like:
@@ -439,7 +452,12 @@ Short‑term priorities:
    - Add example scripts for fraud-style flows (device/location fingerprints,
      behavior deltas) and baseline tests for detectors.
 
-13. **Demos**
+13. **Media ingestion and processing**
+   - Add ingestion gateways and media pipelines for text, image, audio, video.
+   - Document pipeline extension points for OCR/ASR/frame analysis.
+   - Provide examples wired into Intelligence for multi-modal inputs.
+
+14. **Demos**
    - Disaster response classification demo (mock dataset first, real dataset
      later) that exercises classification + feedback.
    - An agent demo that runs without LLM keys and can optionally use LLM

--- a/docs/Media.md
+++ b/docs/Media.md
@@ -1,0 +1,224 @@
+# Media Utilities Specification
+
+## Purpose
+Provide a lightweight, consistent media ingestion and processing toolkit for Automata that can:
+- Accept text, images, audio, video, documents, and URLs as file paths, stream handles, or raw strings/bytes.
+- Normalize, parse, and extract features/entities without adding new required dependencies.
+- Feed outputs into Intelligence/Engine, Sensory Input, and Context with a predictable, structured payload.
+- Allow advanced capabilities (OCR, speech recognition, frame extraction) via optional callables or external engines.
+
+## Core Concepts
+
+### MediaItem
+A normalized representation of an input asset with:
+- type (InputType::TEXT, IMAGE, AUDIO, VIDEO, DOCUMENT, URL)
+- content (string/bytes if loaded)
+- path (if file-based)
+- stream (resource or Stream wrapper)
+- meta (mime, size, dimensions, duration, encoding, etc)
+- context (Context instance for tags, normalization info)
+- features (optional computed features)
+
+### Stream
+A lightweight wrapper for stream resources to provide:
+- read(), rewind(), meta(), and length() accessors
+- a consistent interface for file handles, resources, or SplFileObject
+
+### Ingestion
+Raw intake, opening, and normalization of input.
+- IIngestor interface with supports(...) and ingest(...)
+- Ingestion Gateway to register and select ingestors by type or profile
+- Default ingestors: Text, Image, Audio, Video, Document, URL
+
+### Processing
+Pipelines that use analysis, normalization, and learning utilities.
+- Pipeline class with ordered processors
+- IProcessor interface and optional ITrainable interface
+- Processing Gateway to select pipelines by type
+- Result object containing tokens, entities, features, segments, and meta
+
+### Result
+Structured processing output with:
+- tokens, entities, features, and metrics
+- segments array compatible with Intelligence::analyze
+- helpers to convert to engine-ready segments and context metadata
+
+## Ingestion Responsibilities
+
+### Input types
+- Text: raw string or text file
+- Image/Audio/Video/Document: file path, bytes, or stream
+- URL: raw URL (no fetch by default)
+
+### Metadata extraction
+- MIME type via finfo
+- File size via filesize
+- Image dimensions via getimagesize (if available)
+- Stream meta via stream_get_meta_data
+
+### Options
+- load_content (bool): read bytes into content; default true for text, false for large binaries
+- max_bytes (int): cap on content read
+- force_type (string): override InputTypeDetector
+- context (Context|array): inject base context
+
+## Processing Pipelines
+
+### Text Pipeline
+Processors:
+- Normalizer: strip tags, lower-case, normalize quotes, optional contraction normalization
+- Tokenizer: Language\Preparer tokenize
+- Entity extraction: Language\EntityExtractor (email, url, dates, etc)
+- Bag of words: token counts
+- Heuristics: length, sentence count, token count
+
+Outputs:
+- normalized_text, tokens, bag_of_words, entities, heuristics
+- segments with payload set to normalized text + meta
+
+### Image Pipeline
+Processors:
+- Metadata: width, height, aspect ratio
+- OCR (hook/callable)
+- Boundary detection (hook/callable)
+- Convolution features (hook/callable)
+
+Outputs:
+- entities (optional), boundaries (optional), feature vectors
+
+### Audio Pipeline
+Processors:
+- Metadata (mime, size)
+- Volume normalization (hook/callable)
+- Speech-to-text (hook/callable)
+- Event classification: speech/music/sfx (hook/callable)
+
+Outputs:
+- transcript, events, speaker signatures (optional), normalized levels
+
+### Video Pipeline
+Processors:
+- Frame extraction (hook/callable)
+- Frame entities (hook/callable)
+- Timeline convergence (hook/callable)
+
+Outputs:
+- frames, timeline entities, aggregated features
+
+## Handler Adapters (Optional CLI)
+
+Media processors accept callables via the `options` array. The library includes
+lightweight CLI handler adapters that only run if the external binaries are
+installed:
+
+- `Image\TesseractOcrHandler` (requires `tesseract`)
+- `Audio\WhisperCliHandler` (requires `whisper` CLI)
+- `Video\FfmpegFrameExtractor` (requires `ffmpeg`)
+- `Image\SimpleClientsOcrHandler` (uses SimpleClients Vision\OcrClient if available)
+- `Audio\SimpleClientsTranscriptionHandler` (uses SimpleClients Speech\TranscriptionClient if available)
+- `Video\SimpleClientsVideoAnalysisHandler` (uses SimpleClients Video\AnalysisClient if available)
+
+Example wiring:
+
+```php
+use BlueFission\Automata\Media\Processing\Image\TesseractOcrHandler;
+use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
+use BlueFission\Automata\Media\Processing\Audio\WhisperCliHandler;
+use BlueFission\Automata\Media\Processing\Video\FfmpegFrameExtractor;
+
+$ocr = new TesseractOcrHandler();
+$frames = new FfmpegFrameExtractor();
+
+$imageResult = $imagePipeline->process($imageItem, null, [
+    'ocr' => $ocr,
+]);
+
+$videoResult = $videoPipeline->process($videoItem, null, [
+    'frame_extractor' => $frames,
+    'fps' => 2,
+]);
+
+$audioResult = $audioPipeline->process($audioItem, null, [
+    'speech_to_text' => new Audio\\WhisperCliHandler(),
+]);
+
+$imageResult = $imagePipeline->process($imageItem, null, [
+    'ocr' => new Image\\SimpleClientsOcrHandler(),
+]);
+```
+
+Handler signatures are:
+
+```
+function(MediaItem $item, Context $context, array $options = []): mixed
+```
+
+Handlers should return:
+
+- OCR: string or null
+- Frame extractor: array of frame descriptors
+- Audio transcriber: string or null
+- Boundary/convolution: array of numeric features
+
+### Handler Registry
+
+You can register handlers once and let processors resolve them by capability:
+
+```php
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\Image\TesseractOcrHandler;
+
+$registry = new HandlerRegistry();
+$registry->register('ocr', new TesseractOcrHandler(), 'tesseract', 10);
+
+$imageResult = $imagePipeline->process($imageItem, null, [
+    'handler_registry' => $registry,
+]);
+```
+
+Pipelines and gateways can also store a default registry:
+
+```php
+$pipeline->setRegistry($registry);
+$processingGateway->setRegistry($registry);
+```
+
+Capabilities used by default processors:
+- `ocr`
+- `boundary_detector`
+- `convolution`
+- `volume_normalizer`
+- `speech_to_text`
+- `audio_event_detector`
+- `frame_extractor`
+- `timeline_analyzer`
+
+## Integration Notes
+
+### Intelligence and Engine
+- Result::segments() produces input compatible with Intelligence::analyze
+- Use type-specific pipelines to enrich Context and meta, then pass to Engine/Intelligence
+
+### Sensory Input
+- MediaItem->context() can be passed through Sensory Input processors
+- Pipelines can emit Context tags (type, confidence, normalization info)
+
+## Extensibility
+- Register custom ingestors/pipelines via Gateways
+- Use DevElation hooks to inject external OCR/ASR/video tools
+- Optional adapters for PHP-ML or external engines (future roadmap)
+
+## Proposed Refactors / Additions
+- InputTypeDetector: support stream resources or accept a custom detector callable
+- Sensory Input: accept MediaItem payloads directly
+- Additional Normalization utilities for text and media-specific scaling
+- Optional wrappers for external OCR/ASR tools (no required deps)
+
+## Example Flow
+1) Ingestion Gateway selects a TextIngestor for a file path.
+2) TextPipeline normalizes, tokenizes, extracts entities, and builds features.
+3) Result segments are passed to Intelligence::analyze.
+
+## Roadmap Notes
+- Pluggable adapters for OCR/ASR/video engines.
+- Optional ML backend abstraction (Rubix/Python) as a broader ML decoupling effort.

--- a/docs/VIBE_PROFILES.md
+++ b/docs/VIBE_PROFILES.md
@@ -31,3 +31,36 @@ The example prints JSON showing:
 
 - file-backed profile output and prompt
 - named override output and prompt
+
+Long-form generation attributes can also compose stable thread/session identifiers directly from scoped vars.
+
+Example:
+
+```txt
+{=content
+  profile="editorial"
+  label="Chapter [[chapter|pad:2]] / [[section.title]]"
+  thread="book:[[book.slug|slug]]:chapter:[[chapter|pad:2]]:section:[[section.slug|slug]]"
+  session="draft:[[book.slug|slug]]:[[chapter|pad:2]]"
+  context_strategy="windowed-prefix"
+  max_context_tokens="1200"
+}
+```
+
+Supported interpolation shape:
+
+- `[[path.to.value]]`
+- `[[path.to.value|slug]]`
+- `[[chapter|pad:2]]`
+- `[[section.slug|default:untitled|slug]]`
+
+`[[...]]` is the preferred form for generation attributes because it does not collide with the surrounding template tag braces.
+
+Supported filters:
+
+- `slug`
+- `lower`
+- `upper`
+- `trim`
+- `pad:length[:character[:left|right]]`
+- `default:value`

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,8 @@ Notable examples:
 - `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an activity.
 - `examples/anomaly_logistics_requests.php` – KNN-based anomaly scoring over logistics requests.
 - `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
+- `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
+- `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
 
 Additional examples will be added as modules are fleshed out and tested.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,11 @@ To run an example:
 php examples/collections_basic.php
 ```
 
+Media pipeline examples:
+
+- `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
+- `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
+
 Notable examples:
 
 - `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an activity.
@@ -31,8 +36,6 @@ Notable examples:
 - `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
 - `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
 - `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
-- `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
-- `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
 - `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action ranking over uncertain route outcomes.
 - `examples/monte_carlo_tree_search_dispatch.php` – MCTS planning over a small sequential dispatch decision tree.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,9 +23,20 @@ Notable examples:
 
 - `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an activity.
 - `examples/anomaly_logistics_requests.php` – KNN-based anomaly scoring over logistics requests.
-- `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
+- `examples/graph_routing_logistics.php` – route planning with `Func` fitness plus state-aware assessment.
+- `examples/graph_route_allocation_logistics.php` – route allocation where the fitness hook can see asset and demand context.
+- `examples/decision_tree_dispatch_policy.php` – decision trees with shared method state and injected assessors.
+- `examples/carrier_backed_simulation.php` – simulation over object-backed state via the carrier adapter seam.
+- `examples/entity_condition_worldview.php` – worldview-oriented `Entity` and `Condition` snapshot/explain contracts.
+- `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
+- `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
 - `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
 - `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
+- `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action ranking over uncertain route outcomes.
+- `examples/monte_carlo_tree_search_dispatch.php` – MCTS planning over a small sequential dispatch decision tree.
 
 Additional examples will be added as modules are fleshed out and tested.
+
+Many branch-local examples load `examples/bootstrap.php` so they execute against
+the worktree source rather than another checkout.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ Notable examples:
 - `examples/entity_condition_worldview.php` – worldview-oriented `Entity` and `Condition` snapshot/explain contracts.
 - `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
 - `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
+- `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
 - `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
 - `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
 - `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action ranking over uncertain route outcomes.

--- a/examples/media_pipeline_engine.php
+++ b/examples/media_pipeline_engine.php
@@ -1,0 +1,63 @@
+<?php
+
+use BlueFission\Automata\Engine;
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\Ingestion\Gateway as IngestionGateway;
+use BlueFission\Automata\Media\Ingestion\TextIngestor;
+use BlueFission\Automata\Media\Processing\Gateway as ProcessingGateway;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
+use BlueFission\Automata\Media\Processing\Text\TextPipeline;
+use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$input = $argv[1] ?? 'Flooded roadway near bridge; volunteers needed.';
+
+$ingestion = new IngestionGateway();
+$ingestion->registerIngestor(new TextIngestor(), 'text', ['types' => [InputType::TEXT]]);
+
+$processing = new ProcessingGateway();
+$processing->registerPipeline(new TextPipeline(), 'text', ['types' => [InputType::TEXT]]);
+
+$registry = new HandlerRegistry();
+$registry->register('ocr', new SimpleClientsOcrHandler(), 'simpleclients-ocr', 5);
+
+$item = $ingestion->ingest($input);
+$result = $processing->process($item, [
+    'handler_registry' => $registry,
+]);
+
+$strategy = new NaiveBayesTextClassification();
+$samples = [
+    'Flooded roadway near bridge',
+    'Volunteers needed for medical aid',
+    'Road cleared after storm',
+    'Missing persons reported',
+];
+$labels = [
+    'infrastructure',
+    'people',
+    'infrastructure',
+    'people',
+];
+
+$strategy->train($samples, $labels, 0.25);
+
+$engine = new Engine();
+$engine->registerStrategyProfile($strategy, 'naive-bayes-text', [
+    'types' => [InputType::TEXT],
+    'tags' => ['media', 'text'],
+]);
+
+$normalized = $result->meta()['normalized_text'] ?? $input;
+
+$report = $engine->analyzeWithAttention($normalized, [
+    'segmenter' => function () use ($result) {
+        return $result->segments();
+    },
+]);
+
+echo "Attention score: " . ($report['attention']['score'] ?? 0) . PHP_EOL;
+echo "Top strategies: " . implode(', ', $report['gestalt']['top_strategies'] ?? []) . PHP_EOL;
+echo "Segments: " . count($report['segments'] ?? []) . PHP_EOL;

--- a/examples/media_pipeline_intelligence.php
+++ b/examples/media_pipeline_intelligence.php
@@ -1,0 +1,58 @@
+<?php
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Intelligence;
+use BlueFission\Automata\Media\Ingestion\Gateway as IngestionGateway;
+use BlueFission\Automata\Media\Ingestion\TextIngestor;
+use BlueFission\Automata\Media\Processing\Gateway as ProcessingGateway;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
+use BlueFission\Automata\Media\Processing\Text\TextPipeline;
+use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$input = $argv[1] ?? 'Bridge collapse near river. Volunteers needed.';
+
+$ingestion = new IngestionGateway();
+$ingestion->registerIngestor(new TextIngestor(), 'text', ['types' => [InputType::TEXT]]);
+
+$processing = new ProcessingGateway();
+$processing->registerPipeline(new TextPipeline(), 'text', ['types' => [InputType::TEXT]]);
+
+$registry = new HandlerRegistry();
+$registry->register('ocr', new SimpleClientsOcrHandler(), 'simpleclients-ocr', 5);
+
+$item = $ingestion->ingest($input);
+$result = $processing->process($item, [
+    'handler_registry' => $registry,
+]);
+
+$strategy = new NaiveBayesTextClassification();
+$samples = [
+    'Bridge collapse near river',
+    'Volunteers needed for medical aid',
+    'Road cleared after storm',
+    'Missing persons reported',
+];
+$labels = [
+    'infrastructure',
+    'people',
+    'infrastructure',
+    'people',
+];
+
+$strategy->train($samples, $labels, 0.25);
+
+$intelligence = new Intelligence();
+$intelligence->registerStrategyProfile($strategy, 'naive-bayes-text', [
+    'types' => [InputType::TEXT],
+    'tags' => ['media', 'text'],
+]);
+
+$analysis = $intelligence->analyze($result->segments());
+
+echo "Normalized text: " . ($result->meta()['normalized_text'] ?? '') . PHP_EOL;
+echo "Tokens: " . implode(', ', $result->tokens()) . PHP_EOL;
+echo "Bag of words: " . json_encode($result->features()['bag_of_words'] ?? []) . PHP_EOL;
+echo "Gestalt summary: " . json_encode($analysis['gestalt']) . PHP_EOL;

--- a/src/Automata/LLM/FillIn.php
+++ b/src/Automata/LLM/FillIn.php
@@ -24,6 +24,7 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Data\FileSystem;
 use BlueFission\Obj;
 use BlueFission\Arr;
+use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
 use RuntimeException;
@@ -269,7 +270,7 @@ class FillIn implements IDispatcher
         if ($this->isAbsolutePath($profile)) {
             $candidates[] = $profile;
         } else {
-            $searchPaths = array_merge($this->profilePaths, $this->includePaths);
+            $searchPaths = Arr::merge($this->profilePaths, $this->includePaths);
             foreach ($searchPaths as $base) {
                 $base = rtrim((string)$base, '\\/');
                 if ($base === '') {
@@ -320,6 +321,6 @@ class FillIn implements IDispatcher
         }
 
         preg_match_all('/\S+/u', $text, $matches);
-        return max(count($matches[0] ?? []), (int)ceil(Str::len($text) / 4));
+        return (int)Num::max(Arr::size($matches[0] ?? []), (int)ceil(Str::len($text) / 4));
     }
 }

--- a/src/Automata/Media/Ingestion/AbstractIngestor.php
+++ b/src/Automata/Media/Ingestion/AbstractIngestor.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\InputTypeDetector;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Stream;
+use BlueFission\Str;
+
+abstract class AbstractIngestor implements IIngestor
+{
+    protected function resolveContext(array $options): Context
+    {
+        $context = $options['context'] ?? null;
+
+        if ($context instanceof Context) {
+            return $context;
+        }
+
+        $contextObj = new Context();
+        if (is_array($context)) {
+            foreach ($context as $key => $value) {
+                $contextObj->set($key, $value);
+            }
+        }
+
+        return $contextObj;
+    }
+
+    protected function resolveStream($input): ?Stream
+    {
+        if ($input instanceof Stream) {
+            return $input;
+        }
+
+        if (is_resource($input)) {
+            return new Stream($input);
+        }
+
+        if ($input instanceof \SplFileObject) {
+            $path = $input->getRealPath();
+            if ($path) {
+                return $this->streamFromPath($path);
+            }
+        }
+
+        return null;
+    }
+
+    protected function streamFromPath(string $path): ?Stream
+    {
+        $resource = @fopen($path, 'rb');
+        if ($resource === false) {
+            return null;
+        }
+
+        return new Stream($resource);
+    }
+
+    protected function detectMimeType($input): ?string
+    {
+        if ($input instanceof Stream && is_resource($input->resource())) {
+            $meta = $input->meta();
+            if (isset($meta['uri']) && is_string($meta['uri']) && is_file($meta['uri'])) {
+                return $this->mimeFromPath($meta['uri']);
+            }
+        }
+
+        if (Str::is($input) && is_file($input)) {
+            return $this->mimeFromPath($input);
+        }
+
+        if (Str::is($input)) {
+            return $this->mimeFromBuffer($input);
+        }
+
+        return null;
+    }
+
+    protected function mimeFromPath(string $path): ?string
+    {
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $finfo->file($path);
+        return $mimeType ?: null;
+    }
+
+    protected function mimeFromBuffer(string $buffer): ?string
+    {
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $finfo->buffer($buffer);
+        return $mimeType ?: null;
+    }
+
+    protected function readContent($input, array $options = []): string
+    {
+        $maxBytes = isset($options['max_bytes']) ? (int)$options['max_bytes'] : null;
+
+        if ($input instanceof Stream) {
+            $input->rewind();
+            return $input->read($maxBytes);
+        }
+
+        if (is_resource($input)) {
+            $stream = new Stream($input);
+            $stream->rewind();
+            return $stream->read($maxBytes);
+        }
+
+        if (Str::is($input) && is_file($input)) {
+            if ($maxBytes !== null && $maxBytes > 0) {
+                $handle = @fopen($input, 'rb');
+                if ($handle) {
+                    $data = fread($handle, $maxBytes);
+                    fclose($handle);
+                    return $data === false ? '' : $data;
+                }
+            }
+
+            $data = @file_get_contents($input);
+            return $data === false ? '' : $data;
+        }
+
+        if (Str::is($input)) {
+            if ($maxBytes !== null && $maxBytes > 0) {
+                return substr($input, 0, $maxBytes);
+            }
+            return $input;
+        }
+
+        return '';
+    }
+
+    protected function baseMeta($input, ?string $mimeType = null): array
+    {
+        $meta = [];
+
+        if ($mimeType) {
+            $meta['mime'] = $mimeType;
+        }
+
+        if (Str::is($input) && is_file($input)) {
+            $meta['path'] = $input;
+            $size = @filesize($input);
+            if ($size !== false) {
+                $meta['size'] = (int)$size;
+            }
+        }
+
+        if ($input instanceof Stream) {
+            $meta['stream'] = $input->meta();
+            $length = $input->length();
+            if ($length !== null) {
+                $meta['size'] = $length;
+            }
+        }
+
+        return $meta;
+    }
+
+    protected function buildItem(string $type, $content, array $meta, array $options = []): MediaItem
+    {
+        $context = $this->resolveContext($options);
+        $item = new MediaItem($type, $content, $meta, $context);
+
+        if (isset($meta['path']) && is_string($meta['path'])) {
+            $item->path($meta['path']);
+        }
+
+        if (isset($options['stream']) && $options['stream'] instanceof Stream) {
+            $item->stream($options['stream']);
+        }
+
+        return $item;
+    }
+
+    protected function resolveType($input, array $options = []): ?string
+    {
+        if (isset($options['force_type']) && is_string($options['force_type'])) {
+            return $options['force_type'];
+        }
+
+        return InputTypeDetector::detect($input);
+    }
+}

--- a/src/Automata/Media/Ingestion/AudioIngestor.php
+++ b/src/Automata/Media/Ingestion/AudioIngestor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+
+class AudioIngestor extends BinaryIngestor
+{
+    protected string $type = InputType::AUDIO;
+    protected string $mimePrefix = 'audio/';
+}

--- a/src/Automata/Media/Ingestion/BinaryIngestor.php
+++ b/src/Automata/Media/Ingestion/BinaryIngestor.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\DevElation as Dev;
+use BlueFission\Str;
+
+abstract class BinaryIngestor extends AbstractIngestor
+{
+    protected string $type;
+    protected string $mimePrefix;
+
+    public function supports($input, array $options = []): bool
+    {
+        $type = $this->resolveType($input, $options);
+        if ($type === $this->type) {
+            return true;
+        }
+
+        $mime = $this->detectMimeType($input);
+        if ($mime && Str::pos($mime, $this->mimePrefix) === 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        $mime = $this->detectMimeType($input);
+        $meta = $this->baseMeta($input, $mime);
+
+        $content = null;
+        if ($this->shouldLoadContent($options)) {
+            $content = $this->readContent($input, $options);
+        }
+
+        $meta = Dev::apply('media.ingestion.binary.meta', $meta);
+
+        return $this->buildItem($this->type, $content, $meta, $options);
+    }
+
+    protected function shouldLoadContent(array $options): bool
+    {
+        if (array_key_exists('load_content', $options)) {
+            return (bool)$options['load_content'];
+        }
+
+        return false;
+    }
+}

--- a/src/Automata/Media/Ingestion/DocumentIngestor.php
+++ b/src/Automata/Media/Ingestion/DocumentIngestor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+
+class DocumentIngestor extends BinaryIngestor
+{
+    protected string $type = InputType::DOCUMENT;
+    protected string $mimePrefix = 'application/';
+
+    public function supports($input, array $options = []): bool
+    {
+        $type = $this->resolveType($input, $options);
+        if ($type === InputType::DOCUMENT) {
+            return true;
+        }
+
+        $mime = $this->detectMimeType($input);
+        return $mime === 'application/pdf';
+    }
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        return parent::ingest($input, $options);
+    }
+}

--- a/src/Automata/Media/Ingestion/Gateway.php
+++ b/src/Automata/Media/Ingestion/Gateway.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Ingestion;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Collections\OrganizedCollection;
 use BlueFission\Automata\InputTypeDetector;
 use BlueFission\Automata\Media\MediaItem;
@@ -26,7 +27,7 @@ class Gateway
             'weight' => null,
         ];
 
-        $profile = array_merge($defaults, $profile);
+        $profile = Arr::merge($defaults, $profile);
 
         $this->_ingestors->add($ingestor, $name);
         $this->_profiles[$name] = $profile;
@@ -53,7 +54,7 @@ class Gateway
             $profile = $this->_profiles[$name] ?? [];
             $types = $profile['types'] ?? [];
 
-            if (!empty($types) && $typeHint && !in_array($typeHint, $types, true)) {
+            if (Arr::size($types) > 0 && $typeHint && !Arr::hasValue($types, $typeHint, true)) {
                 continue;
             }
 

--- a/src/Automata/Media/Ingestion/Gateway.php
+++ b/src/Automata/Media/Ingestion/Gateway.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\Collections\OrganizedCollection;
+use BlueFission\Automata\InputTypeDetector;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Ingestion\TextIngestor;
+use BlueFission\DevElation as Dev;
+
+class Gateway
+{
+    protected OrganizedCollection $_ingestors;
+    protected array $_profiles;
+
+    public function __construct()
+    {
+        $this->_ingestors = new OrganizedCollection();
+        $this->_profiles = [];
+    }
+
+    public function registerIngestor(IIngestor $ingestor, string $name, array $profile = []): void
+    {
+        $defaults = [
+            'types' => [],
+            'weight' => null,
+        ];
+
+        $profile = array_merge($defaults, $profile);
+
+        $this->_ingestors->add($ingestor, $name);
+        $this->_profiles[$name] = $profile;
+
+        if ($profile['weight'] !== null) {
+            $this->_ingestors->weight($name, (float)$profile['weight']);
+            $this->_ingestors->sort();
+        }
+
+        Dev::do('media.ingestion.gateway.registered', ['name' => $name, 'profile' => $profile]);
+    }
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        $input = Dev::apply('media.ingestion.gateway.input', $input);
+        $typeHint = $options['type'] ?? InputTypeDetector::detect($input);
+
+        foreach ($this->_ingestors->contents() as $name => $entry) {
+            $ingestor = $entry['value'] ?? null;
+            if (!$ingestor instanceof IIngestor) {
+                continue;
+            }
+
+            $profile = $this->_profiles[$name] ?? [];
+            $types = $profile['types'] ?? [];
+
+            if (!empty($types) && $typeHint && !in_array($typeHint, $types, true)) {
+                continue;
+            }
+
+            if ($ingestor->supports($input, $options)) {
+                $item = $ingestor->ingest($input, $options);
+                Dev::do('media.ingestion.gateway.ingested', ['name' => $name, 'type' => $item->type()]);
+                return $item;
+            }
+        }
+
+        Dev::do('media.ingestion.gateway.fallback', ['type' => $typeHint]);
+        $fallback = new TextIngestor();
+        return $fallback->ingest($input, $options);
+    }
+}

--- a/src/Automata/Media/Ingestion/IIngestor.php
+++ b/src/Automata/Media/Ingestion/IIngestor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\Media\MediaItem;
+
+interface IIngestor
+{
+    public function supports($input, array $options = []): bool;
+
+    public function ingest($input, array $options = []): MediaItem;
+}

--- a/src/Automata/Media/Ingestion/ImageIngestor.php
+++ b/src/Automata/Media/Ingestion/ImageIngestor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+
+class ImageIngestor extends BinaryIngestor
+{
+    protected string $type = InputType::IMAGE;
+    protected string $mimePrefix = 'image/';
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        $item = parent::ingest($input, $options);
+        $meta = $item->meta();
+        $content = $item->content();
+
+        $dimensions = $this->resolveDimensions($input, $content, $meta);
+        if ($dimensions !== null) {
+            $meta['width'] = $dimensions['width'];
+            $meta['height'] = $dimensions['height'];
+        }
+
+        $item->meta($meta);
+        return $item;
+    }
+
+    protected function resolveDimensions($input, $content, array $meta): ?array
+    {
+        if (function_exists('getimagesize')) {
+            if (isset($meta['path']) && is_file($meta['path'])) {
+                $data = @getimagesize($meta['path']);
+                if (is_array($data)) {
+                    return ['width' => (int)$data[0], 'height' => (int)$data[1]];
+                }
+            }
+        }
+
+        if (function_exists('getimagesizefromstring') && is_string($content) && $content !== '') {
+            $data = @getimagesizefromstring($content);
+            if (is_array($data)) {
+                return ['width' => (int)$data[0], 'height' => (int)$data[1]];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Automata/Media/Ingestion/TextIngestor.php
+++ b/src/Automata/Media/Ingestion/TextIngestor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\DevElation as Dev;
+use BlueFission\Str;
+
+class TextIngestor extends AbstractIngestor
+{
+    public function supports($input, array $options = []): bool
+    {
+        $type = $this->resolveType($input, $options);
+        if ($type === InputType::TEXT || $type === InputType::DOCUMENT) {
+            return true;
+        }
+
+        if (Str::is($input) && !is_file($input)) {
+            return true;
+        }
+
+        $mime = $this->detectMimeType($input);
+        return $mime ? $this->isTextMime($mime) : false;
+    }
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        $type = InputType::TEXT;
+        $mime = $this->detectMimeType($input);
+        $meta = $this->baseMeta($input, $mime);
+
+        $content = $this->readContent($input, $options);
+        if ($mime) {
+            $meta['mime'] = $mime;
+        }
+
+        if (function_exists('mb_detect_encoding')) {
+            $encoding = mb_detect_encoding($content, mb_detect_order(), true);
+            if ($encoding) {
+                $meta['encoding'] = $encoding;
+            }
+        }
+
+        $content = Dev::apply('media.ingestion.text.content', $content);
+
+        return $this->buildItem($type, $content, $meta, $options);
+    }
+
+    protected function isTextMime(string $mime): bool
+    {
+        if (Str::pos($mime, 'text/') === 0) {
+            return true;
+        }
+
+        return in_array($mime, ['application/json', 'application/xml', 'application/xhtml+xml'], true);
+    }
+}

--- a/src/Automata/Media/Ingestion/UrlIngestor.php
+++ b/src/Automata/Media/Ingestion/UrlIngestor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\DevElation as Dev;
+use BlueFission\Str;
+
+class UrlIngestor extends AbstractIngestor
+{
+    public function supports($input, array $options = []): bool
+    {
+        if (!Str::is($input)) {
+            return false;
+        }
+
+        return (bool)preg_match('#^https?://#i', $input);
+    }
+
+    public function ingest($input, array $options = []): MediaItem
+    {
+        $meta = ['url' => (string)$input];
+        $content = (string)$input;
+        $content = Dev::apply('media.ingestion.url.content', $content);
+
+        return $this->buildItem(InputType::URL, $content, $meta, $options);
+    }
+}

--- a/src/Automata/Media/Ingestion/VideoIngestor.php
+++ b/src/Automata/Media/Ingestion/VideoIngestor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BlueFission\Automata\Media\Ingestion;
+
+use BlueFission\Automata\InputType;
+
+class VideoIngestor extends BinaryIngestor
+{
+    protected string $type = InputType::VIDEO;
+    protected string $mimePrefix = 'video/';
+}

--- a/src/Automata/Media/MediaItem.php
+++ b/src/Automata/Media/MediaItem.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace BlueFission\Automata\Media;
+
+use BlueFission\Automata\Context;
+use BlueFission\Obj;
+
+class MediaItem extends Obj
+{
+    protected ?string $_mediaType = null;
+    protected $content = null;
+    protected ?string $_path = null;
+    protected $stream = null;
+    protected array $_meta = [];
+    protected ?Context $_context = null;
+    protected array $_features = [];
+
+    public function __construct(?string $type = null, $content = null, array $meta = [], ?Context $context = null)
+    {
+        parent::__construct();
+        $this->_mediaType = $type;
+        $this->content = $content;
+        $this->_meta = $meta;
+        $this->_context = $context ?? new Context();
+    }
+
+    public function type(?string $type = null): ?string
+    {
+        if ($type === null) {
+            return $this->_mediaType;
+        }
+
+        $this->_mediaType = $type;
+        return $this->_mediaType;
+    }
+
+    public function content($content = null)
+    {
+        if ($content === null) {
+            return $this->content;
+        }
+
+        $this->content = $content;
+        return $this->content;
+    }
+
+    public function path(?string $path = null): ?string
+    {
+        if ($path === null) {
+            return $this->_path;
+        }
+
+        $this->_path = $path;
+        return $this->_path;
+    }
+
+    public function stream($stream = null)
+    {
+        if ($stream === null) {
+            return $this->stream;
+        }
+
+        $this->stream = $stream;
+        return $this->stream;
+    }
+
+    public function meta($meta = null)
+    {
+        if ($meta === null) {
+            return $this->_meta;
+        }
+
+        if (is_array($meta)) {
+            $this->_meta = $meta;
+        }
+
+        return $this->_meta;
+    }
+
+    public function setMeta(string $key, $value): void
+    {
+        $this->_meta[$key] = $value;
+    }
+
+    public function context(?Context $context = null): Context
+    {
+        if ($context !== null) {
+            $this->_context = $context;
+        }
+
+        return $this->_context ?? new Context();
+    }
+
+    public function addFeature(string $name, $value): void
+    {
+        $this->_features[$name] = $value;
+    }
+
+    public function features(?array $features = null): array
+    {
+        if ($features !== null) {
+            $this->_features = $features;
+        }
+
+        return $this->_features;
+    }
+
+    public function tag(string $tag): void
+    {
+        $this->context()->addTag($tag);
+    }
+
+    public function tags(): array
+    {
+        return $this->context()->tags();
+    }
+}

--- a/src/Automata/Media/Processing/Audio/AudioPipeline.php
+++ b/src/Automata/Media/Processing/Audio/AudioPipeline.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing\Audio;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\Automata\Media\Processing\Pipeline;
@@ -22,7 +23,7 @@ class AudioPipeline extends Pipeline
     {
         $result = parent::process($item, $context, $options);
 
-        if (empty($result->segments())) {
+        if (Arr::size($result->segments()) === 0) {
             $result->addSegment($item->type() ?? 'audio', $item->path() ?? 'audio', [
                 'features' => $result->features(),
             ]);

--- a/src/Automata/Media/Processing/Audio/AudioPipeline.php
+++ b/src/Automata/Media/Processing/Audio/AudioPipeline.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Pipeline;
+use BlueFission\Automata\Media\Processing\Result;
+
+class AudioPipeline extends Pipeline
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addProcessor(new MetadataProcessor());
+        $this->addProcessor(new VolumeNormalizer());
+        $this->addProcessor(new TranscriptionProcessor());
+        $this->addProcessor(new EventProcessor());
+    }
+
+    public function process(MediaItem $item, ?Context $context = null, array $options = []): Result
+    {
+        $result = parent::process($item, $context, $options);
+
+        if (empty($result->segments())) {
+            $result->addSegment($item->type() ?? 'audio', $item->path() ?? 'audio', [
+                'features' => $result->features(),
+            ]);
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Audio/EventProcessor.php
+++ b/src/Automata/Media/Processing/Audio/EventProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class EventProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['audio_event_detector'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('audio_event_detector');
+        }
+
+        if (is_callable($handler)) {
+            $events = call_user_func($handler, $item, $context, $options);
+            $events = Dev::apply('media.processing.audio.events', $events);
+            if (is_array($events)) {
+                $result->addFeature('events', $events);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Audio/MetadataProcessor.php
+++ b/src/Automata/Media/Processing/Audio/MetadataProcessor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class MetadataProcessor implements IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $meta = $item->meta();
+
+        if (isset($meta['mime'])) {
+            $result->setMeta('mime', $meta['mime']);
+        }
+        if (isset($meta['size'])) {
+            $result->setMetric('size_bytes', (int)$meta['size']);
+        }
+
+        Dev::do('media.processing.audio.meta', ['meta' => $meta]);
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Audio/SimpleClientsTranscriptionHandler.php
+++ b/src/Automata/Media/Processing/Audio/SimpleClientsTranscriptionHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Obj;
+
+class SimpleClientsTranscriptionHandler extends Obj
+{
+    protected $client;
+    protected array $_config;
+
+    public function __construct($client = null, array $config = [])
+    {
+        parent::__construct();
+        $this->client = $client;
+        $this->_config = $config;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->client !== null || class_exists('BlueFission\\SimpleClients\\Speech\\TranscriptionClient');
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?string
+    {
+        $client = $this->resolveClient($options);
+        if (!$client) {
+            return null;
+        }
+
+        $input = $this->resolveInput($item);
+        if ($input === null) {
+            return null;
+        }
+
+        $result = null;
+        if (method_exists($client, 'transcribe')) {
+            $result = $client->transcribe($input, $options);
+        }
+
+        $text = $this->extractText($result);
+        return $text !== '' ? $text : null;
+    }
+
+    protected function resolveClient(array $options)
+    {
+        if (isset($options['client'])) {
+            return $options['client'];
+        }
+
+        if ($this->client) {
+            return $this->client;
+        }
+
+        $class = 'BlueFission\\SimpleClients\\Speech\\TranscriptionClient';
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        $config = $options['config'] ?? $this->_config;
+        return new $class($config);
+    }
+
+    protected function resolveInput(MediaItem $item)
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (is_string($content) && $content !== '') {
+            return $content;
+        }
+
+        return null;
+    }
+
+    protected function extractText($result): string
+    {
+        if (is_array($result)) {
+            if (isset($result['text'])) {
+                return (string)$result['text'];
+            }
+            if (isset($result['transcript'])) {
+                return (string)$result['transcript'];
+            }
+            if (isset($result['result']['text'])) {
+                return (string)$result['result']['text'];
+            }
+        }
+
+        if (is_string($result)) {
+            return $result;
+        }
+
+        return '';
+    }
+}

--- a/src/Automata/Media/Processing/Audio/TranscriptionProcessor.php
+++ b/src/Automata/Media/Processing/Audio/TranscriptionProcessor.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class TranscriptionProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['speech_to_text']
+            ?? $options['transcriber']
+            ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('speech_to_text');
+        }
+
+        if (is_callable($handler)) {
+            $text = call_user_func($handler, $item, $context, $options);
+            $text = Dev::apply('media.processing.audio.transcript', $text);
+            if (is_string($text) && $text !== '') {
+                $result->setMeta('transcript', $text);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Audio/VolumeNormalizer.php
+++ b/src/Automata/Media/Processing/Audio/VolumeNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class VolumeNormalizer implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['volume_normalizer'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('volume_normalizer');
+        }
+
+        if (is_callable($handler)) {
+            $level = call_user_func($handler, $item, $context, $options);
+            $level = Dev::apply('media.processing.audio.volume', $level);
+            if ($level !== null) {
+                $result->addFeature('volume_level', $level);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Audio/WhisperCliHandler.php
+++ b/src/Automata/Media/Processing/Audio/WhisperCliHandler.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Audio;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Support\TempFile;
+use BlueFission\DevElation as Dev;
+use BlueFission\Obj;
+use BlueFission\System\CommandLocator;
+
+class WhisperCliHandler extends Obj
+{
+    protected ?string $_binary;
+    protected string $_model;
+    protected string $_language;
+
+    public function __construct(?string $binary = null, string $model = 'base', string $language = 'en')
+    {
+        parent::__construct();
+        $this->_binary = $binary;
+        $this->_model = $model;
+        $this->_language = $language;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->resolveBinary() !== null;
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?string
+    {
+        $binary = $this->resolveBinary($options['binary'] ?? $this->_binary);
+        if (!$binary) {
+            return null;
+        }
+
+        $inputPath = $this->resolveInputPath($item);
+        if (!$inputPath) {
+            return null;
+        }
+
+        $model = $options['model'] ?? $this->_model;
+        $language = $options['language'] ?? $this->_language;
+        $result = $this->runWhisper($binary, $inputPath, $model, $language, $options);
+
+        if ($inputPath !== $item->path()) {
+            TempFile::cleanup($inputPath);
+        }
+
+        return $result;
+    }
+
+    protected function resolveBinary(?string $binary = null): ?string
+    {
+        $binary = $binary ?: 'whisper';
+
+        if (is_file($binary)) {
+            return $binary;
+        }
+
+        return CommandLocator::find($binary);
+    }
+
+    protected function resolveInputPath(MediaItem $item): ?string
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (!is_string($content) || $content === '') {
+            return null;
+        }
+
+        $extension = $this->extensionFromMime($item->meta()['mime'] ?? null) ?? 'wav';
+        return TempFile::createFromContent($content, $extension);
+    }
+
+    protected function extensionFromMime(?string $mime): ?string
+    {
+        if (!$mime) {
+            return null;
+        }
+
+        $map = [
+            'audio/mpeg' => 'mp3',
+            'audio/wav' => 'wav',
+            'audio/x-wav' => 'wav',
+            'audio/ogg' => 'ogg',
+            'audio/flac' => 'flac',
+        ];
+
+        return $map[$mime] ?? null;
+    }
+
+    protected function runWhisper(string $binary, string $inputPath, string $model, string $language, array $options): ?string
+    {
+        $outputDir = $options['output_dir'] ?? $this->createOutputDir();
+        if (!$outputDir) {
+            return null;
+        }
+
+        $command = escapeshellarg($binary)
+            . ' ' . escapeshellarg($inputPath)
+            . ' --model ' . escapeshellarg($model)
+            . ' --language ' . escapeshellarg($language)
+            . ' --output_format txt'
+            . ' --output_dir ' . escapeshellarg($outputDir);
+
+        $output = [];
+        $status = 0;
+        @exec($command . ' 2>&1', $output, $status);
+
+        Dev::do('media.processing.audio.whisper', ['status' => $status, 'input' => $inputPath]);
+
+        if ($status !== 0) {
+            $this->cleanupOutput($outputDir, $options);
+            return null;
+        }
+
+        $text = $this->readOutputText($outputDir);
+        $this->cleanupOutput($outputDir, $options);
+
+        return $text;
+    }
+
+    protected function createOutputDir(): ?string
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'automata_whisper_' . uniqid();
+        if (!@mkdir($path, 0777, true)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    protected function readOutputText(string $outputDir): ?string
+    {
+        $files = glob($outputDir . DIRECTORY_SEPARATOR . '*.txt');
+        if (!$files) {
+            return null;
+        }
+
+        $text = @file_get_contents($files[0]);
+        if ($text === false) {
+            return null;
+        }
+
+        $text = trim($text);
+        return $text !== '' ? $text : null;
+    }
+
+    protected function cleanupOutput(string $outputDir, array $options): void
+    {
+        if (!empty($options['keep_output'])) {
+            return;
+        }
+
+        if (is_dir($outputDir)) {
+            $files = glob($outputDir . DIRECTORY_SEPARATOR . '*');
+            if (is_array($files)) {
+                foreach ($files as $file) {
+                    if (is_file($file)) {
+                        @unlink($file);
+                    }
+                }
+            }
+            @rmdir($outputDir);
+        }
+    }
+}

--- a/src/Automata/Media/Processing/Gateway.php
+++ b/src/Automata/Media/Processing/Gateway.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+use BlueFission\Automata\Collections\OrganizedCollection;
+use BlueFission\Automata\InputTypeDetector;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\DevElation as Dev;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+
+class Gateway
+{
+    protected OrganizedCollection $_pipelines;
+    protected array $_profiles;
+    protected ?HandlerRegistry $_registry = null;
+
+    public function __construct()
+    {
+        $this->_pipelines = new OrganizedCollection();
+        $this->_profiles = [];
+    }
+
+    public function registerPipeline(Pipeline $pipeline, string $name, array $profile = []): void
+    {
+        $defaults = [
+            'types' => [],
+            'weight' => null,
+        ];
+
+        $profile = array_merge($defaults, $profile);
+
+        $this->_pipelines->add($pipeline, $name);
+        $this->_profiles[$name] = $profile;
+
+        if ($profile['weight'] !== null) {
+            $this->_pipelines->weight($name, (float)$profile['weight']);
+            $this->_pipelines->sort();
+        }
+
+        Dev::do('media.processing.gateway.registered', ['name' => $name, 'profile' => $profile]);
+    }
+
+    public function setRegistry(HandlerRegistry $registry): void
+    {
+        $this->_registry = $registry;
+    }
+
+    public function registry(): ?HandlerRegistry
+    {
+        return $this->_registry;
+    }
+
+    public function process(MediaItem $item, array $options = []): Result
+    {
+        $typeHint = $item->type() ?? InputTypeDetector::detect($item->content());
+        if (!isset($options['handler_registry']) && !isset($options['registry']) && $this->_registry) {
+            $options['handler_registry'] = $this->_registry;
+        }
+
+        foreach ($this->_pipelines->contents() as $name => $entry) {
+            $pipeline = $entry['value'] ?? null;
+            if (!$pipeline instanceof Pipeline) {
+                continue;
+            }
+
+            $profile = $this->_profiles[$name] ?? [];
+            $types = $profile['types'] ?? [];
+
+            if (!empty($types) && $typeHint && !in_array($typeHint, $types, true)) {
+                continue;
+            }
+
+            if (method_exists($pipeline, 'setRegistry') && $this->_registry) {
+                $pipeline->setRegistry($this->_registry);
+            }
+
+            $result = $pipeline->process($item, $item->context(), $options);
+            Dev::do('media.processing.gateway.processed', ['name' => $name, 'type' => $typeHint]);
+            return $result;
+        }
+
+        Dev::do('media.processing.gateway.fallback', ['type' => $typeHint]);
+        $fallback = new Pipeline();
+        return $fallback->process($item, $item->context(), $options);
+    }
+}

--- a/src/Automata/Media/Processing/Gateway.php
+++ b/src/Automata/Media/Processing/Gateway.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Collections\OrganizedCollection;
 use BlueFission\Automata\InputTypeDetector;
 use BlueFission\Automata\Media\MediaItem;
@@ -27,7 +28,7 @@ class Gateway
             'weight' => null,
         ];
 
-        $profile = array_merge($defaults, $profile);
+        $profile = Arr::merge($defaults, $profile);
 
         $this->_pipelines->add($pipeline, $name);
         $this->_profiles[$name] = $profile;
@@ -66,7 +67,7 @@ class Gateway
             $profile = $this->_profiles[$name] ?? [];
             $types = $profile['types'] ?? [];
 
-            if (!empty($types) && $typeHint && !in_array($typeHint, $types, true)) {
+            if (Arr::size($types) > 0 && $typeHint && !Arr::hasValue($types, $typeHint, true)) {
                 continue;
             }
 

--- a/src/Automata/Media/Processing/HandlerRegistry.php
+++ b/src/Automata/Media/Processing/HandlerRegistry.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+use BlueFission\Automata\Collections\OrganizedCollection;
+use BlueFission\DevElation as Dev;
+
+class HandlerRegistry
+{
+    protected array $_handlers = [];
+
+    public function register(string $capability, $handler, ?string $name = null, ?float $weight = null): void
+    {
+        $capability = strtolower(trim($capability));
+        if ($capability === '') {
+            return;
+        }
+
+        if (!isset($this->_handlers[$capability])) {
+            $this->_handlers[$capability] = new OrganizedCollection();
+        }
+
+        $collection = $this->_handlers[$capability];
+        $name = $name ?? $this->inferName($handler, $capability);
+
+        $collection->add($handler, $name);
+
+        if ($weight !== null) {
+            $collection->weight($name, (float)$weight);
+            $collection->sort();
+        }
+
+        Dev::do('media.processing.registry.registered', [
+            'capability' => $capability,
+            'name' => $name,
+            'weight' => $weight,
+        ]);
+    }
+
+    public function resolve(string $capability)
+    {
+        $capability = strtolower(trim($capability));
+        $collection = $this->_handlers[$capability] ?? null;
+        if (!$collection instanceof OrganizedCollection) {
+            return null;
+        }
+
+        foreach ($collection->contents() as $entry) {
+            $handler = $entry['value'] ?? null;
+            if ($this->isAvailable($handler)) {
+                return $handler;
+            }
+        }
+
+        return null;
+    }
+
+    public function resolveAll(string $capability): array
+    {
+        $capability = strtolower(trim($capability));
+        $collection = $this->_handlers[$capability] ?? null;
+        if (!$collection instanceof OrganizedCollection) {
+            return [];
+        }
+
+        $handlers = [];
+        foreach ($collection->contents() as $entry) {
+            $handler = $entry['value'] ?? null;
+            if ($this->isAvailable($handler)) {
+                $handlers[] = $handler;
+            }
+        }
+
+        return $handlers;
+    }
+
+    protected function isAvailable($handler): bool
+    {
+        if (is_object($handler) && method_exists($handler, 'isAvailable')) {
+            return (bool)$handler->isAvailable();
+        }
+
+        return is_callable($handler);
+    }
+
+    protected function inferName($handler, string $capability): string
+    {
+        if (is_object($handler)) {
+            return get_class($handler);
+        }
+
+        if (is_string($handler)) {
+            return $handler;
+        }
+
+        return $capability . '_' . uniqid();
+    }
+}

--- a/src/Automata/Media/Processing/HandlerRegistry.php
+++ b/src/Automata/Media/Processing/HandlerRegistry.php
@@ -4,6 +4,7 @@ namespace BlueFission\Automata\Media\Processing;
 
 use BlueFission\Automata\Collections\OrganizedCollection;
 use BlueFission\DevElation as Dev;
+use BlueFission\Str;
 
 class HandlerRegistry
 {
@@ -11,7 +12,7 @@ class HandlerRegistry
 
     public function register(string $capability, $handler, ?string $name = null, ?float $weight = null): void
     {
-        $capability = strtolower(trim($capability));
+        $capability = Str::lower(Str::trim($capability));
         if ($capability === '') {
             return;
         }
@@ -39,7 +40,7 @@ class HandlerRegistry
 
     public function resolve(string $capability)
     {
-        $capability = strtolower(trim($capability));
+        $capability = Str::lower(Str::trim($capability));
         $collection = $this->_handlers[$capability] ?? null;
         if (!$collection instanceof OrganizedCollection) {
             return null;
@@ -57,7 +58,7 @@ class HandlerRegistry
 
     public function resolveAll(string $capability): array
     {
-        $capability = strtolower(trim($capability));
+        $capability = Str::lower(Str::trim($capability));
         $collection = $this->_handlers[$capability] ?? null;
         if (!$collection instanceof OrganizedCollection) {
             return [];

--- a/src/Automata/Media/Processing/IProcessor.php
+++ b/src/Automata/Media/Processing/IProcessor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+
+interface IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result;
+}

--- a/src/Automata/Media/Processing/ITrainable.php
+++ b/src/Automata/Media/Processing/ITrainable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+interface ITrainable
+{
+    public function train(array $samples, array $labels = [], array $options = []): void;
+}

--- a/src/Automata/Media/Processing/Image/BoundaryProcessor.php
+++ b/src/Automata/Media/Processing/Image/BoundaryProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class BoundaryProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['boundary_detector'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('boundary_detector');
+        }
+
+        if (is_callable($handler)) {
+            $boundaries = call_user_func($handler, $item, $context, $options);
+            $boundaries = Dev::apply('media.processing.image.boundaries', $boundaries);
+            if (is_array($boundaries)) {
+                $result->addFeature('boundaries', $boundaries);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Image/ConvolutionProcessor.php
+++ b/src/Automata/Media/Processing/Image/ConvolutionProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class ConvolutionProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['convolution'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('convolution');
+        }
+
+        if (is_callable($handler)) {
+            $features = call_user_func($handler, $item, $context, $options);
+            $features = Dev::apply('media.processing.image.convolution', $features);
+            if (is_array($features)) {
+                $result->addFeature('convolution', $features);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Image/ImagePipeline.php
+++ b/src/Automata/Media/Processing/Image/ImagePipeline.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing\Image;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\Automata\Media\Processing\Pipeline;
@@ -22,7 +23,7 @@ class ImagePipeline extends Pipeline
     {
         $result = parent::process($item, $context, $options);
 
-        if (empty($result->segments())) {
+        if (Arr::size($result->segments()) === 0) {
             $result->addSegment($item->type() ?? 'image', $item->path() ?? 'image', [
                 'features' => $result->features(),
                 'entities' => $result->entities(),

--- a/src/Automata/Media/Processing/Image/ImagePipeline.php
+++ b/src/Automata/Media/Processing/Image/ImagePipeline.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Pipeline;
+use BlueFission\Automata\Media\Processing\Result;
+
+class ImagePipeline extends Pipeline
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addProcessor(new MetadataProcessor());
+        $this->addProcessor(new OcrProcessor());
+        $this->addProcessor(new BoundaryProcessor());
+        $this->addProcessor(new ConvolutionProcessor());
+    }
+
+    public function process(MediaItem $item, ?Context $context = null, array $options = []): Result
+    {
+        $result = parent::process($item, $context, $options);
+
+        if (empty($result->segments())) {
+            $result->addSegment($item->type() ?? 'image', $item->path() ?? 'image', [
+                'features' => $result->features(),
+                'entities' => $result->entities(),
+            ]);
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Image/MetadataProcessor.php
+++ b/src/Automata/Media/Processing/Image/MetadataProcessor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class MetadataProcessor implements IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $meta = $item->meta();
+        $width = $meta['width'] ?? null;
+        $height = $meta['height'] ?? null;
+
+        if ($width && $height) {
+            $result->addFeature('width', (int)$width);
+            $result->addFeature('height', (int)$height);
+            $result->addFeature('aspect_ratio', $height > 0 ? $width / $height : 0.0);
+        }
+
+        Dev::do('media.processing.image.meta', ['width' => $width, 'height' => $height]);
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Image/OcrProcessor.php
+++ b/src/Automata/Media/Processing/Image/OcrProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class OcrProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['ocr'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('ocr');
+        }
+
+        if (is_callable($handler)) {
+            $text = call_user_func($handler, $item, $context, $options);
+            $text = Dev::apply('media.processing.image.ocr', $text);
+            if (is_string($text) && $text !== '') {
+                $result->setMeta('ocr_text', $text);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Image/SimpleClientsOcrHandler.php
+++ b/src/Automata/Media/Processing/Image/SimpleClientsOcrHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\DevElation as Dev;
+use BlueFission\Obj;
+
+class SimpleClientsOcrHandler extends Obj
+{
+    protected $client;
+    protected array $_config;
+
+    public function __construct($client = null, array $config = [])
+    {
+        parent::__construct();
+        $this->client = $client;
+        $this->_config = $config;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->client !== null || class_exists('BlueFission\\SimpleClients\\Vision\\OcrClient');
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?string
+    {
+        $client = $this->resolveClient($options);
+        if (!$client) {
+            return null;
+        }
+
+        $input = $this->resolveInput($item);
+        if ($input === null) {
+            return null;
+        }
+
+        $result = null;
+        if (method_exists($client, 'analyze')) {
+            $result = $client->analyze($input, $options);
+        }
+
+        $text = $this->extractText($result);
+        return $text !== '' ? $text : null;
+    }
+
+    protected function resolveClient(array $options)
+    {
+        if (isset($options['client'])) {
+            return $options['client'];
+        }
+
+        if ($this->client) {
+            return $this->client;
+        }
+
+        $class = 'BlueFission\\SimpleClients\\Vision\\OcrClient';
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        $config = $options['config'] ?? $this->_config;
+        return new $class($config);
+    }
+
+    protected function resolveInput(MediaItem $item)
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (is_string($content) && $content !== '') {
+            return $content;
+        }
+
+        return null;
+    }
+
+    protected function extractText($result): string
+    {
+        if (is_array($result)) {
+            if (isset($result['text'])) {
+                return (string)$result['text'];
+            }
+            if (isset($result['result']['text'])) {
+                return (string)$result['result']['text'];
+            }
+        }
+
+        if (is_string($result)) {
+            return $result;
+        }
+
+        return '';
+    }
+}

--- a/src/Automata/Media/Processing/Image/TesseractOcrHandler.php
+++ b/src/Automata/Media/Processing/Image/TesseractOcrHandler.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Image;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Support\TempFile;
+use BlueFission\DevElation as Dev;
+use BlueFission\Obj;
+use BlueFission\System\CommandLocator;
+
+class TesseractOcrHandler extends Obj
+{
+    protected ?string $_binary;
+    protected string $_lang;
+    protected ?int $_psm;
+
+    public function __construct(?string $binary = null, string $lang = 'eng', ?int $psm = null)
+    {
+        parent::__construct();
+        $this->_binary = $binary;
+        $this->_lang = $lang;
+        $this->_psm = $psm;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->resolveBinary() !== null;
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?string
+    {
+        $binary = $this->resolveBinary($options['binary'] ?? $this->_binary);
+        if (!$binary) {
+            return null;
+        }
+
+        $inputPath = $this->resolveInputPath($item);
+        if (!$inputPath) {
+            return null;
+        }
+
+        $lang = $options['lang'] ?? $this->_lang;
+        $psm = $options['psm'] ?? $this->_psm;
+        $text = $this->runTesseract($binary, $inputPath, $lang, $psm);
+
+        if ($inputPath !== $item->path()) {
+            TempFile::cleanup($inputPath);
+        }
+
+        return $text;
+    }
+
+    protected function resolveBinary(?string $binary = null): ?string
+    {
+        $binary = $binary ?: 'tesseract';
+
+        if (is_file($binary)) {
+            return $binary;
+        }
+
+        return CommandLocator::find($binary);
+    }
+
+    protected function resolveInputPath(MediaItem $item): ?string
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (!is_string($content) || $content === '') {
+            return null;
+        }
+
+        $extension = $this->extensionFromMime($item->meta()['mime'] ?? null) ?? 'png';
+        return TempFile::createFromContent($content, $extension);
+    }
+
+    protected function extensionFromMime(?string $mime): ?string
+    {
+        if (!$mime) {
+            return null;
+        }
+
+        $map = [
+            'image/png' => 'png',
+            'image/jpeg' => 'jpg',
+            'image/jpg' => 'jpg',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+        ];
+
+        return $map[$mime] ?? null;
+    }
+
+    protected function runTesseract(string $binary, string $inputPath, string $lang, ?int $psm): ?string
+    {
+        $command = escapeshellarg($binary)
+            . ' ' . escapeshellarg($inputPath)
+            . ' stdout'
+            . ' -l ' . escapeshellarg($lang);
+
+        if ($psm !== null) {
+            $command .= ' --psm ' . (int)$psm;
+        }
+
+        $output = [];
+        $status = 0;
+        @exec($command . ' 2>&1', $output, $status);
+
+        Dev::do('media.processing.image.tesseract', ['status' => $status, 'input' => $inputPath]);
+
+        if ($status !== 0) {
+            return null;
+        }
+
+        $text = trim(implode(PHP_EOL, $output));
+        return $text !== '' ? $text : null;
+    }
+}

--- a/src/Automata/Media/Processing/Pipeline.php
+++ b/src/Automata/Media/Processing/Pipeline.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Collections\Collection;
+use BlueFission\DevElation as Dev;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+
+class Pipeline
+{
+    protected Collection $_processors;
+    protected ?HandlerRegistry $_registry = null;
+
+    public function __construct()
+    {
+        $this->_processors = new Collection();
+    }
+
+    public function addProcessor($processor, ?string $name = null): void
+    {
+        if ($name !== null) {
+            $this->_processors->add($processor, $name);
+            return;
+        }
+
+        $this->_processors[] = $processor;
+    }
+
+    public function setRegistry(HandlerRegistry $registry): void
+    {
+        $this->_registry = $registry;
+    }
+
+    public function registry(): ?HandlerRegistry
+    {
+        return $this->_registry;
+    }
+
+    public function process(MediaItem $item, ?Context $context = null, array $options = []): Result
+    {
+        if (!isset($options['handler_registry']) && !isset($options['registry']) && $this->_registry) {
+            $options['handler_registry'] = $this->_registry;
+        }
+
+        $context = $context ?? $item->context();
+        $result = new Result();
+        $result->type($item->type());
+        $result->context($context);
+        $result->meta($item->meta());
+
+        Dev::do('media.processing.pipeline.start', ['type' => $item->type()]);
+
+        foreach ($this->_processors as $processor) {
+            $processor = Dev::apply('media.processing.pipeline.processor', $processor);
+
+            if ($processor instanceof IProcessor) {
+                $result = $processor->process($item, $context, $result, $options);
+            } elseif (is_callable($processor)) {
+                $output = call_user_func($processor, $item, $context, $result, $options);
+                if ($output instanceof Result) {
+                    $result = $output;
+                }
+            }
+        }
+
+        if (empty($result->segments())) {
+            $payload = $item->content();
+            $meta = $result->meta();
+            $result->addSegment($item->type() ?? 'text', $payload, $meta);
+        }
+
+        Dev::do('media.processing.pipeline.complete', ['type' => $item->type()]);
+
+        return $result;
+    }
+
+    public function train(array $samples, array $labels = [], array $options = []): void
+    {
+        foreach ($this->_processors as $processor) {
+            if ($processor instanceof ITrainable) {
+                $processor->train($samples, $labels, $options);
+            } elseif (is_callable($processor)) {
+                call_user_func($processor, $samples, $labels, $options);
+            }
+        }
+    }
+}

--- a/src/Automata/Media/Processing/Pipeline.php
+++ b/src/Automata/Media/Processing/Pipeline.php
@@ -2,11 +2,13 @@
 
 namespace BlueFission\Automata\Media\Processing;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\Collections\Collection;
 use BlueFission\DevElation as Dev;
 use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Func;
 
 class Pipeline
 {
@@ -58,14 +60,15 @@ class Pipeline
             if ($processor instanceof IProcessor) {
                 $result = $processor->process($item, $context, $result, $options);
             } elseif (is_callable($processor)) {
-                $output = call_user_func($processor, $item, $context, $result, $options);
+                $callable = $processor instanceof Func ? $processor : new Func($processor);
+                $output = $callable->call($item, $context, $result, $options);
                 if ($output instanceof Result) {
                     $result = $output;
                 }
             }
         }
 
-        if (empty($result->segments())) {
+        if (Arr::size($result->segments()) === 0) {
             $payload = $item->content();
             $meta = $result->meta();
             $result->addSegment($item->type() ?? 'text', $payload, $meta);
@@ -82,7 +85,8 @@ class Pipeline
             if ($processor instanceof ITrainable) {
                 $processor->train($samples, $labels, $options);
             } elseif (is_callable($processor)) {
-                call_user_func($processor, $samples, $labels, $options);
+                $callable = $processor instanceof Func ? $processor : new Func($processor);
+                $callable->call($samples, $labels, $options);
             }
         }
     }

--- a/src/Automata/Media/Processing/Result.php
+++ b/src/Automata/Media/Processing/Result.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\DevElation as Dev;
 
@@ -66,7 +67,7 @@ class Result
         }
 
         if (is_array($value)) {
-            $this->entities[$label] = array_values(array_unique(array_merge($this->entities[$label], $value)));
+            $this->entities[$label] = array_values(Arr::unique(Arr::merge($this->entities[$label], $value)));
         } else {
             $this->entities[$label][] = $value;
         }
@@ -112,7 +113,7 @@ class Result
 
     public function toSegments(): array
     {
-        if (!empty($this->segments)) {
+        if (Arr::size($this->segments) > 0) {
             return $this->segments;
         }
 

--- a/src/Automata/Media/Processing/Result.php
+++ b/src/Automata/Media/Processing/Result.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing;
+
+use BlueFission\Automata\Context;
+use BlueFission\DevElation as Dev;
+
+class Result
+{
+    protected ?string $type = null;
+    protected array $meta = [];
+    protected array $features = [];
+    protected array $entities = [];
+    protected array $segments = [];
+    protected array $tokens = [];
+    protected array $metrics = [];
+    protected ?Context $context = null;
+
+    public function type(?string $type = null): ?string
+    {
+        if ($type === null) {
+            return $this->type;
+        }
+
+        $this->type = $type;
+        return $this->type;
+    }
+
+    public function context(?Context $context = null): ?Context
+    {
+        if ($context !== null) {
+            $this->context = $context;
+        }
+
+        return $this->context;
+    }
+
+    public function meta(?array $meta = null): array
+    {
+        if ($meta !== null) {
+            $this->meta = $meta;
+        }
+
+        return $this->meta;
+    }
+
+    public function setMeta(string $key, $value): void
+    {
+        $this->meta[$key] = $value;
+    }
+
+    public function addFeature(string $name, $value): void
+    {
+        $this->features[$name] = $value;
+    }
+
+    public function features(): array
+    {
+        return $this->features;
+    }
+
+    public function addEntity(string $label, $value): void
+    {
+        if (!isset($this->entities[$label])) {
+            $this->entities[$label] = [];
+        }
+
+        if (is_array($value)) {
+            $this->entities[$label] = array_values(array_unique(array_merge($this->entities[$label], $value)));
+        } else {
+            $this->entities[$label][] = $value;
+        }
+    }
+
+    public function entities(): array
+    {
+        return $this->entities;
+    }
+
+    public function tokens(?array $tokens = null): array
+    {
+        if ($tokens !== null) {
+            $this->tokens = $tokens;
+        }
+
+        return $this->tokens;
+    }
+
+    public function setMetric(string $name, $value): void
+    {
+        $this->metrics[$name] = $value;
+    }
+
+    public function metrics(): array
+    {
+        return $this->metrics;
+    }
+
+    public function addSegment(string $type, $payload, array $meta = []): void
+    {
+        $this->segments[] = [
+            'type' => $type,
+            'payload' => $payload,
+            'meta' => $meta,
+        ];
+    }
+
+    public function segments(): array
+    {
+        return $this->segments;
+    }
+
+    public function toSegments(): array
+    {
+        if (!empty($this->segments)) {
+            return $this->segments;
+        }
+
+        $payload = $this->meta;
+        $meta = [
+            'features' => $this->features,
+            'entities' => $this->entities,
+            'metrics' => $this->metrics,
+        ];
+
+        $segment = [
+            'type' => $this->type ?? 'text',
+            'payload' => $payload,
+            'meta' => $meta,
+        ];
+
+        $segment = Dev::apply('media.processing.result.segment', $segment);
+
+        return [$segment];
+    }
+}

--- a/src/Automata/Media/Processing/Support/TempFile.php
+++ b/src/Automata/Media/Processing/Support/TempFile.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Support;
+
+class TempFile
+{
+    public static function createFromContent(string $content, string $extension = ''): ?string
+    {
+        $extension = ltrim($extension, '.');
+        $path = tempnam(sys_get_temp_dir(), 'automata_media_');
+
+        if ($path === false) {
+            return null;
+        }
+
+        if ($extension !== '') {
+            $newPath = $path . '.' . $extension;
+            if (!@rename($path, $newPath)) {
+                @unlink($path);
+                return null;
+            }
+            $path = $newPath;
+        }
+
+        if ($content !== '') {
+            @file_put_contents($path, $content);
+        }
+
+        return $path;
+    }
+
+    public static function cleanup(?string $path): void
+    {
+        if ($path && is_file($path)) {
+            @unlink($path);
+        }
+    }
+}

--- a/src/Automata/Media/Processing/Text/BagOfWords.php
+++ b/src/Automata/Media/Processing/Text/BagOfWords.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class BagOfWords implements IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $tokens = $result->tokens();
+        $bag = [];
+
+        foreach ($tokens as $token) {
+            $token = (string)$token;
+            if ($token === '') {
+                continue;
+            }
+            $bag[$token] = ($bag[$token] ?? 0) + 1;
+        }
+
+        $bag = Dev::apply('media.processing.text.bag_of_words', $bag);
+
+        $result->addFeature('bag_of_words', $bag);
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Text/EntityProcessor.php
+++ b/src/Automata/Media/Processing/Text/EntityProcessor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\Automata\Language\EntityExtractor;
+use BlueFission\DevElation as Dev;
+
+class EntityProcessor implements IProcessor
+{
+    protected EntityExtractor $extractor;
+
+    public function __construct(?EntityExtractor $extractor = null)
+    {
+        $this->extractor = $extractor ?? new EntityExtractor();
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $text = $result->meta()['normalized_text'] ?? $item->content();
+
+        $entities = [
+            'email' => $this->extractor->email($text),
+            'url' => $this->extractor->web($text),
+            'date' => $this->extractor->date($text),
+            'time' => $this->extractor->time($text),
+            'phone' => $this->extractor->phone($text),
+            'tag' => $this->extractor->tags($text),
+            'mention' => $this->extractor->mentions($text),
+        ];
+
+        $entities = Dev::apply('media.processing.text.entities', $entities);
+
+        foreach ($entities as $label => $values) {
+            if (!empty($values)) {
+                $result->addEntity($label, $values);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Text/Heuristics.php
+++ b/src/Automata/Media/Processing/Text/Heuristics.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class Heuristics implements IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $text = (string)($result->meta()['normalized_text'] ?? $item->content());
+        $tokens = $result->tokens();
+
+        $metrics = [
+            'length' => strlen($text),
+            'token_count' => count($tokens),
+            'unique_tokens' => count(array_unique($tokens)),
+            'sentence_count' => max(1, preg_match_all('/[.!?]+/', $text)),
+        ];
+
+        $metrics = Dev::apply('media.processing.text.heuristics', $metrics);
+
+        foreach ($metrics as $name => $value) {
+            $result->setMetric($name, $value);
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Text/Normalizer.php
+++ b/src/Automata/Media/Processing/Text/Normalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\Automata\Language\ContractionNormalizer;
+use BlueFission\DevElation as Dev;
+
+class Normalizer implements IProcessor
+{
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $text = (string)$item->content();
+        $text = strip_tags($text);
+        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        $text = ContractionNormalizer::normalize($text);
+        $text = trim($text);
+
+        $lowercase = $options['lowercase'] ?? true;
+        if ($lowercase) {
+            $text = function_exists('mb_strtolower') ? mb_strtolower($text) : strtolower($text);
+        }
+
+        $text = Dev::apply('media.processing.text.normalized', $text);
+
+        $result->setMeta('normalized_text', $text);
+        $context->setNormalization('text', ['normalized' => $text]);
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Text/TextPipeline.php
+++ b/src/Automata/Media/Processing/Text/TextPipeline.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing\Text;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\Automata\Media\Processing\Pipeline;
 use BlueFission\Automata\Media\Processing\Result;
@@ -23,7 +24,7 @@ class TextPipeline extends Pipeline
     {
         $result = parent::process($item, $context, $options);
 
-        if (empty($result->segments())) {
+        if (Arr::size($result->segments()) === 0) {
             $normalized = $result->meta()['normalized_text'] ?? $item->content();
             $result->addSegment($item->type() ?? 'text', $normalized, [
                 'features' => $result->features(),

--- a/src/Automata/Media/Processing/Text/TextPipeline.php
+++ b/src/Automata/Media/Processing/Text/TextPipeline.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Pipeline;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\Automata\Context;
+
+class TextPipeline extends Pipeline
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addProcessor(new Normalizer());
+        $this->addProcessor(new Tokenizer());
+        $this->addProcessor(new EntityProcessor());
+        $this->addProcessor(new BagOfWords());
+        $this->addProcessor(new Heuristics());
+    }
+
+    public function process(MediaItem $item, ?Context $context = null, array $options = []): Result
+    {
+        $result = parent::process($item, $context, $options);
+
+        if (empty($result->segments())) {
+            $normalized = $result->meta()['normalized_text'] ?? $item->content();
+            $result->addSegment($item->type() ?? 'text', $normalized, [
+                'features' => $result->features(),
+                'entities' => $result->entities(),
+                'metrics' => $result->metrics(),
+            ]);
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Text/Tokenizer.php
+++ b/src/Automata/Media/Processing/Text/Tokenizer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Text;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\Automata\Language\Preparer;
+use BlueFission\DevElation as Dev;
+
+class Tokenizer implements IProcessor
+{
+    protected Preparer $preparer;
+
+    public function __construct(?Preparer $preparer = null)
+    {
+        $this->preparer = $preparer ?? new Preparer();
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $text = $result->meta()['normalized_text'] ?? $item->content();
+        $boundary = $options['boundary'] ?? '/\s+/';
+
+        if (isset($options['blacklist']) && is_array($options['blacklist'])) {
+            $this->preparer->setBlacklist($options['blacklist']);
+        }
+
+        $tokens = $this->preparer->tokenize((string)$text, $boundary);
+        $tokens = Dev::apply('media.processing.text.tokens', $tokens);
+
+        $result->tokens($tokens);
+        $context->setNormalization('tokens', $tokens);
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Video/FfmpegFrameExtractor.php
+++ b/src/Automata/Media/Processing/Video/FfmpegFrameExtractor.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Video;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Support\TempFile;
+use BlueFission\DevElation as Dev;
+use BlueFission\Obj;
+use BlueFission\System\CommandLocator;
+
+class FfmpegFrameExtractor extends Obj
+{
+    protected ?string $_binary;
+    protected int $_fps;
+
+    public function __construct(?string $binary = null, int $fps = 1)
+    {
+        parent::__construct();
+        $this->_binary = $binary;
+        $this->_fps = $fps;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->resolveBinary() !== null;
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?array
+    {
+        $binary = $this->resolveBinary($options['binary'] ?? $this->_binary);
+        if (!$binary) {
+            return null;
+        }
+
+        $inputPath = $this->resolveInputPath($item);
+        if (!$inputPath) {
+            return null;
+        }
+
+        $fps = $options['fps'] ?? $this->_fps;
+        $limit = isset($options['limit']) ? (int)$options['limit'] : null;
+
+        $frames = $this->runFfmpeg($binary, $inputPath, $fps, $limit, $options);
+
+        if ($inputPath !== $item->path()) {
+            TempFile::cleanup($inputPath);
+        }
+
+        return $frames;
+    }
+
+    protected function resolveBinary(?string $binary = null): ?string
+    {
+        $binary = $binary ?: 'ffmpeg';
+
+        if (is_file($binary)) {
+            return $binary;
+        }
+
+        return CommandLocator::find($binary);
+    }
+
+    protected function resolveInputPath(MediaItem $item): ?string
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (!is_string($content) || $content === '') {
+            return null;
+        }
+
+        $extension = $this->extensionFromMime($item->meta()['mime'] ?? null) ?? 'mp4';
+        return TempFile::createFromContent($content, $extension);
+    }
+
+    protected function extensionFromMime(?string $mime): ?string
+    {
+        if (!$mime) {
+            return null;
+        }
+
+        $map = [
+            'video/mp4' => 'mp4',
+            'video/quicktime' => 'mov',
+            'video/webm' => 'webm',
+        ];
+
+        return $map[$mime] ?? null;
+    }
+
+    protected function runFfmpeg(string $binary, string $inputPath, int $fps, ?int $limit, array $options): ?array
+    {
+        $outputDir = $options['output_dir'] ?? $this->createOutputDir();
+        if (!$outputDir) {
+            return null;
+        }
+
+        $pattern = $outputDir . DIRECTORY_SEPARATOR . 'frame_%04d.png';
+        $command = escapeshellarg($binary)
+            . ' -i ' . escapeshellarg($inputPath)
+            . ' -vf fps=' . max(1, $fps)
+            . ' ' . escapeshellarg($pattern);
+
+        if ($limit !== null && $limit > 0) {
+            $command = escapeshellarg($binary)
+                . ' -i ' . escapeshellarg($inputPath)
+                . ' -vf fps=' . max(1, $fps)
+                . ' -vframes ' . $limit
+                . ' ' . escapeshellarg($pattern);
+        }
+
+        $output = [];
+        $status = 0;
+        @exec($command . ' 2>&1', $output, $status);
+
+        Dev::do('media.processing.video.ffmpeg', ['status' => $status, 'input' => $inputPath]);
+
+        $frames = [];
+        if ($status === 0) {
+            $files = glob($outputDir . DIRECTORY_SEPARATOR . 'frame_*.png');
+            if (is_array($files)) {
+                foreach ($files as $index => $file) {
+                    $frames[] = ['index' => $index, 'path' => $file];
+                }
+            }
+        }
+
+        if (empty($options['keep_output'])) {
+            $this->cleanupOutput($outputDir);
+        }
+
+        return $frames ?: null;
+    }
+
+    protected function createOutputDir(): ?string
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'automata_ffmpeg_' . uniqid();
+        if (!@mkdir($path, 0777, true)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    protected function cleanupOutput(string $outputDir): void
+    {
+        if (is_dir($outputDir)) {
+            $files = glob($outputDir . DIRECTORY_SEPARATOR . '*');
+            if (is_array($files)) {
+                foreach ($files as $file) {
+                    if (is_file($file)) {
+                        @unlink($file);
+                    }
+                }
+            }
+            @rmdir($outputDir);
+        }
+    }
+}

--- a/src/Automata/Media/Processing/Video/FrameExtractor.php
+++ b/src/Automata/Media/Processing/Video/FrameExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Video;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class FrameExtractor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['frame_extractor'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('frame_extractor');
+        }
+
+        if (is_callable($handler)) {
+            $frames = call_user_func($handler, $item, $context, $options);
+            $frames = Dev::apply('media.processing.video.frames', $frames);
+            if (is_array($frames)) {
+                $result->addFeature('frames', $frames);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Video/SimpleClientsVideoAnalysisHandler.php
+++ b/src/Automata/Media/Processing/Video/SimpleClientsVideoAnalysisHandler.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Video;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Obj;
+
+class SimpleClientsVideoAnalysisHandler extends Obj
+{
+    protected $client;
+    protected array $_config;
+
+    public function __construct($client = null, array $config = [])
+    {
+        parent::__construct();
+        $this->client = $client;
+        $this->_config = $config;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->client !== null || class_exists('BlueFission\\SimpleClients\\Video\\AnalysisClient');
+    }
+
+    public function __invoke(MediaItem $item, Context $context, array $options = []): ?array
+    {
+        $client = $this->resolveClient($options);
+        if (!$client) {
+            return null;
+        }
+
+        $input = $this->resolveInput($item);
+        if ($input === null) {
+            return null;
+        }
+
+        $result = null;
+        if (method_exists($client, 'analyze')) {
+            $result = $client->analyze($input, $options);
+        }
+
+        if (is_array($result)) {
+            return $result;
+        }
+
+        return null;
+    }
+
+    protected function resolveClient(array $options)
+    {
+        if (isset($options['client'])) {
+            return $options['client'];
+        }
+
+        if ($this->client) {
+            return $this->client;
+        }
+
+        $class = 'BlueFission\\SimpleClients\\Video\\AnalysisClient';
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        $config = $options['config'] ?? $this->_config;
+        return new $class($config);
+    }
+
+    protected function resolveInput(MediaItem $item)
+    {
+        $path = $item->path();
+        if ($path && is_file($path)) {
+            return $path;
+        }
+
+        $content = $item->content();
+        if (is_string($content) && $content !== '') {
+            return $content;
+        }
+
+        return null;
+    }
+}

--- a/src/Automata/Media/Processing/Video/TimelineProcessor.php
+++ b/src/Automata/Media/Processing/Video/TimelineProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Video;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\IProcessor;
+use BlueFission\Automata\Media\Processing\Result;
+use BlueFission\DevElation as Dev;
+
+class TimelineProcessor implements IProcessor
+{
+    protected $handler;
+
+    public function __construct($handler = null)
+    {
+        $this->handler = $handler;
+    }
+
+    public function process(MediaItem $item, Context $context, Result $result, array $options = []): Result
+    {
+        $handler = $options['timeline_analyzer'] ?? $this->handler;
+        $registry = $options['registry'] ?? $options['handler_registry'] ?? null;
+        if (!$handler && $registry instanceof HandlerRegistry) {
+            $handler = $registry->resolve('timeline_analyzer');
+        }
+
+        if (is_callable($handler)) {
+            $timeline = call_user_func($handler, $item, $context, $options);
+            $timeline = Dev::apply('media.processing.video.timeline', $timeline);
+            if (is_array($timeline)) {
+                $result->addFeature('timeline', $timeline);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Video/VideoPipeline.php
+++ b/src/Automata/Media/Processing/Video/VideoPipeline.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BlueFission\Automata\Media\Processing\Video;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Pipeline;
+use BlueFission\Automata\Media\Processing\Result;
+
+class VideoPipeline extends Pipeline
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addProcessor(new FrameExtractor());
+        $this->addProcessor(new TimelineProcessor());
+    }
+
+    public function process(MediaItem $item, ?Context $context = null, array $options = []): Result
+    {
+        $result = parent::process($item, $context, $options);
+
+        if (empty($result->segments())) {
+            $result->addSegment($item->type() ?? 'video', $item->path() ?? 'video', [
+                'features' => $result->features(),
+            ]);
+        }
+
+        return $result;
+    }
+}

--- a/src/Automata/Media/Processing/Video/VideoPipeline.php
+++ b/src/Automata/Media/Processing/Video/VideoPipeline.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Processing\Video;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\Automata\Media\Processing\Pipeline;
@@ -20,7 +21,7 @@ class VideoPipeline extends Pipeline
     {
         $result = parent::process($item, $context, $options);
 
-        if (empty($result->segments())) {
+        if (Arr::size($result->segments()) === 0) {
             $result->addSegment($item->type() ?? 'video', $item->path() ?? 'video', [
                 'features' => $result->features(),
             ]);

--- a/src/Automata/Media/Stream.php
+++ b/src/Automata/Media/Stream.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BlueFission\Automata\Media;
+
+class Stream
+{
+    protected $resource;
+    protected array $meta = [];
+
+    public function __construct($resource)
+    {
+        $this->resource = $resource;
+        if (is_resource($resource)) {
+            $this->meta = stream_get_meta_data($resource) ?: [];
+        }
+    }
+
+    public function resource()
+    {
+        return $this->resource;
+    }
+
+    public function meta(): array
+    {
+        return $this->meta;
+    }
+
+    public function read(?int $length = null): string
+    {
+        if (!is_resource($this->resource)) {
+            return '';
+        }
+
+        $data = $length === null ? stream_get_contents($this->resource) : stream_get_contents($this->resource, $length);
+        return $data === false ? '' : $data;
+    }
+
+    public function rewind(): void
+    {
+        if (is_resource($this->resource)) {
+            rewind($this->resource);
+        }
+    }
+
+    public function length(): ?int
+    {
+        if (!is_resource($this->resource)) {
+            return null;
+        }
+
+        $stats = fstat($this->resource);
+        return isset($stats['size']) ? (int)$stats['size'] : null;
+    }
+}

--- a/src/Automata/Parsing/Elements/PromptElement.php
+++ b/src/Automata/Parsing/Elements/PromptElement.php
@@ -10,12 +10,14 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Collections\Collection;
 use BlueFission\Str;
 use BlueFission\DevElation as Dev;
+use BlueFission\Val;
 use Exception;
 
 class PromptElement extends EvalElement implements IExecutableElement, IRenderableElement
 {
     protected $llm;
     protected array $buffer = [];
+    protected const ATTRIBUTE_INTERPOLATION_PATTERN = '/(?:\[\[\s*(.*?)\s*\]\]|\{\{\s*(.*?)\s*\}\})/';
 
     public function setLLM($llm): void
     {
@@ -35,6 +37,30 @@ class PromptElement extends EvalElement implements IExecutableElement, IRenderab
         return $this->description;
     }
 
+    public function getAttribute($name): mixed
+    {
+        $value = parent::getAttribute($name);
+
+        if (Str::is($value)) {
+            $value = $this->interpolateAttributeString((string)$value);
+        }
+
+        return $value;
+    }
+
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+
+        foreach ($attributes as $key => $value) {
+            if (Str::is($value)) {
+                $attributes[$key] = $this->interpolateAttributeString((string)$value);
+            }
+        }
+
+        return $attributes;
+    }
+
     public function render(): string
     {
         $silent = $this->getAttribute('silent');
@@ -43,5 +69,133 @@ class PromptElement extends EvalElement implements IExecutableElement, IRenderab
         }
 
         return (string)$this->value;
+    }
+
+    protected function interpolateAttributeString(string $value): string
+    {
+        if (Str::pos($value, '[[') === false && Str::pos($value, '{{') === false) {
+            return $value;
+        }
+
+        $interpolated = preg_replace_callback(
+            self::ATTRIBUTE_INTERPOLATION_PATTERN,
+            function (array $matches): string {
+                $expression = Str::trim((string)(($matches[1] ?? '') !== '' ? $matches[1] : ($matches[2] ?? '')));
+                if ($expression === '') {
+                    return '';
+                }
+
+                return $this->resolveInterpolationExpression($expression);
+            },
+            $value
+        );
+
+        $interpolated = Dev::apply('automata.parsing.elements.promptelement.interpolate_attribute', $interpolated);
+        Dev::do('automata.parsing.elements.promptelement.interpolate_attribute.action1', [
+            'element' => $this,
+            'value' => $value,
+            'interpolated' => $interpolated,
+        ]);
+
+        return (string)$interpolated;
+    }
+
+    protected function resolveInterpolationExpression(string $expression): string
+    {
+        $segments = preg_split('/\|/', $expression) ?: [];
+        $base = Str::trim((string)array_shift($segments));
+        $value = $this->resolveInterpolationValue($base);
+
+        foreach ($segments as $segment) {
+            $segment = Str::trim((string)$segment);
+            if ($segment === '') {
+                continue;
+            }
+
+            [$filter, $arguments] = $this->parseInterpolationFilter($segment);
+            $value = $this->applyInterpolationFilter($value, $filter, $arguments);
+        }
+
+        return $this->stringifyInterpolatedValue($value);
+    }
+
+    protected function resolveInterpolationValue(string $expression): mixed
+    {
+        if ($expression === '') {
+            return '';
+        }
+
+        if (preg_match('/^(["\']).*\\1$/', $expression)) {
+            return trim($expression, '\'"');
+        }
+
+        return parent::resolveValue($expression);
+    }
+
+    protected function parseInterpolationFilter(string $segment): array
+    {
+        $parts = explode(':', $segment);
+        $filter = Str::lower(Str::trim((string)array_shift($parts)));
+        $arguments = array_map(fn ($argument) => Str::trim((string)$argument), $parts);
+
+        return [$filter, $arguments];
+    }
+
+    protected function applyInterpolationFilter(mixed $value, string $filter, array $arguments = []): mixed
+    {
+        return match ($filter) {
+            'slug', 'slugify' => Str::slugify($this->stringifyInterpolatedValue($value)),
+            'lower' => Str::lower($this->stringifyInterpolatedValue($value)),
+            'upper' => Str::upper($this->stringifyInterpolatedValue($value)),
+            'trim' => Str::trim($this->stringifyInterpolatedValue($value)),
+            'pad' => $this->applyPadFilter($value, $arguments),
+            'default' => $this->applyDefaultFilter($value, $arguments),
+            default => $value,
+        };
+    }
+
+    protected function applyPadFilter(mixed $value, array $arguments = []): string
+    {
+        $string = $this->stringifyInterpolatedValue($value);
+        $length = isset($arguments[0]) && is_numeric($arguments[0]) ? (int)$arguments[0] : 2;
+        $pad = isset($arguments[1]) && $arguments[1] !== '' ? $arguments[1] : '0';
+        $direction = isset($arguments[2]) && Str::lower($arguments[2]) === 'right' ? STR_PAD_RIGHT : STR_PAD_LEFT;
+
+        return str_pad($string, $length, $pad, $direction);
+    }
+
+    protected function applyDefaultFilter(mixed $value, array $arguments = []): mixed
+    {
+        $default = $arguments[0] ?? '';
+        if ($value === null) {
+            return $default;
+        }
+
+        if (Str::is($value) && Str::trim((string)$value) === '') {
+            return $default;
+        }
+
+        if (Val::is($value) && !Str::is($value) && !$value) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    protected function stringifyInterpolatedValue(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_scalar($value)) {
+            return (string)$value;
+        }
+
+        if (is_array($value)) {
+            return implode(',', array_map(fn ($item) => $this->stringifyInterpolatedValue($item), $value));
+        }
+
+        return (string)$value;
     }
 }

--- a/tests/Automata/LLM/FillInProfileTest.php
+++ b/tests/Automata/LLM/FillInProfileTest.php
@@ -232,4 +232,37 @@ class FillInProfileTest extends TestCase
         $this->assertCount(1, $client->prompts);
         $this->assertSame('', $client->prompts[0]);
     }
+
+    public function testGenerationAttributesSupportScopedInterpolationForThreadIds(): void
+    {
+        $client = new RecordingClient('threaded');
+        $fillIn = new FillIn(
+            $client,
+            '{=content thread="book:[[book.slug|slug]]:chapter:[[chapter|pad:2]]:section:[[section.slug|slug]]" session="session:[[book.slug|slug]]:[[chapter|pad:2]]"}'
+        );
+        $fillIn->setVariables([
+            'book' => ['slug' => 'Field Notes on Response'],
+            'chapter' => 3,
+            'section' => ['slug' => 'Initial Damage Survey'],
+        ]);
+
+        $sent = [];
+        $fillIn->when(Event::SENT, function ($behavior, $meta) use (&$sent) {
+            $sent[] = $meta;
+        });
+
+        $fillIn->run();
+
+        $this->assertNotEmpty($sent);
+        $data = $sent[0]->data;
+
+        $this->assertSame(
+            'book:field-notes-on-response:chapter:03:section:initial-damage-survey',
+            $data['thread']
+        );
+        $this->assertSame(
+            'session:field-notes-on-response:03',
+            $data['session']
+        );
+    }
 }

--- a/tests/Automata/Media/AudioPipelineTest.php
+++ b/tests/Automata/Media/AudioPipelineTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Audio\AudioPipeline;
+use PHPUnit\Framework\TestCase;
+
+class AudioPipelineTest extends TestCase
+{
+    public function testAudioPipelineUsesHandlers(): void
+    {
+        $item = new MediaItem(InputType::AUDIO, 'binary', ['size' => 123]);
+        $pipeline = new AudioPipeline();
+
+        $result = $pipeline->process($item, null, [
+            'volume_normalizer' => function () {
+                return 0.5;
+            },
+            'speech_to_text' => function () {
+                return 'hello';
+            },
+            'audio_event_detector' => function () {
+                return ['speech'];
+            },
+        ]);
+
+        $this->assertSame(0.5, $result->features()['volume_level'] ?? null);
+        $this->assertSame('hello', $result->meta()['transcript'] ?? null);
+        $this->assertSame(['speech'], $result->features()['events'] ?? null);
+        $this->assertNotEmpty($result->segments());
+    }
+}

--- a/tests/Automata/Media/CommandLocatorTest.php
+++ b/tests/Automata/Media/CommandLocatorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\System\CommandLocator;
+use PHPUnit\Framework\TestCase;
+
+class CommandLocatorTest extends TestCase
+{
+    public function testFindReturnsNullForMissingBinary(): void
+    {
+        $path = CommandLocator::find('definitely-not-a-binary');
+        $this->assertNull($path);
+    }
+}

--- a/tests/Automata/Media/HandlerRegistryTest.php
+++ b/tests/Automata/Media/HandlerRegistryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use PHPUnit\Framework\TestCase;
+
+class HandlerRegistryTest extends TestCase
+{
+    public function testRegistryResolvesAvailableHandler(): void
+    {
+        $registry = new HandlerRegistry();
+
+        $registry->register('ocr', new class {
+            public function isAvailable(): bool { return false; }
+            public function __invoke() { return 'skip'; }
+        }, 'unavailable', 10);
+
+        $registry->register('ocr', new class {
+            public function isAvailable(): bool { return true; }
+            public function __invoke() { return 'ok'; }
+        }, 'available', 1);
+
+        $handler = $registry->resolve('ocr');
+
+        $this->assertNotNull($handler);
+        $this->assertSame('ok', $handler());
+    }
+}

--- a/tests/Automata/Media/ImagePipelineTest.php
+++ b/tests/Automata/Media/ImagePipelineTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Image\ImagePipeline;
+use PHPUnit\Framework\TestCase;
+
+class ImagePipelineTest extends TestCase
+{
+    public function testImagePipelineUsesHandlers(): void
+    {
+        $item = new MediaItem(InputType::IMAGE, 'binary', ['width' => 10, 'height' => 5]);
+        $pipeline = new ImagePipeline();
+
+        $result = $pipeline->process($item, null, [
+            'ocr' => function () {
+                return 'sample text';
+            },
+            'boundary_detector' => function () {
+                return [['x' => 1, 'y' => 2, 'w' => 3, 'h' => 4]];
+            },
+        ]);
+
+        $this->assertSame('sample text', $result->meta()['ocr_text'] ?? null);
+        $this->assertSame(10, $result->features()['width'] ?? null);
+        $this->assertSame(5, $result->features()['height'] ?? null);
+        $this->assertNotEmpty($result->segments());
+    }
+}

--- a/tests/Automata/Media/IngestionGatewayTest.php
+++ b/tests/Automata/Media/IngestionGatewayTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\Ingestion\Gateway as IngestionGateway;
+use BlueFission\Automata\Media\Ingestion\TextIngestor;
+use PHPUnit\Framework\TestCase;
+
+class IngestionGatewayTest extends TestCase
+{
+    public function testTextIngestionFromString(): void
+    {
+        $gateway = new IngestionGateway();
+        $gateway->registerIngestor(new TextIngestor(), 'text', ['types' => [InputType::TEXT]]);
+
+        $item = $gateway->ingest('Hello world');
+
+        $this->assertSame(InputType::TEXT, $item->type());
+        $this->assertSame('Hello world', $item->content());
+    }
+}

--- a/tests/Automata/Media/PipelineRegistryTest.php
+++ b/tests/Automata/Media/PipelineRegistryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\HandlerRegistry;
+use BlueFission\Automata\Media\Processing\Image\ImagePipeline;
+use PHPUnit\Framework\TestCase;
+
+class PipelineRegistryTest extends TestCase
+{
+    public function testPipelineUsesRegistryByDefault(): void
+    {
+        $registry = new HandlerRegistry();
+        $registry->register('ocr', new class {
+            public function isAvailable(): bool { return true; }
+            public function __invoke(MediaItem $item, Context $context, array $options = [])
+            {
+                return 'registry text';
+            }
+        });
+
+        $pipeline = new ImagePipeline();
+        $pipeline->setRegistry($registry);
+
+        $item = new MediaItem(InputType::IMAGE, 'binary');
+        $result = $pipeline->process($item);
+
+        $this->assertSame('registry text', $result->meta()['ocr_text'] ?? null);
+    }
+}

--- a/tests/Automata/Media/SimpleClientsHandlersTest.php
+++ b/tests/Automata/Media/SimpleClientsHandlersTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\Context;
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Audio\SimpleClientsTranscriptionHandler;
+use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
+use BlueFission\Automata\Media\Processing\Video\SimpleClientsVideoAnalysisHandler;
+use PHPUnit\Framework\TestCase;
+
+class SimpleClientsHandlersTest extends TestCase
+{
+    public function testOcrHandlerUsesInjectedClient(): void
+    {
+        $client = new class {
+            public function analyze($input, array $options = [])
+            {
+                return ['text' => 'hello'];
+            }
+        };
+
+        $handler = new SimpleClientsOcrHandler($client);
+        $item = new MediaItem(InputType::IMAGE, 'binary');
+        $text = $handler($item, new Context(), []);
+
+        $this->assertSame('hello', $text);
+    }
+
+    public function testTranscriptionHandlerUsesInjectedClient(): void
+    {
+        $client = new class {
+            public function transcribe($input, array $options = [])
+            {
+                return ['text' => 'voice'];
+            }
+        };
+
+        $handler = new SimpleClientsTranscriptionHandler($client);
+        $item = new MediaItem(InputType::AUDIO, 'binary');
+        $text = $handler($item, new Context(), []);
+
+        $this->assertSame('voice', $text);
+    }
+
+    public function testVideoHandlerUsesInjectedClient(): void
+    {
+        $client = new class {
+            public function analyze($input, array $options = [])
+            {
+                return ['entities' => ['car']];
+            }
+        };
+
+        $handler = new SimpleClientsVideoAnalysisHandler($client);
+        $item = new MediaItem(InputType::VIDEO, 'binary');
+        $result = $handler($item, new Context(), []);
+
+        $this->assertSame(['entities' => ['car']], $result);
+    }
+}

--- a/tests/Automata/Media/TextPipelineTest.php
+++ b/tests/Automata/Media/TextPipelineTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Text\TextPipeline;
+use PHPUnit\Framework\TestCase;
+
+class TextPipelineTest extends TestCase
+{
+    public function testTextPipelineBuildsTokensAndBag(): void
+    {
+        $item = new MediaItem(InputType::TEXT, 'Hello world hello');
+        $pipeline = new TextPipeline();
+
+        $result = $pipeline->process($item);
+        $tokens = $result->tokens();
+        $features = $result->features();
+        $bag = $features['bag_of_words'] ?? [];
+
+        $this->assertContains('hello', $tokens);
+        $this->assertSame(2, $bag['hello'] ?? 0);
+        $this->assertNotEmpty($result->segments());
+    }
+}

--- a/tests/Automata/Media/VideoPipelineTest.php
+++ b/tests/Automata/Media/VideoPipelineTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Media;
+
+use BlueFission\Automata\InputType;
+use BlueFission\Automata\Media\MediaItem;
+use BlueFission\Automata\Media\Processing\Video\VideoPipeline;
+use PHPUnit\Framework\TestCase;
+
+class VideoPipelineTest extends TestCase
+{
+    public function testVideoPipelineUsesHandlers(): void
+    {
+        $item = new MediaItem(InputType::VIDEO, 'binary');
+        $pipeline = new VideoPipeline();
+
+        $result = $pipeline->process($item, null, [
+            'frame_extractor' => function () {
+                return [['index' => 0, 'path' => 'frame_0001.png']];
+            },
+            'timeline_analyzer' => function () {
+                return ['entities' => ['car']];
+            },
+        ]);
+
+        $this->assertSame([['index' => 0, 'path' => 'frame_0001.png']], $result->features()['frames'] ?? null);
+        $this->assertSame(['entities' => ['car']], $result->features()['timeline'] ?? null);
+        $this->assertNotEmpty($result->segments());
+    }
+}


### PR DESCRIPTION
Intent summary

- Extend FillIn and prompt parsing so generation-style tags can resolve reusable VIBE profiles and interpolate stable thread/session identifiers from scoped values.
- Add a new Media ingestion and processing subsystem that normalizes text, image, audio, video, document, and URL inputs into pipeline results consumable by `Intelligence` and `Engine`.

User stories / acceptance criteria

- As an Automata integrator, I can point generation tags at named or file-backed VIBE profiles without rewriting templates.
- As an Automata integrator, I can interpolate stable labels, thread ids, and session ids from scoped vars in prompt attributes.
- As an Automata integrator, I can ingest text, image, audio, video, document, and URL inputs into a consistent `MediaItem` abstraction.
- As an Automata integrator, I can run lightweight media pipelines that emit normalized text, tokens, entities, features, heuristics, and `Intelligence`-ready segments.
- As an Automata integrator, I can inject optional OCR, transcription, and video-analysis handlers through registry/callable seams instead of hard dependencies.
- As a library user, I can run examples showing media pipelines feeding both `Intelligence` and `Engine`.

Key files changed

- `src/Automata/LLM/FillIn.php`
- `src/Automata/Parsing/Elements/PromptElement.php`
- `src/Automata/Parsing/Generators/LLMGenerator.php`
- `docs/VIBE_PROFILES.md`
- `examples/generic/vibe_profile_fillin.php`
- `src/Automata/Media/**`
- `tests/Automata/Media/**`
- `docs/Media.md`
- `examples/media_pipeline_intelligence.php`
- `examples/media_pipeline_engine.php`
- `README.md`
- `SPEC.md`
- `ARCHITECTURE.md`
- `examples/README.md`

How to test

- `./vendor/bin/phpunit --do-not-cache-result tests/Automata/Media tests/Automata/LLM/FillInProfileTest.php tests/Examples/VibeProfileFillInExampleTest.php`
- `php examples/media_pipeline_engine.php`
- `php examples/media_pipeline_intelligence.php`
- `php examples/generic/vibe_profile_fillin.php`

QA checklist

- [x] Media suite passes
- [x] VIBE profile tests pass
- [x] Media -> Engine example runs
- [x] Media -> Intelligence example runs
- [x] Docs updated for media ingestion/pipelines and VIBE profiles

Approval conditions

- Human review of the `MediaItem` / pipeline / handler registry abstraction boundary
- Human review of the VIBE profile resolution model and prompt interpolation surface
- Human review of whether template assets in local scratch should remain out of scope for this PR
