### PR TITLE
Align Holoscene and Statement with prototypes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,6 +217,12 @@ Responsibilities:
   - recover relevant context,
   - update knowledge graphs as events occur.
 
+World-model carriers such as `Comprehension\Holoscene` should prefer
+DevElation prototype traits where shared domain/member/state semantics improve
+interoperability. Semantic carriers such as `Language\Statement` should adopt
+prototype traits selectively where conditions, relations, and position metadata
+meaningfully improve downstream comprehension and narration flows.
+
 ### 2.7 Language and LLM Layer
 
 **Key folders:**

--- a/src/Automata/Comprehension/Holoscene.php
+++ b/src/Automata/Comprehension/Holoscene.php
@@ -64,8 +64,8 @@ class Holoscene extends Obj
 	{
 		$scene = Dev::apply('comprehension.holoscene.push_scene', $scene);
 		$this->_holo->add($scene, $key);
-		$this->addMember($scene, $key);
-		$this->record('scene_pushed', ['key' => $key]);
+		$this->addMember($this->sceneSnapshotValue($scene), $key);
+		$this->record('scene_pushed', ['key' => $key, 'scene' => $this->sceneSnapshotValue($scene)]);
 		Dev::do('comprehension.holoscene.pushed', ['key' => $key, 'scene' => $scene]);
 	}
 
@@ -117,5 +117,26 @@ class Holoscene extends Obj
 		$this->summary($summary);
 
 		return $summary;
+	}
+
+	private function sceneSnapshotValue(mixed $scene): mixed
+	{
+		if (is_object($scene) && method_exists($scene, 'snapshot')) {
+			return $scene->snapshot();
+		}
+
+		if (is_object($scene) && method_exists($scene, 'toArray')) {
+			return $scene->toArray();
+		}
+
+		if (is_object($scene) && (method_exists($scene, 'data') || method_exists($scene, 'stats'))) {
+			return [
+				'kind' => 'scene',
+				'data' => method_exists($scene, 'data') ? $scene->data() : [],
+				'stats' => method_exists($scene, 'stats') ? $scene->stats() : [],
+			];
+		}
+
+		return $this->prototypeSnapshotValue($scene);
 	}
 }

--- a/src/Automata/Comprehension/Holoscene.php
+++ b/src/Automata/Comprehension/Holoscene.php
@@ -51,7 +51,7 @@ class Holoscene extends Obj
 		$this->protoId($name);
 		$this->domainName($name);
 		$this->summary("domain[{$name}]");
-        Dev::do('comprehension.holoscene.construct', ['collection' => $this->_holo]);
+		Dev::do('comprehension.holoscene.construct', ['collection' => $this->_holo]);
 	}
 
 	/**
@@ -62,11 +62,11 @@ class Holoscene extends Obj
 	 */
 	public function push(string $key, $scene): void
 	{
-        $scene = Dev::apply('comprehension.holoscene.push_scene', $scene);
+		$scene = Dev::apply('comprehension.holoscene.push_scene', $scene);
 		$this->_holo->add($scene, $key);
 		$this->addMember($scene, $key);
 		$this->record('scene_pushed', ['key' => $key]);
-        Dev::do('comprehension.holoscene.pushed', ['key' => $key, 'scene' => $scene]);
+		Dev::do('comprehension.holoscene.pushed', ['key' => $key, 'scene' => $scene]);
 	}
 
 	/**
@@ -78,16 +78,16 @@ class Holoscene extends Obj
 	 */
 	public function review(): void
 	{
-        Dev::do('comprehension.holoscene.review_start', ['collection' => $this->_holo]);
+		Dev::do('comprehension.holoscene.review_start', ['collection' => $this->_holo]);
 		$this->_assessment = $this->_holo->contents();
 		$this->domainState('assessment', $this->_assessment);
 		$this->measure('scene_count', Arr::size($this->_assessment));
-        Dev::do('comprehension.holoscene.reviewed', ['assessment' => $this->_assessment]);
+		Dev::do('comprehension.holoscene.reviewed', ['assessment' => $this->_assessment]);
 	}
 
 	public function assessment(): array
 	{
-        return Dev::apply('comprehension.holoscene.assessment', $this->_assessment);
+		return Dev::apply('comprehension.holoscene.assessment', $this->_assessment);
 	}
 
 	public function snapshot(): array

--- a/src/Automata/Comprehension/Holoscene.php
+++ b/src/Automata/Comprehension/Holoscene.php
@@ -16,14 +16,22 @@
 */
 namespace BlueFission\Automata\Comprehension;
 
-use BlueFission\Behavioral\Dispatches;
+use BlueFission\Arr;
 use BlueFission\Automata\Collections\OrganizedCollection;
-use BlueFission\Behavioral\IDispatcher;
+use BlueFission\Collections\Collection;
 use BlueFission\DevElation as Dev;
+use BlueFission\Obj;
+use BlueFission\Prototypes\Domain;
+use BlueFission\Prototypes\Proto;
+use BlueFission\Str;
 
-class Holoscene implements IDispatcher
+class Holoscene extends Obj
 {
-	use Dispatches;
+	use Proto {
+		explain as protected prototypeExplain;
+		snapshot as protected prototypeSnapshot;
+	}
+	use Domain;
 
 	/**
 	 * @var OrganizedCollection<string,mixed> Map of scene keys to scene-like objects
@@ -35,9 +43,14 @@ class Holoscene implements IDispatcher
 	 */
 	private array $_assessment = [];
 
-	public function __construct()
+	public function __construct(?string $name = null)
 	{
+		parent::__construct();
 		$this->_holo = new OrganizedCollection();
+		$name = Str::trim((string)($name ?? 'holoscene'));
+		$this->protoId($name);
+		$this->domainName($name);
+		$this->summary("domain[{$name}]");
         Dev::do('comprehension.holoscene.construct', ['collection' => $this->_holo]);
 	}
 
@@ -51,6 +64,8 @@ class Holoscene implements IDispatcher
 	{
         $scene = Dev::apply('comprehension.holoscene.push_scene', $scene);
 		$this->_holo->add($scene, $key);
+		$this->addMember($scene, $key);
+		$this->record('scene_pushed', ['key' => $key]);
         Dev::do('comprehension.holoscene.pushed', ['key' => $key, 'scene' => $scene]);
 	}
 
@@ -65,11 +80,42 @@ class Holoscene implements IDispatcher
 	{
         Dev::do('comprehension.holoscene.review_start', ['collection' => $this->_holo]);
 		$this->_assessment = $this->_holo->contents();
+		$this->domainState('assessment', $this->_assessment);
+		$this->measure('scene_count', Arr::size($this->_assessment));
         Dev::do('comprehension.holoscene.reviewed', ['assessment' => $this->_assessment]);
 	}
 
 	public function assessment(): array
 	{
         return Dev::apply('comprehension.holoscene.assessment', $this->_assessment);
+	}
+
+	public function snapshot(): array
+	{
+		$snapshot = $this->prototypeSnapshot();
+		$snapshot['kind'] = 'domain';
+		$snapshot['assessment'] = $this->assessment();
+		$snapshot['sceneCount'] = Arr::size($this->_holo->contents());
+		$snapshot['summary'] = $this->summary() ?: $this->explain();
+
+		return $snapshot;
+	}
+
+	public function explain(): string
+	{
+		$parts = [
+			'domain[' . ($this->protoId() ?: $this->domainName() ?: 'holoscene') . ']',
+			'name=' . ($this->domainName() ?: 'holoscene'),
+			'members=' . Arr::size($this->members()),
+			'assessment=' . Arr::size($this->assessment()),
+			'history=' . Arr::size($this->history()),
+		];
+
+		$summary = implode(' | ', (new Collection($parts))
+			->filter(fn ($part) => $part !== null && $part !== '')
+			->contents());
+		$this->summary($summary);
+
+		return $summary;
 	}
 }

--- a/src/Automata/Comprehension/Scene.php
+++ b/src/Automata/Comprehension/Scene.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Automata\Comprehension;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\Memory\IWorkingMemory;
 use BlueFission\Automata\Memory\IRecallScoringStrategy;
@@ -11,6 +12,8 @@ class Scene
 	private array $_frames = [];
 	private array $_stack = [];
 	private array $_groups = [];
+	private array $_relations = [];
+	private array $_frameEdges = [];
 
 	private float $_group_tolerance = 100;
 	private float $_variance_tolerance = 100;
@@ -21,6 +24,8 @@ class Scene
 	private array $_temporalEdges = [];
 
 	private IWorkingMemory $_memory;
+	private ?int $_startedAt = null;
+	private ?int $_endedAt = null;
 
 	public function __construct(IWorkingMemory $memory)
 	{
@@ -29,12 +34,21 @@ class Scene
 
 	public function addFrame(Frame $frame): void
 	{
-		if (count($this->_frames) >= $this->_buffer_size) {
+		if (Arr::size($this->_frames) >= $this->_buffer_size) {
 			array_shift($this->_frames); // Remove oldest frame
 		}
+
+		$frameIndex = Arr::size($this->_frames);
+		$timestamp = time();
+		if ($this->_startedAt === null) {
+			$this->_startedAt = $timestamp;
+		}
+
 		$this->_frames[] = $frame;
+		$this->_endedAt = $timestamp;
 
 		$entities = $frame->extract();
+		$this->trackFrameRelations($entities, $frameIndex, $timestamp);
 		$this->processEntities($entities);
 	}
 
@@ -62,7 +76,7 @@ class Scene
 	    $clusters = $this->clusterEntities($contextMap);
 
 	    foreach ($clusters as $clusterLabel => $contextGroup) {
-	        if (count($contextGroup) === 1) {
+	        if (Arr::size($contextGroup) === 1) {
 	            // Original logic: treat as a single memory
 	            $context = current($contextGroup);
 	            $this->_memory->addMemory($clusterLabel, $context);
@@ -130,7 +144,7 @@ class Scene
 	    $normA = 0.0;
 	    $normB = 0.0;
 
-	    $length = min(count($vec1), count($vec2));
+	    $length = min(Arr::size($vec1), Arr::size($vec2));
 	    for ($i = 0; $i < $length; $i++) {
 	        $dot += $vec1[$i] * $vec2[$i];
 	        $normA += $vec1[$i] ** 2;
@@ -144,7 +158,9 @@ class Scene
 
 	protected function generateGroupLabel(array $contexts): string
 	{
-		$labels = array_map(fn($ctx) => $ctx->get('label'), $contexts);
+		$labels = (new Collection($contexts))
+			->map(fn($ctx) => $ctx->get('label'))
+			->contents();
 		sort($labels);
 		return 'group_' . md5(implode('_', $labels));
 	}
@@ -164,8 +180,8 @@ class Scene
 	        $vectors[$label] = $this->hashContextVector($context);
 	    }
 
-	    $labels = array_keys($vectors);
-	    $count = count($labels);
+	    $labels = Arr::keys($vectors);
+	    $count = Arr::size($labels);
 
 	    for ($i = 0; $i < $count; $i++) {
 	        $labelA = $labels[$i];
@@ -201,7 +217,8 @@ class Scene
 	    $hashes = [];
 
 	    foreach ($data as $key => $value) {
-	        $scalar = is_scalar($value) ? (string)$value : json_encode($value);
+	        $normalized = $this->snapshotValue($value);
+	        $scalar = is_scalar($normalized) ? (string)$normalized : json_encode($normalized);
 	        $hashes[] = crc32((string)$key . ':' . $scalar) * 0.0000000001;
 	    }
 
@@ -226,11 +243,122 @@ class Scene
 
 	public function stats() 
 	{
-		return [];
+		return [
+			'frame_count' => Arr::size($this->_frames),
+			'group_count' => Arr::size($this->_groups),
+			'relation_count' => Arr::size($this->_relations),
+			'temporal_edge_count' => Arr::size($this->_frameEdges),
+			'started_at' => $this->_startedAt,
+			'ended_at' => $this->_endedAt,
+		];
 	}
 
 	public function data() 
 	{
-		return [];
+		$frames = [];
+		foreach ($this->_frames as $frame) {
+			$frames[] = $frame->extract();
+		}
+
+		$groups = [];
+		foreach ($this->_groups as $label => $contexts) {
+			$groups[$label] = [];
+			foreach ($contexts as $context) {
+				$groups[$label][] = $this->snapshotContext($context);
+			}
+		}
+
+		return [
+			'frames' => $frames,
+			'groups' => $groups,
+			'relations' => $this->_relations,
+			'temporal_edges' => $this->_frameEdges,
+		];
+	}
+
+	public function snapshot(): array
+	{
+		return [
+			'kind' => 'scene',
+			'stats' => $this->stats(),
+			'data' => $this->data(),
+		];
+	}
+
+	private function trackFrameRelations(array $entities, int $frameIndex, int $timestamp): void
+	{
+		if ($frameIndex > 0) {
+			$this->_frameEdges[] = [
+				'from' => $frameIndex - 1,
+				'to' => $frameIndex,
+				'timestamp' => $timestamp,
+			];
+		}
+
+		$subject = $entities['subject']['value'] ?? null;
+		$behavior = $entities['behavior']['value'] ?? null;
+		$object = $entities['object']['value'] ?? null;
+
+		if ($subject === null && $behavior === null && $object === null) {
+			return;
+		}
+
+		$this->_relations[] = [
+			'frame' => $frameIndex,
+			'timestamp' => $timestamp,
+			'subject' => $this->snapshotValue($subject),
+			'behavior' => $this->snapshotValue($behavior),
+			'object' => $this->snapshotValue($object),
+		];
+	}
+
+	private function snapshotContext(Context $context): array
+	{
+		$data = [];
+		foreach ($context->all() as $key => $value) {
+			$data[$key] = $this->snapshotValue($value);
+		}
+
+		return [
+			'data' => $data,
+			'tags' => $context->tags(),
+			'normalizations' => $context->normalizations(),
+		];
+	}
+
+	private function snapshotValue(mixed $value): mixed
+	{
+		if (Arr::is($value)) {
+			$normalized = [];
+			foreach (Arr::toArray($value) as $key => $item) {
+				$normalized[$key] = $this->snapshotValue($item);
+			}
+
+			return $normalized;
+		}
+
+		if ($value instanceof Context) {
+			return $this->snapshotContext($value);
+		}
+
+		if (is_object($value)) {
+			if (method_exists($value, 'snapshot')) {
+				return $value->snapshot();
+			}
+
+			if (method_exists($value, 'toArray')) {
+				return $value->toArray();
+			}
+
+			if (method_exists($value, 'all')) {
+				return $value->all();
+			}
+
+			if (method_exists($value, '__toString')) {
+				return (string)$value;
+			}
+		}
+
+		return $value;
 	}
 }

--- a/src/Automata/Language/Statement.php
+++ b/src/Automata/Language/Statement.php
@@ -1,10 +1,14 @@
 <?php
 namespace BlueFission\Automata\Language;
 
-// http://ogden.basic-english.org/verbs.html
-
-use BlueFission\Obj;
 use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Prototypes\HasConditions;
+use BlueFission\Prototypes\Position;
+use BlueFission\Prototypes\Proto;
+use BlueFission\Str;
 
 /*
 The intended meanings for vocalizations were grouped into six main categories: animate entities (child, man, woman, tiger, snake, deer), inanimate entities (knife, fire, rock, water, meat, fruit), actions (gather, cook, hide, cut, pound, hunt, eat, sleep), properties (dull, sharp, big, small, good, bad), quantifiers (one, many) and demonstratives (this, that).
@@ -13,6 +17,30 @@ https://www.livescience.com/iconic-vocalizations-lead-to-human-languages.html
 */
 
 class Statement extends Obj {
+	use Proto {
+		explain as protected prototypeExplain;
+		snapshot as protected prototypeSnapshot;
+	}
+	use Position;
+	use HasConditions {
+		normalizeConditionRecord as protected prototypeNormalizeConditionRecord;
+	}
+
+	private const SEMANTIC_FIELDS = [
+		'type',
+		'context',
+		'priority',
+		'subject',
+		'negation',
+		'modality',
+		'behavior',
+		'condition',
+		'object',
+		'relationship',
+		'indirect_object',
+		'position',
+	];
+
 	protected $_data = [
 		'type'=>1, // interogative, imperative, declarative
 		'context'=>'',
@@ -28,34 +56,205 @@ class Statement extends Obj {
 		'position'=>''
 	];
 
+	public function __construct()
+	{
+		parent::__construct();
+		$this->protoId('statement_' . uniqid());
+		$this->kind('statement');
+		$this->syncPrototypeState();
+	}
+
 	public function field( string $field, $value = null ): mixed
 	{
-		return parent::field($field, $value);
+		$result = parent::field($field, $value);
+
+		if (func_num_args() > 1) {
+			$this->syncPrototypeState();
+		}
+
+		return $result;
 	}
 
 	public function percentSatisfied() {
-		$parts = Arr::size($this->_data);
+		$parts = Arr::size(self::SEMANTIC_FIELDS);
 		$satisfied = 0;
-		foreach ( $this->_data as $part=>$value ) {
-			if ( $value ) {
+		foreach ( self::SEMANTIC_FIELDS as $part ) {
+			if ( $this->isSatisfiedFieldValue($this->field($part)) ) {
 				$satisfied++;
 			}
 		}
-		return $satisfied / $parts;
+		return (float)Num::divide($satisfied, $parts);
 	}
 
 	public function satisfy() {
-		foreach ( $this->_data as $part=>$value ) {
-			if ( !$value ) {
+		foreach ( self::SEMANTIC_FIELDS as $part ) {
+			if ( !$this->isSatisfiedFieldValue($this->field($part)) ) {
 				return "{$part}";
-				// return "? {$part}".PHP_EOL;
 			}
-			return null;
 		}
+
+		return null;
 	}
 
 	public function entities() {
-		$entities = Arr::merge($this->subject, $this->object, $this->indirect_object );
-		return $entities;
+		return (new Collection([
+			$this->field('subject'),
+			$this->field('object'),
+			$this->field('indirect_object'),
+		]))
+			->filter(fn ($entity) => $entity !== null && $entity !== '')
+			->contents();
+	}
+
+	public function snapshot(): array
+	{
+		$snapshot = $this->prototypeSnapshot();
+		foreach (self::SEMANTIC_FIELDS as $field) {
+			$snapshot[$field] = $this->field($field);
+		}
+		$snapshot['kind'] = 'statement';
+		$snapshot['entities'] = $this->entities();
+		$snapshot['percentSatisfied'] = $this->percentSatisfied();
+		$snapshot['summary'] = $this->summary() ?: $this->explain();
+
+		return $snapshot;
+	}
+
+	public function explain(): string
+	{
+		$parts = [
+			'statement[' . ($this->protoId() ?: 'unidentified') . ']',
+			$this->field('subject'),
+			$this->field('behavior'),
+			$this->field('object'),
+			'satisfied=' . $this->percentSatisfied(),
+			'conditions=' . Arr::size($this->conditions()),
+			'relations=' . Arr::size($this->relations()),
+		];
+
+		$summary = implode(' | ', (new Collection($parts))
+			->filter(fn ($part) => $part !== null && $part !== '')
+			->contents());
+		$this->summary($summary);
+
+		return $summary;
+	}
+
+	private function syncPrototypeState(): void
+	{
+		$this->kind('statement');
+		$this->properties([]);
+		$this->stateValue('statement', []);
+
+		$state = [];
+		foreach (self::SEMANTIC_FIELDS as $field) {
+			$value = $this->field($field);
+			$state[$field] = $value;
+			$this->property($field, $value);
+		}
+
+		$this->stateValue('statement', $state);
+		$this->name($this->statementName());
+		$this->labels($this->statementLabels());
+		$this->prototypeSet('relations', [], 'automata.language.statement.relations_reset');
+		$this->prototypeSet('conditions', [], 'automata.language.statement.conditions_reset');
+		$this->syncRelationshipPrototype();
+		$this->syncConditionPrototype();
+		$this->syncPositionPrototype();
+	}
+
+	private function syncRelationshipPrototype(): void
+	{
+		$relationship = Str::trim((string)$this->field('relationship'));
+		$object = $this->field('object');
+
+		if ($object === null || $object === '') {
+			return;
+		}
+
+		$this->relate($relationship !== '' ? $relationship : 'object', $object, [
+			'subject' => $this->field('subject'),
+			'indirect_object' => $this->field('indirect_object'),
+		]);
+	}
+
+	private function syncConditionPrototype(): void
+	{
+		$condition = $this->field('condition');
+		if ($condition === null || $condition === '') {
+			return;
+		}
+
+		$this->addCondition($this->prototypeNormalizeConditionRecord([
+			'name' => 'statement_condition',
+			'path' => (string)$condition,
+			'expected' => true,
+			'operator' => 'requires',
+		]));
+	}
+
+	private function syncPositionPrototype(): void
+	{
+		$position = $this->field('position');
+		$this->prototypeSet('coordinates', [], 'automata.language.statement.coordinates_reset');
+
+		if (is_array($position)) {
+			foreach ($position as $dimension => $value) {
+				$this->defineDimension((string)$dimension);
+				$this->coordinate((string)$dimension, $value);
+			}
+			$this->position($this->coordinates());
+			return;
+		}
+
+		if ($position !== null && $position !== '') {
+			$this->defineDimension('position');
+			$this->coordinate('position', $position);
+			$this->position($this->coordinates());
+			return;
+		}
+
+		$this->position([]);
+	}
+
+	private function statementName(): string
+	{
+		$parts = (new Collection([
+			$this->field('subject'),
+			$this->field('behavior'),
+			$this->field('object'),
+		]))
+			->filter(fn ($part) => $part !== null && $part !== '')
+			->contents();
+
+		return implode(' ', $parts);
+	}
+
+	private function statementLabels(): array
+	{
+		return (new Collection([
+			Str::trim((string)$this->field('context')),
+			Str::trim((string)$this->field('modality')),
+			Str::trim((string)$this->field('relationship')),
+		]))
+			->filter(fn ($label) => $label !== '')
+			->contents();
+	}
+
+	private function isSatisfiedFieldValue(mixed $value): bool
+	{
+		if (is_array($value)) {
+			return Arr::size($value) > 0;
+		}
+
+		if (is_bool($value)) {
+			return $value;
+		}
+
+		if (is_numeric($value)) {
+			return true;
+		}
+
+		return Str::trim((string)$value) !== '';
 	}
 }

--- a/src/Automata/Language/Statement.php
+++ b/src/Automata/Language/Statement.php
@@ -3,6 +3,7 @@ namespace BlueFission\Automata\Language;
 
 use BlueFission\Arr;
 use BlueFission\Collections\Collection;
+use BlueFission\Flag;
 use BlueFission\Num;
 use BlueFission\Obj;
 use BlueFission\Prototypes\HasConditions;
@@ -59,7 +60,7 @@ class Statement extends Obj {
 	public function __construct()
 	{
 		parent::__construct();
-		$this->protoId('statement_' . uniqid());
+		$this->protoId('statement_' . Str::uuid4());
 		$this->kind('statement');
 		$this->syncPrototypeState();
 	}
@@ -198,7 +199,7 @@ class Statement extends Obj {
 		$position = $this->field('position');
 		$this->prototypeSet('coordinates', [], 'automata.language.statement.coordinates_reset');
 
-		if (is_array($position)) {
+		if (Arr::is($position)) {
 			foreach ($position as $dimension => $value) {
 				$this->defineDimension((string)$dimension);
 				$this->coordinate((string)$dimension, $value);
@@ -243,15 +244,15 @@ class Statement extends Obj {
 
 	private function isSatisfiedFieldValue(mixed $value): bool
 	{
-		if (is_array($value)) {
+		if (Arr::is($value)) {
 			return Arr::size($value) > 0;
 		}
 
-		if (is_bool($value)) {
-			return $value;
+		if (Flag::isTrue($value) || Flag::isFalse($value)) {
+			return Flag::isTrue($value);
 		}
 
-		if (is_numeric($value)) {
+		if (Num::is($value)) {
 			return true;
 		}
 

--- a/src/Automata/Language/Statement.php
+++ b/src/Automata/Language/Statement.php
@@ -2,6 +2,8 @@
 namespace BlueFission\Automata\Language;
 
 use BlueFission\Arr;
+use BlueFission\Automata\Comprehension\Entity as ComprehensionEntity;
+use BlueFission\Automata\Context;
 use BlueFission\Collections\Collection;
 use BlueFission\Flag;
 use BlueFission\Num;
@@ -42,6 +44,21 @@ class Statement extends Obj {
 		'position',
 	];
 
+	private const SATISFACTION_WEIGHTS = [
+		'type' => 0.05,
+		'context' => 0.025,
+		'priority' => 0.0,
+		'subject' => 0.25,
+		'negation' => 0.05,
+		'modality' => 0.025,
+		'behavior' => 0.25,
+		'condition' => 0.05,
+		'object' => 0.2,
+		'relationship' => 0.05,
+		'indirect_object' => 0.05,
+		'position' => 0.05,
+	];
+
 	protected $_data = [
 		'type'=>1, // interogative, imperative, declarative
 		'context'=>'',
@@ -67,28 +84,30 @@ class Statement extends Obj {
 
 	public function field( string $field, $value = null ): mixed
 	{
-		$result = parent::field($field, $value);
-
 		if (func_num_args() > 1) {
+			$this->_data[$field] = $this->normalizeSemanticFieldValue($field, $value);
 			$this->syncPrototypeState();
+
+			return $this;
 		}
 
-		return $result;
+		return parent::field($field);
 	}
 
 	public function percentSatisfied() {
-		$parts = Arr::size(self::SEMANTIC_FIELDS);
-		$satisfied = 0;
+		$score = 0.0;
+
 		foreach ( self::SEMANTIC_FIELDS as $part ) {
 			if ( $this->isSatisfiedFieldValue($this->field($part)) ) {
-				$satisfied++;
+				$score = Num::add($score, self::SATISFACTION_WEIGHTS[$part] ?? 0.0);
 			}
 		}
-		return (float)Num::divide($satisfied, $parts);
+
+		return (float)Num::min(1.0, $score);
 	}
 
 	public function satisfy() {
-		foreach ( self::SEMANTIC_FIELDS as $part ) {
+		foreach ( $this->requiredFields() as $part ) {
 			if ( !$this->isSatisfiedFieldValue($this->field($part)) ) {
 				return "{$part}";
 			}
@@ -111,10 +130,12 @@ class Statement extends Obj {
 	{
 		$snapshot = $this->prototypeSnapshot();
 		foreach (self::SEMANTIC_FIELDS as $field) {
-			$snapshot[$field] = $this->field($field);
+			$snapshot[$field] = $this->semanticPrototypeValue($this->field($field));
 		}
 		$snapshot['kind'] = 'statement';
-		$snapshot['entities'] = $this->entities();
+		$snapshot['entities'] = (new Collection($this->entities()))
+			->map(fn ($entity) => $this->semanticPrototypeValue($entity))
+			->contents();
 		$snapshot['percentSatisfied'] = $this->percentSatisfied();
 		$snapshot['summary'] = $this->summary() ?: $this->explain();
 
@@ -125,9 +146,9 @@ class Statement extends Obj {
 	{
 		$parts = [
 			'statement[' . ($this->protoId() ?: 'unidentified') . ']',
-			$this->field('subject'),
-			$this->field('behavior'),
-			$this->field('object'),
+			$this->semanticTextValue($this->field('subject')),
+			$this->semanticTextValue($this->field('behavior')),
+			$this->semanticTextValue($this->field('object')),
 			'satisfied=' . $this->percentSatisfied(),
 			'conditions=' . Arr::size($this->conditions()),
 			'relations=' . Arr::size($this->relations()),
@@ -150,8 +171,8 @@ class Statement extends Obj {
 		$state = [];
 		foreach (self::SEMANTIC_FIELDS as $field) {
 			$value = $this->field($field);
-			$state[$field] = $value;
-			$this->property($field, $value);
+			$state[$field] = $this->semanticPrototypeValue($value);
+			$this->property($field, $state[$field]);
 		}
 
 		$this->stateValue('statement', $state);
@@ -166,29 +187,47 @@ class Statement extends Obj {
 
 	private function syncRelationshipPrototype(): void
 	{
-		$relationship = Str::trim((string)$this->field('relationship'));
+		$relationship = $this->semanticTextValue($this->field('relationship'));
 		$object = $this->field('object');
 
-		if ($object === null || $object === '') {
+		if (!$this->isSatisfiedFieldValue($object)) {
 			return;
 		}
 
-		$this->relate($relationship !== '' ? $relationship : 'object', $object, [
-			'subject' => $this->field('subject'),
-			'indirect_object' => $this->field('indirect_object'),
+		$this->relate($relationship ?: 'object', $this->semanticPrototypeValue($object), [
+			'subject' => $this->semanticPrototypeValue($this->field('subject')),
+			'indirect_object' => $this->semanticPrototypeValue($this->field('indirect_object')),
+			'context' => $this->semanticPrototypeValue($this->field('context')),
 		]);
 	}
 
 	private function syncConditionPrototype(): void
 	{
 		$condition = $this->field('condition');
-		if ($condition === null || $condition === '') {
+		if (!$this->isSatisfiedFieldValue($condition)) {
+			return;
+		}
+
+		if (Arr::is($condition) || is_callable($condition)) {
+			$this->addCondition($this->prototypeNormalizeConditionRecord($condition));
+			return;
+		}
+
+		if (is_object($condition) && method_exists($condition, 'conditions')) {
+			foreach ($condition->conditions() as $record) {
+				$this->addCondition($this->prototypeNormalizeConditionRecord($record));
+			}
+			return;
+		}
+
+		$conditionText = $this->semanticTextValue($condition);
+		if ($conditionText === null || $conditionText === '') {
 			return;
 		}
 
 		$this->addCondition($this->prototypeNormalizeConditionRecord([
 			'name' => 'statement_condition',
-			'path' => (string)$condition,
+			'path' => $conditionText,
 			'expected' => true,
 			'operator' => 'requires',
 		]));
@@ -196,10 +235,11 @@ class Statement extends Obj {
 
 	private function syncPositionPrototype(): void
 	{
-		$position = $this->field('position');
+		$position = $this->semanticPositionPayload($this->field('position'));
+		$this->prototypeSet('dimensions', [], 'automata.language.statement.dimensions_reset');
 		$this->prototypeSet('coordinates', [], 'automata.language.statement.coordinates_reset');
 
-		if (Arr::is($position)) {
+		if (Arr::is($position) && Arr::size($position) > 0) {
 			foreach ($position as $dimension => $value) {
 				$this->defineDimension((string)$dimension);
 				$this->coordinate((string)$dimension, $value);
@@ -221,9 +261,9 @@ class Statement extends Obj {
 	private function statementName(): string
 	{
 		$parts = (new Collection([
-			$this->field('subject'),
-			$this->field('behavior'),
-			$this->field('object'),
+			$this->semanticTextValue($this->field('subject')),
+			$this->semanticTextValue($this->field('behavior')),
+			$this->semanticTextValue($this->field('object')),
 		]))
 			->filter(fn ($part) => $part !== null && $part !== '')
 			->contents();
@@ -234,18 +274,30 @@ class Statement extends Obj {
 	private function statementLabels(): array
 	{
 		return (new Collection([
-			Str::trim((string)$this->field('context')),
-			Str::trim((string)$this->field('modality')),
-			Str::trim((string)$this->field('relationship')),
+			...$this->semanticLabels($this->field('context')),
+			...$this->semanticLabels($this->field('modality')),
+			...$this->semanticLabels($this->field('relationship')),
 		]))
-			->filter(fn ($label) => $label !== '')
+			->filter(fn ($label) => Str::trim((string)$label) !== '')
 			->contents();
 	}
 
 	private function isSatisfiedFieldValue(mixed $value): bool
 	{
+		if ($value instanceof Context) {
+			return Arr::size($value->all()) > 0
+				|| Arr::size($value->tags()) > 0
+				|| Arr::size($value->normalizations()) > 0;
+		}
+
 		if (Arr::is($value)) {
 			return Arr::size($value) > 0;
+		}
+
+		if (is_object($value)) {
+			return $this->semanticTextValue($value) !== null
+				|| Arr::size($this->semanticPositionPayload($value)) > 0
+				|| $this->semanticPrototypeValue($value) !== $value;
 		}
 
 		if (Flag::isTrue($value) || Flag::isFalse($value)) {
@@ -257,5 +309,161 @@ class Statement extends Obj {
 		}
 
 		return Str::trim((string)$value) !== '';
+	}
+
+	private function requiredFields(): array
+	{
+		return [
+			'subject',
+			'behavior',
+			'object',
+		];
+	}
+
+	private function normalizeSemanticFieldValue(string $field, mixed $value): mixed
+	{
+		if (Arr::contains(['subject', 'object', 'indirect_object'], $field, true) && Arr::isAssoc($value)) {
+			$name = $value['name'] ?? $value['value'] ?? $value['label'] ?? null;
+			if ($name !== null) {
+				return new ComprehensionEntity(
+					(string)$name,
+					isset($value['description']) ? (string)$value['description'] : null,
+					$value['meta'] ?? $value
+				);
+			}
+		}
+
+		if ($field === 'context' && Arr::isAssoc($value)) {
+			return new Context($value);
+		}
+
+		return $value;
+	}
+
+	private function semanticPrototypeValue(mixed $value): mixed
+	{
+		if ($value instanceof Context) {
+			return [
+				'data' => $value->all(),
+				'tags' => $value->tags(),
+				'normalizations' => $value->normalizations(),
+			];
+		}
+
+		if (is_object($value) && method_exists($value, 'all')) {
+			return $value->all();
+		}
+
+		if (is_object($value) && method_exists($value, 'coordinates')) {
+			$coordinates = $value->coordinates();
+			if (Arr::is($coordinates) && Arr::size($coordinates) > 0) {
+				return [
+					'coordinates' => $coordinates,
+					'name' => $this->semanticTextValue($value),
+				];
+			}
+		}
+
+		return $this->prototypeSnapshotValue($value);
+	}
+
+	private function semanticTextValue(mixed $value): ?string
+	{
+		if ($value instanceof Context) {
+			$candidate = $value->normalizedValue('label')
+				?? $value->get('label')
+				?? $value->normalizedValue('value')
+				?? $value->get('value');
+
+			if ($candidate !== null) {
+				$candidate = Str::trim((string)$candidate);
+				return $candidate === '' ? null : $candidate;
+			}
+
+			return null;
+		}
+
+		if (is_object($value) && method_exists($value, 'name')) {
+			$candidate = Str::trim((string)$value->name());
+			return $candidate === '' ? null : $candidate;
+		}
+
+		if (is_object($value) && method_exists($value, 'protoId')) {
+			$candidate = Str::trim((string)$value->protoId());
+			return $candidate === '' ? null : $candidate;
+		}
+
+		if (is_object($value) && method_exists($value, '__toString')) {
+			$candidate = Str::trim((string)$value);
+			return $candidate === '' ? null : $candidate;
+		}
+
+		if (is_object($value)) {
+			return null;
+		}
+
+		if ($value === null) {
+			return null;
+		}
+
+		$candidate = Str::trim((string)$value);
+		return $candidate === '' ? null : $candidate;
+	}
+
+	private function semanticLabels(mixed $value): array
+	{
+		if ($value instanceof Context) {
+			return (new Collection([
+				$value->get('label'),
+				$value->normalizedValue('label'),
+				...Arr::keys($value->tags()),
+				...Arr::keys($value->normalizations()),
+			]))
+				->filter(fn ($label) => $label !== null && Str::trim((string)$label) !== '')
+				->map(fn ($label) => Str::trim((string)$label))
+				->contents();
+		}
+
+		if (is_object($value) && method_exists($value, 'labels')) {
+			return (new Collection($value->labels()))
+				->filter(fn ($label) => $label !== null && Str::trim((string)$label) !== '')
+				->map(fn ($label) => Str::trim((string)$label))
+				->contents();
+		}
+
+		$label = $this->semanticTextValue($value);
+
+		return $label === null ? [] : [$label];
+	}
+
+	private function semanticPositionPayload(mixed $position): array
+	{
+		if (Arr::is($position)) {
+			return Arr::toArray($position);
+		}
+
+		if (is_object($position) && method_exists($position, 'coordinates')) {
+			$coordinates = $position->coordinates();
+			return Arr::is($coordinates) ? Arr::toArray($coordinates) : [];
+		}
+
+		if (is_object($position) && method_exists($position, 'position')) {
+			$payload = $position->position();
+			return Arr::is($payload) ? Arr::toArray($payload) : [];
+		}
+
+		if (is_object($position) && method_exists($position, 'snapshot')) {
+			$snapshot = $position->snapshot();
+			if (Arr::isAssoc($snapshot)) {
+				$coordinates = $snapshot['coordinates'] ?? $snapshot['position'] ?? null;
+				return Arr::is($coordinates) ? Arr::toArray($coordinates) : [];
+			}
+		}
+
+		if ($position !== null && $position !== '') {
+			return ['position' => $position];
+		}
+
+		return [];
 	}
 }

--- a/tests/Automata/Comprehension/HolosceneTest.php
+++ b/tests/Automata/Comprehension/HolosceneTest.php
@@ -38,6 +38,9 @@ class HolosceneTest extends TestCase
 
         $this->assertSame($sceneA, $assessment['episode_a']['value']);
         $this->assertSame($sceneB, $assessment['episode_b']['value']);
+        $this->assertSame('holoscene', $holoscene->domainName());
+        $this->assertCount(2, $holoscene->members());
+        $this->assertSame(2, $holoscene->snapshot()['sceneCount']);
     }
 }
 

--- a/tests/Automata/Comprehension/HolosceneTest.php
+++ b/tests/Automata/Comprehension/HolosceneTest.php
@@ -41,6 +41,9 @@ class HolosceneTest extends TestCase
         $this->assertSame('holoscene', $holoscene->domainName());
         $this->assertCount(2, $holoscene->members());
         $this->assertSame(2, $holoscene->snapshot()['sceneCount']);
+        $this->assertIsArray($holoscene->members()['episode_a']);
+        $this->assertSame('scene', $holoscene->members()['episode_a']['kind']);
+        $this->assertSame(['summary' => 'test'], $holoscene->members()['episode_a']['data']);
     }
 }
 

--- a/tests/Automata/Language/ReaderTest.php
+++ b/tests/Automata/Language/ReaderTest.php
@@ -105,6 +105,8 @@ class ReaderTest extends TestCase
         $scene = $sceneEntry['value'] ?? null;
 
         $this->assertNotNull($scene);
+        $this->assertSame('scene', $holoscene->members()['episode_language_reader']['kind']);
+        $this->assertNotEmpty($holoscene->members()['episode_language_reader']['data']['relations']);
 
         $frames = $scene->frames();
         $this->assertNotEmpty($frames);

--- a/tests/Automata/Language/StatementTest.php
+++ b/tests/Automata/Language/StatementTest.php
@@ -32,4 +32,24 @@ class StatementTest extends TestCase
 
         $this->assertNotEmpty($entities);
     }
+
+    public function testStatementSnapshotProjectsPrototypeState(): void
+    {
+        $statement = new Statement();
+        $statement->field('subject', 'HospitalA');
+        $statement->field('behavior', 'requests');
+        $statement->field('object', 'oxygen');
+        $statement->field('relationship', 'needs');
+        $statement->field('condition', 'critical_supply');
+        $statement->field('position', ['x' => 12, 'y' => 4]);
+
+        $snapshot = $statement->snapshot();
+
+        $this->assertSame('statement', $snapshot['kind']);
+        $this->assertSame('HospitalA requests oxygen', $snapshot['name']);
+        $this->assertNotEmpty($snapshot['relations']);
+        $this->assertNotEmpty($snapshot['conditions']);
+        $this->assertSame(12, $snapshot['coordinates']['x']);
+        $this->assertSame(4, $snapshot['coordinates']['y']);
+    }
 }

--- a/tests/Automata/Language/StatementTest.php
+++ b/tests/Automata/Language/StatementTest.php
@@ -3,6 +3,8 @@
 namespace BlueFission\Tests\Automata\Language;
 
 use PHPUnit\Framework\TestCase;
+use BlueFission\Automata\Comprehension\Entity;
+use BlueFission\Automata\Context;
 use BlueFission\Automata\Language\Statement;
 
 class StatementTest extends TestCase
@@ -51,5 +53,55 @@ class StatementTest extends TestCase
         $this->assertNotEmpty($snapshot['conditions']);
         $this->assertSame(12, $snapshot['coordinates']['x']);
         $this->assertSame(4, $snapshot['coordinates']['y']);
+    }
+
+    public function testStatementAcceptsContextAndEntityObjects(): void
+    {
+        $statement = new Statement();
+        $statement->field('context', (new Context(['topic' => 'triage']))->addTag('emergency'));
+        $statement->field('subject', new Entity('Hospital A', 'Regional hospital'));
+        $statement->field('behavior', 'requests');
+        $statement->field('object', new Entity('Oxygen', 'Critical supply'));
+
+        $snapshot = $statement->snapshot();
+
+        $this->assertSame('Hospital A requests Oxygen', $snapshot['name']);
+        $this->assertContains('emergency', $snapshot['labels']);
+        $this->assertSame('Hospital A', $snapshot['subject']['name']);
+        $this->assertSame('triage', $snapshot['context']['data']['topic']);
+        $this->assertStringContainsString('Hospital A', $snapshot['summary']);
+    }
+
+    public function testStatementAcceptsPositionLikeObjects(): void
+    {
+        $statement = new Statement();
+        $statement->field('subject', 'Vehicle 1');
+        $statement->field('behavior', 'travels');
+        $statement->field('object', 'Depot');
+        $statement->field('position', new class {
+            public function coordinates(): array
+            {
+                return ['x' => 3, 'y' => 4];
+            }
+        });
+
+        $snapshot = $statement->snapshot();
+
+        $this->assertSame(3, $snapshot['coordinates']['x']);
+        $this->assertSame(4, $snapshot['coordinates']['y']);
+    }
+
+    public function testStatementSatisfyFocusesOnCoreClauseCompletion(): void
+    {
+        $statement = new Statement();
+        $statement->field('subject', 'HospitalA');
+        $statement->field('behavior', 'requests');
+
+        $this->assertSame('object', $statement->satisfy());
+
+        $statement->field('object', 'oxygen');
+
+        $this->assertNull($statement->satisfy());
+        $this->assertGreaterThanOrEqual(0.7, $statement->percentSatisfied());
     }
 }


### PR DESCRIPTION
Intent summary

- Extend DevElation prototype usage into `Comprehension\Holoscene` and `Language\Statement`.
- Keep the adoption practical: `Holoscene` becomes a prototype-backed domain carrier, while `Statement` becomes a prototype-backed semantic carrier with condition and position support.
- Prefer DevElation primitives over vanilla helpers in the touched carrier classes where it is functionally justified.

User stories / acceptance criteria

- As an Automata integrator, I can treat `Holoscene` as a shared domain/world-model carrier with members, assessment state, history, and snapshot/explain semantics.
- As an Automata integrator, I can treat `Statement` as a prototype-backed semantic object with stable snapshot/explain output, relations, conditions, and position metadata.
- As a downstream comprehension/language consumer, existing reader and walker flows continue to work while exposing richer shared semantics.
- As a maintainer, touched classes prefer DevElation primitives and prototype traits over bespoke contracts where it is functionally justified.

Issues addressed

- Closes #13

Key files changed

- `src/Automata/Comprehension/Holoscene.php`
- `src/Automata/Language/Statement.php`
- `tests/Automata/Comprehension/HolosceneTest.php`
- `tests/Automata/Language/StatementTest.php`
- `ARCHITECTURE.md`

How to test

- `php D:\projects\chat\intelligence\vendor\bin\phpunit --do-not-cache-result tests/Automata/Comprehension/HolosceneTest.php tests/Automata/Comprehension/HolosceneLogTest.php tests/Automata/Language/StatementTest.php tests/Automata/Language/ReaderTest.php tests/Automata/Language/WalkerTest.php tests/Automata/Language/WalkerBehaviorTest.php`

Run that from:
- `D:\projects\chat\intelligence\.worktrees\feature-13-prototype-holoscene-and-statement`

QA checklist

- [x] Holoscene tests pass
- [x] Statement tests pass
- [x] Reader/Walker language flow tests pass
- [x] Architectural notes updated

Approval conditions

- Human review that `Holoscene` should be treated as a prototype-backed domain carrier rather than a lighter collection-only container
- Human review that `Statement` uses only the prototype traits that are functionally justified
- Human review of the remaining vanilla-helper surface in adjacent legacy language/comprehension classes
