### PR TITLE
Define Automata integration contract for JenSS and linqr

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Media Ingestion**: Normalize text, image, audio, video, document, and URL inputs into consistent pipelines.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
-- **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, orchestration patterns, DevElation-backed agent state/goal decisions, and interpreter-facing integration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
+- **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, Holoscene comprehension, orchestration patterns, DevElation-backed agent state/goal decisions, and interpreter-facing integration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
 - **Feature Engineering**: Provides robust tools for transforming raw data into features that better represent the underlying processes to predictive models.
 - **Data Science**: Basic machine learning functionalities alongside data manipulation, preparation, and visualization tools.
 - **Input Management**: Sophisticated input type detection and handling, ensuring that data flows seamlessly through processing pipelines.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Media Ingestion**: Normalize text, image, audio, video, document, and URL inputs into consistent pipelines.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
-- **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, orchestration patterns, and DevElation-backed agent state/goal decisions around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
+- **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, orchestration patterns, DevElation-backed agent state/goal decisions, and interpreter-facing integration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
 - **Feature Engineering**: Provides robust tools for transforming raw data into features that better represent the underlying processes to predictive models.
 - **Data Science**: Basic machine learning functionalities alongside data manipulation, preparation, and visualization tools.
 - **Input Management**: Sophisticated input type detection and handling, ensuring that data flows seamlessly through processing pipelines.

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -2,6 +2,8 @@
 
 Automata agents treat language models as reasoning components and keep execution in deterministic PHP boundaries. The `BlueFission\Automata\LLM\Agent` class coordinates model prompts, registered tools, lifecycle hooks, and later memory or orchestration layers without requiring external agent harnesses.
 
+`Agent` is also a DevElation prototype carrier: it extends `Obj` and uses the shared `Proto` and `Prototypes\Agent` traits. That gives interpreter adapters a consistent way to inspect agent role, scope, autonomy, control, goals, strategies, decision history, and snapshot metadata without inventing a parallel identity structure. Automata-specific runtime work still lives in the Agent, session, tool, governance, memory, orchestration, state, and telemetry classes below.
+
 ## Tool Contracts
 
 Tools are registered through `ToolCatalog` and described by `ToolDefinition`. A definition is a DevElation-configurable contract with:

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -91,6 +91,23 @@ Goal reasoning lives in Automata's `Goal` namespace instead of inside the cognit
 
 The default classes are dependency-injection examples as much as concrete implementations. `GoalManager` implements `IGoalManager` and uses `ManagesGoals`; custom managers can implement the same interface and import the trait when they only need to adjust persistence, weighting, or constructor policy. `CognitiveController` implements `IStateController` and uses `ControlsAgentState`; custom controllers can import that trait to keep the standard bottleneck, goal recommendation, and state-write behavior while overriding only the decision context or option selection. `AgentState` accepts an `IGoalManager`, and `Agent::setCognitiveController()` accepts an `IStateController`, so applications can swap either side through normal dependency injection.
 
+## Interpreter Integration Contract
+
+`AgentIntegrationContract` exposes Automata's stable agent feature surface as deterministic metadata for JenSS, Jenerator, Chainlinq, and linqr adapters. It does not execute tools or prompts. Instead, it names the supported feature ids, owning classes, lifecycle hooks, tool catalog filter constants, language binding hints, and production acceptance checks that downstream runtimes can use to generate syntax bindings and conformance fixtures.
+
+The first contract version covers:
+
+- agent runtime configuration and execution
+- tool contracts, catalog filtering, and structured results
+- lifecycle hooks for deterministic adapter behavior
+- session scope, permissions, context, and working memory
+- governance, human review, MCP/RPC/API task-call monitoring
+- orchestration patterns, nested orchestrations, and PIANO flows
+- behavioral state, goals, criteria, expectations, and bounded decisions
+- CPCT telemetry and runtime security validation
+
+Adapters should bind to the contract's feature ids rather than hard-coding prompt text or concrete class internals. For example, JenSS can map a `tool` construct to `agent.tool_contracts`, while linqr can map query catalog retrieval to the same feature through `query.tool_catalog`. This keeps syntax design in JenSS and linqr while Automata owns the runtime contract.
+
 ## Integration Notes
 
 Prefer DevElation helpers for value, array, collection, and configuration behavior when extending these classes. Keep tool implementations thin and reusable; put selection guidance in `ToolDefinition`, execution behavior in the tool, and lifecycle side effects behind hooks.

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -75,7 +75,7 @@ The monitor emits lifecycle hooks, applies policy, asks for review when configur
 
 `AgentSession` is the boundary for shared scope. An agent can keep its own prompt context, while the session decides what context, permissions, tools, uploaded inputs, working memory, and Holoscene episodes are available to one or more agents. The session can attach an Automata `IWorkingMemory` implementation, including `Abs2Memory`, so durable memory and Holoscene-compatible working-memory implementations are reached through existing Automata contracts instead of a separate memory silo.
 
-Sessions can also attach a `Holoscene` directly. This lets interpreter adapters project sensory data, statements, scenes, and narrative episodes into the comprehension layer while still keeping access scoped by the session. Agents expose that Holoscene through prototype metadata by `holoscene_id`, so downstream runtimes can inspect the association without forcing raw scene data into prompt context.
+Sessions can also attach a `Holoscene` directly. This lets interpreter adapters project sensory data, statements, scenes, and narrative episodes into the comprehension layer while still keeping access scoped by the session. Agents expose that Holoscene through prototype metadata by `holoscene_id`, so adapter runtimes can inspect the association without forcing raw scene data into prompt context.
 
 Lifecycle memory logging is intentionally tied to `AgentHook` names rather than memory-specific hook constants. Memory event stores persist hook activity, but the lifecycle belongs to the agent. `InMemoryEventStore` is process-local for tests and short runs. `FileMemoryEventStore` uses DevElation `Disk` storage through `StorageMemoryEventStore`, so applications can replace the storage adapter with another DevElation storage implementation without overriding file and JSON logic.
 
@@ -95,9 +95,9 @@ Goal reasoning lives in Automata's `Goal` namespace instead of inside the cognit
 
 The default classes are dependency-injection examples as much as concrete implementations. `GoalManager` implements `IGoalManager` and uses `ManagesGoals`; custom managers can implement the same interface and import the trait when they only need to adjust persistence, weighting, or constructor policy. `CognitiveController` implements `IStateController` and uses `ControlsAgentState`; custom controllers can import that trait to keep the standard bottleneck, goal recommendation, and state-write behavior while overriding only the decision context or option selection. `AgentState` accepts an `IGoalManager`, and `Agent::setCognitiveController()` accepts an `IStateController`, so applications can swap either side through normal dependency injection.
 
-## Interpreter Integration Contract
+## Integration Contract Template
 
-`AgentIntegrationContract` exposes Automata's stable agent feature surface as deterministic metadata for JenSS, Jenerator, Chainlinq, and linqr adapters. It does not execute tools or prompts. Instead, it names the supported feature ids, owning classes, lifecycle hooks, tool catalog filter constants, language binding hints, and production acceptance checks that downstream runtimes can use to generate syntax bindings and conformance fixtures.
+`AgentIntegrationContract` exposes Automata's stable agent feature surface as deterministic metadata for external adapters. It does not execute tools or prompts, and it does not know which descendant or application library will consume it. Instead, it names supported feature ids, owning classes, lifecycle hooks, tool catalog filter constants, neutral construct hints, a reusable contract template, and production acceptance checks that other libraries can use to publish their own upstream-facing contracts.
 
 The first contract version covers:
 
@@ -111,7 +111,7 @@ The first contract version covers:
 - behavioral state, goals, criteria, expectations, and bounded decisions
 - CPCT telemetry and runtime security validation
 
-Adapters should bind to the contract's feature ids rather than hard-coding prompt text or concrete class internals. For example, JenSS can map a `tool` construct to `agent.tool_contracts`, while linqr can map query catalog retrieval to the same feature through `query.tool_catalog`. This keeps syntax design in JenSS and linqr while Automata owns the runtime contract.
+Adapters should bind to the contract's feature ids rather than hard-coding prompt text or concrete class internals. Automata provides `contractTemplate()` and `bindingTemplate()` so adapter libraries can decide their own construct names, syntax, query language, ingestion flow, and conformance fixtures while pointing back to stable Automata feature ids. Sibling libraries may coordinate with one another, but Automata should not carry descendant-specific binding maps.
 
 ## Integration Notes
 

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -73,7 +73,9 @@ The monitor emits lifecycle hooks, applies policy, asks for review when configur
 
 ## Session Scope And Memory
 
-`AgentSession` is the boundary for shared scope. An agent can keep its own prompt context, while the session decides what context, permissions, tools, uploaded inputs, and working memory are available to one or more agents. The session can attach an Automata `IWorkingMemory` implementation, including `Abs2Memory`, so durable memory and Holoscene-compatible working-memory implementations are reached through existing Automata contracts instead of a separate memory silo.
+`AgentSession` is the boundary for shared scope. An agent can keep its own prompt context, while the session decides what context, permissions, tools, uploaded inputs, working memory, and Holoscene episodes are available to one or more agents. The session can attach an Automata `IWorkingMemory` implementation, including `Abs2Memory`, so durable memory and Holoscene-compatible working-memory implementations are reached through existing Automata contracts instead of a separate memory silo.
+
+Sessions can also attach a `Holoscene` directly. This lets interpreter adapters project sensory data, statements, scenes, and narrative episodes into the comprehension layer while still keeping access scoped by the session. Agents expose that Holoscene through prototype metadata by `holoscene_id`, so downstream runtimes can inspect the association without forcing raw scene data into prompt context.
 
 Lifecycle memory logging is intentionally tied to `AgentHook` names rather than memory-specific hook constants. Memory event stores persist hook activity, but the lifecycle belongs to the agent. `InMemoryEventStore` is process-local for tests and short runs. `FileMemoryEventStore` uses DevElation `Disk` storage through `StorageMemoryEventStore`, so applications can replace the storage adapter with another DevElation storage implementation without overriding file and JSON logic.
 
@@ -103,6 +105,7 @@ The first contract version covers:
 - tool contracts, catalog filtering, and structured results
 - lifecycle hooks for deterministic adapter behavior
 - session scope, permissions, context, and working memory
+- Holoscene comprehension, scenes, episodes, assessments, and narrative logs
 - governance, human review, MCP/RPC/API task-call monitoring
 - orchestration patterns, nested orchestrations, and PIANO flows
 - behavioral state, goals, criteria, expectations, and bounded decisions

--- a/examples/generic/agent_integration_contract.php
+++ b/examples/generic/agent_integration_contract.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Automata\LLM\Agent\Integration\AgentIntegrationContract;
+use BlueFission\Net\HTTP;
+
+$contract = AgentIntegrationContract::standard();
+
+print HTTP::jsonEncode([
+    'version' => $contract->version(),
+    'jenss_bindings' => $contract->bindings(AgentIntegrationContract::CONSUMER_JENSS),
+    'linqr_features' => $contract->features(AgentIntegrationContract::CONSUMER_LINQR),
+    'catalog_filters' => $contract->toolCatalogFilters(),
+    'production_checks' => $contract->acceptanceCriteria(),
+]) . PHP_EOL;

--- a/examples/generic/agent_integration_contract.php
+++ b/examples/generic/agent_integration_contract.php
@@ -11,8 +11,13 @@ $contract = AgentIntegrationContract::standard();
 
 print HTTP::jsonEncode([
     'version' => $contract->version(),
-    'jenss_bindings' => $contract->bindings(AgentIntegrationContract::CONSUMER_JENSS),
-    'linqr_features' => $contract->features(AgentIntegrationContract::CONSUMER_LINQR),
+    'contract_template' => $contract->contractTemplate(),
+    'binding_template' => $contract->bindingTemplate(),
+    'features' => $contract->features([
+        AgentIntegrationContract::FEATURE_TOOLS,
+        AgentIntegrationContract::FEATURE_HOLOSCENE,
+        AgentIntegrationContract::FEATURE_TELEMETRY,
+    ]),
     'catalog_filters' => $contract->toolCatalogFilters(),
     'production_checks' => $contract->acceptanceCriteria(),
 ]) . PHP_EOL;

--- a/src/Automata/LLM/Agent.php
+++ b/src/Automata/LLM/Agent.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Automata\LLM;
 
 use BlueFission\Arr;
+use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\AgentSession;
 use BlueFission\Behavioral\IDispatcher;
@@ -138,6 +139,8 @@ class Agent extends Obj implements IDispatcher
         $this->addStrategy('tool-contracts');
         $this->addStrategy('lifecycle-hooks');
         $this->addStrategy('governed-task-calls');
+        $this->addStrategy('holoscene-comprehension');
+        $this->addTrait('holoscene_compatible', true);
         $this->summary('agent[' . static::class . '] scope=automata.llm.agent');
     }
 
@@ -415,7 +418,7 @@ class Agent extends Obj implements IDispatcher
     {
         $this->session = $session;
         $this->memorySessionId = $session->id();
-        $this->property('session_id', $session->id());
+        $this->syncPrototypeSessionScope();
     }
 
     /**
@@ -429,18 +432,47 @@ class Agent extends Obj implements IDispatcher
     /**
      * Attach deterministic memory logging and optional context injection to the agent session.
      */
-    public function enableMemory(IMemoryEventStore $store, ?IMemoryInjector $injector = null, ?string $sessionId = null, ?IWorkingMemory $workingMemory = null): void
+    public function enableMemory(IMemoryEventStore $store, ?IMemoryInjector $injector = null, ?string $sessionId = null, ?IWorkingMemory $workingMemory = null, ?Holoscene $holoscene = null): void
     {
         $this->memoryEventStore = $store;
         $this->memoryInjector = $injector;
-        $this->session = new AgentSession($sessionId, $this->session->context(['client' => 'automata']), $workingMemory);
+        $this->session = new AgentSession($sessionId, $this->session->context(['client' => 'automata']), $workingMemory, $holoscene);
         $this->memorySessionId = $this->session->id();
         $this->memorySequence = 0;
-        $this->property('session_id', $this->session->id());
+        $this->syncPrototypeSessionScope();
 
         $this->emitMemoryEvent(AgentHook::SESSION_START, [
             'session_context' => $this->memoryInjector ? $this->memoryInjector->sessionContext($this->memoryContext()) : '',
         ]);
+    }
+
+    /**
+     * Attach a Holoscene to the active session scope.
+     */
+    public function useHoloscene(?Holoscene $holoscene): void
+    {
+        $this->session->useHoloscene($holoscene);
+        $this->syncPrototypeSessionScope();
+    }
+
+    /**
+     * Return the Holoscene attached to the active session scope.
+     */
+    public function holoscene(): ?Holoscene
+    {
+        return $this->session->holoscene();
+    }
+
+    /**
+     * Keep DevElation prototype metadata aligned with session-level scope.
+     */
+    protected function syncPrototypeSessionScope(): void
+    {
+        $memory = $this->session->workingMemory();
+
+        $this->property('session_id', $this->session->id());
+        $this->property('holoscene_id', $this->session->holoscene()?->protoId());
+        $this->property('working_memory', $memory ? get_class($memory) : null);
     }
 
     /**

--- a/src/Automata/LLM/Agent.php
+++ b/src/Automata/LLM/Agent.php
@@ -5,7 +5,6 @@ use BlueFission\Arr;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\AgentSession;
 use BlueFission\Behavioral\IDispatcher;
-use BlueFission\Behavioral\Dispatches;
 use BlueFission\Automata\LLM\Tools\ITool;
 use BlueFission\Automata\LLM\Agent\ToolCatalog;
 use BlueFission\Automata\LLM\Agent\ToolDefinition;
@@ -40,13 +39,15 @@ use BlueFission\Automata\LLM\MCP\Tools\MCPRegisterServerTool;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\DevElation as Dev;
 use BlueFission\Net\HTTP;
+use BlueFission\Obj;
+use BlueFission\Prototypes\Agent as PrototypeAgent;
+use BlueFission\Prototypes\Proto;
 use BlueFission\Str;
 // https://bootcamp.uxdesign.cc/a-comprehensive-and-hands-on-guide-to-autonomous-agents-with-gpt-b58d54724d50
-class Agent implements IDispatcher
+class Agent extends Obj implements IDispatcher
 {
-    use Dispatches {
-        Dispatches::__construct as private __dispatchesConstruct;
-    }
+    use Proto;
+    use PrototypeAgent;
 
     protected $tools = [];
     protected $llm;
@@ -70,10 +71,11 @@ class Agent implements IDispatcher
     protected ?HumanReviewGate $humanReviewGate = null;
 
     public function __construct($llm) {
-        $this->__dispatchesConstruct();
+        parent::__construct();
 
         $this->llm = $llm;
         $this->session = new AgentSession(null, ['client' => 'automata']);
+        $this->bootstrapPrototype();
         $this->toolCatalog = new ToolCatalog();
         $this->toolExecutor = new ToolExecutor();
         $this->agentState = new AgentState();
@@ -116,6 +118,27 @@ class Agent implements IDispatcher
         Dev::do(AgentHook::SESSION_START, [
             'agent' => static::class,
         ]);
+    }
+
+    /**
+     * Seed DevElation prototype metadata for shared agent inspection.
+     */
+    protected function bootstrapPrototype(): void
+    {
+        $this->protoId(TaskTraceSpan::id('agent'));
+        $this->name(static::class);
+        $this->role('llm-runtime');
+        $this->scope('automata.llm.agent');
+        $this->awareness('context-tools-memory-goals');
+        $this->efficacy('deterministic-execution-boundary');
+        $this->autonomy('configurable');
+        $this->control('agent-session');
+        $this->property('session_id', $this->session->id());
+        $this->addGoal('answer-user-visible-tasks');
+        $this->addStrategy('tool-contracts');
+        $this->addStrategy('lifecycle-hooks');
+        $this->addStrategy('governed-task-calls');
+        $this->summary('agent[' . static::class . '] scope=automata.llm.agent');
     }
 
     /**
@@ -392,6 +415,7 @@ class Agent implements IDispatcher
     {
         $this->session = $session;
         $this->memorySessionId = $session->id();
+        $this->property('session_id', $session->id());
     }
 
     /**
@@ -412,6 +436,7 @@ class Agent implements IDispatcher
         $this->session = new AgentSession($sessionId, $this->session->context(['client' => 'automata']), $workingMemory);
         $this->memorySessionId = $this->session->id();
         $this->memorySequence = 0;
+        $this->property('session_id', $this->session->id());
 
         $this->emitMemoryEvent(AgentHook::SESSION_START, [
             'session_context' => $this->memoryInjector ? $this->memoryInjector->sessionContext($this->memoryContext()) : '',

--- a/src/Automata/LLM/Agent/AgentSession.php
+++ b/src/Automata/LLM/Agent/AgentSession.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Automata\LLM\Agent;
 
 use BlueFission\Arr;
+use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\Context;
 use BlueFission\Automata\LLM\Agent\Telemetry\TaskTraceSpan;
 use BlueFission\Automata\Memory\IWorkingMemory;
@@ -24,15 +25,18 @@ class AgentSession implements IDispatcher
 
     protected ?IWorkingMemory $workingMemory = null;
 
+    protected ?Holoscene $holoscene = null;
+
     /**
      * Create a scope boundary for one or more agents.
      */
-    public function __construct(?string $sessionId = null, array $context = [], ?IWorkingMemory $workingMemory = null)
+    public function __construct(?string $sessionId = null, array $context = [], ?IWorkingMemory $workingMemory = null, ?Holoscene $holoscene = null)
     {
         $this->__dispatchesConstruct();
         $this->sessionId = $sessionId ?: TaskTraceSpan::id('session');
         $this->context = $context;
         $this->workingMemory = $workingMemory;
+        $this->holoscene = $holoscene;
         $this->trigger(Event::STARTED);
     }
 
@@ -101,6 +105,46 @@ class AgentSession implements IDispatcher
     public function workingMemory(): ?IWorkingMemory
     {
         return $this->workingMemory;
+    }
+
+    /**
+     * Attach a Holoscene narrative container to this session scope.
+     */
+    public function useHoloscene(?Holoscene $holoscene): self
+    {
+        $this->holoscene = $holoscene;
+        $this->trigger(Event::CHANGE);
+
+        return $this;
+    }
+
+    /**
+     * Return the attached Holoscene, if any.
+     */
+    public function holoscene(): ?Holoscene
+    {
+        return $this->holoscene;
+    }
+
+    /**
+     * Store a scene-like episode in the attached Holoscene.
+     */
+    public function addHolosceneEpisode(string $episodeId, mixed $scene): self
+    {
+        if ($this->holoscene) {
+            $this->holoscene->push($episodeId, $scene);
+            $this->trigger(Event::CHANGE);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return the attached Holoscene snapshot without exposing mutable internals.
+     */
+    public function holosceneSnapshot(): ?array
+    {
+        return $this->holoscene?->snapshot();
     }
 
     /**

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -3,7 +3,10 @@
 namespace BlueFission\Automata\LLM\Agent\Integration;
 
 use BlueFission\Arr;
+use BlueFission\Automata\Comprehension\Holoscene;
+use BlueFission\Automata\Comprehension\Scene;
 use BlueFission\Automata\Goal\GoalManager;
+use BlueFission\Automata\Language\Reader;
 use BlueFission\Automata\LLM\Agent;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\AgentSession;
@@ -14,6 +17,7 @@ use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
 use BlueFission\Automata\LLM\Agent\Security\RuntimeLogicValidator;
 use BlueFission\Automata\LLM\Agent\State\AgentState;
 use BlueFission\Automata\LLM\Agent\Telemetry\TaskTrace;
+use BlueFission\Automata\Memory\IWorkingMemory;
 use BlueFission\Automata\LLM\Agent\ToolCatalog;
 use BlueFission\Automata\LLM\Agent\ToolDefinition;
 use BlueFission\Automata\LLM\Agent\ToolExecutionResult;
@@ -36,6 +40,7 @@ class AgentIntegrationContract extends Obj
     public const FEATURE_HOOKS = 'agent.lifecycle_hooks';
     public const FEATURE_SESSION = 'agent.session_scope';
     public const FEATURE_MEMORY = 'agent.memory_context';
+    public const FEATURE_HOLOSCENE = 'agent.holoscene_comprehension';
     public const FEATURE_GOVERNANCE = 'agent.governance';
     public const FEATURE_MCP = 'agent.mcp_observability';
     public const FEATURE_ORCHESTRATION = 'agent.orchestration';
@@ -210,6 +215,14 @@ class AgentIntegrationContract extends Obj
                     'inputs' => ['label', 'context', 'edges', 'injector'],
                     'outputs' => ['context', 'memory_events'],
                 ],
+                self::FEATURE_HOLOSCENE => [
+                    'summary' => 'Holoscene comprehension for scoped sensory, narrative, scene, and episode context.',
+                    'classes' => [Holoscene::class, Scene::class, Reader::class, IWorkingMemory::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_LINQR, self::CONSUMER_CHAINLINQ],
+                    'constructs' => ['holoscene', 'scene', 'episode', 'reader.to_holoscene', 'holoscene.narrate'],
+                    'inputs' => ['statements', 'episode_id', 'scene', 'working_memory', 'session_scope'],
+                    'outputs' => ['holoscene_snapshot', 'assessment', 'narrative_log', 'working_memory_context'],
+                ],
                 self::FEATURE_GOVERNANCE => [
                     'summary' => 'Human review, steering, policy gates, and governed task calls for tools, APIs, RPC, and MCP.',
                     'classes' => [TaskCallMonitor::class, HumanReviewGate::class, GovernanceDecision::class],
@@ -266,6 +279,7 @@ class AgentIntegrationContract extends Obj
                     'on' => self::FEATURE_HOOKS,
                     'session' => self::FEATURE_SESSION,
                     'memory' => self::FEATURE_MEMORY,
+                    'holoscene' => self::FEATURE_HOLOSCENE,
                     'review' => self::FEATURE_GOVERNANCE,
                     'mcp' => self::FEATURE_MCP,
                     'orchestrate' => self::FEATURE_ORCHESTRATION,
@@ -278,16 +292,19 @@ class AgentIntegrationContract extends Obj
                     'runtime.tool' => self::FEATURE_TOOLS,
                     'runtime.hook' => self::FEATURE_HOOKS,
                     'runtime.session' => self::FEATURE_SESSION,
+                    'runtime.holoscene' => self::FEATURE_HOLOSCENE,
                     'runtime.trace' => self::FEATURE_TELEMETRY,
                 ],
                 self::CONSUMER_LINQR => [
                     'query.tool_catalog' => self::FEATURE_TOOLS,
+                    'query.holoscene' => self::FEATURE_HOLOSCENE,
                     'query.trace' => self::FEATURE_TELEMETRY,
                 ],
                 self::CONSUMER_CHAINLINQ => [
                     'adapter.tool_catalog' => self::FEATURE_TOOLS,
                     'adapter.task_call' => self::FEATURE_GOVERNANCE,
                     'adapter.mcp' => self::FEATURE_MCP,
+                    'adapter.holoscene' => self::FEATURE_HOLOSCENE,
                     'adapter.trace' => self::FEATURE_TELEMETRY,
                 ],
             ],
@@ -309,6 +326,7 @@ class AgentIntegrationContract extends Obj
                 'Language constructs produce deterministic arrays accepted by Automata classes.',
                 'Tool and MCP calls emit task trace spans and governance outcomes.',
                 'Session scope controls shared context instead of agents sharing full context windows.',
+                'Holoscene episodes use scoped working memory and snapshots rather than raw prompt-only memory coupling.',
                 'Conformance fixtures cover successful execution, blocked execution, review steering, and trace export.',
             ],
         ];

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Integration;
+
+use BlueFission\Arr;
+use BlueFission\Automata\Goal\GoalManager;
+use BlueFission\Automata\LLM\Agent;
+use BlueFission\Automata\LLM\Agent\AgentHook;
+use BlueFission\Automata\LLM\Agent\AgentSession;
+use BlueFission\Automata\LLM\Agent\Governance\GovernanceDecision;
+use BlueFission\Automata\LLM\Agent\Governance\HumanReviewGate;
+use BlueFission\Automata\LLM\Agent\Governance\TaskCallMonitor;
+use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
+use BlueFission\Automata\LLM\Agent\Security\RuntimeLogicValidator;
+use BlueFission\Automata\LLM\Agent\State\AgentState;
+use BlueFission\Automata\LLM\Agent\Telemetry\TaskTrace;
+use BlueFission\Automata\LLM\Agent\ToolCatalog;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Automata\LLM\Agent\ToolExecutionResult;
+use BlueFission\Automata\LLM\Agent\ToolExecutor;
+use BlueFission\Automata\LLM\MCP\MCPClient;
+use BlueFission\Net\HTTP;
+use BlueFission\Obj;
+
+class AgentIntegrationContract extends Obj
+{
+    public const VERSION = '1.0.0';
+
+    public const CONSUMER_JENSS = 'jenss';
+    public const CONSUMER_JENERATOR = 'jenerator';
+    public const CONSUMER_LINQR = 'linqr';
+    public const CONSUMER_CHAINLINQ = 'chainlinq';
+
+    public const FEATURE_AGENT = 'agent.runtime';
+    public const FEATURE_TOOLS = 'agent.tool_contracts';
+    public const FEATURE_HOOKS = 'agent.lifecycle_hooks';
+    public const FEATURE_SESSION = 'agent.session_scope';
+    public const FEATURE_MEMORY = 'agent.memory_context';
+    public const FEATURE_GOVERNANCE = 'agent.governance';
+    public const FEATURE_MCP = 'agent.mcp_observability';
+    public const FEATURE_ORCHESTRATION = 'agent.orchestration';
+    public const FEATURE_STATE_GOALS = 'agent.state_goals';
+    public const FEATURE_TELEMETRY = 'agent.cpct_telemetry';
+    public const FEATURE_SECURITY = 'agent.runtime_security';
+
+    /**
+     * Build the standard Automata integration surface for interpreter adapters.
+     */
+    public function __construct(array $overrides = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig($this->defaults(), $overrides));
+    }
+
+    /**
+     * Create the default contract advertised to JenSS and query runtimes.
+     */
+    public static function standard(array $overrides = []): self
+    {
+        return new self($overrides);
+    }
+
+    /**
+     * Return the contract version for compatibility checks.
+     */
+    public function version(): string
+    {
+        return (string)$this->field('version');
+    }
+
+    /**
+     * Return deterministic feature descriptors, optionally filtered by consumer.
+     */
+    public function features(?string $consumer = null): array
+    {
+        $features = Arr::make($this->field('features') ?? [])->toArray();
+
+        if (!$consumer) {
+            return $features;
+        }
+
+        $filtered = [];
+        foreach ($features as $name => $feature) {
+            $consumers = Arr::make($feature['consumers'] ?? [])->toArray();
+            if (Arr::contains($consumers, $consumer, true)) {
+                $filtered[$name] = $feature;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Return one feature descriptor by stable feature id.
+     */
+    public function feature(string $name): ?array
+    {
+        $features = $this->features();
+
+        return Arr::hasKey($features, $name) ? $features[$name] : null;
+    }
+
+    /**
+     * Determine whether the contract advertises a stable feature id.
+     */
+    public function supports(string $name): bool
+    {
+        return Arr::hasKey($this->features(), $name);
+    }
+
+    /**
+     * Return target-language binding names for one consumer or all consumers.
+     */
+    public function bindings(?string $consumer = null): array
+    {
+        $bindings = Arr::make($this->field('bindings') ?? [])->toArray();
+
+        if (!$consumer) {
+            return $bindings;
+        }
+
+        return Arr::make($bindings[$consumer] ?? [])->toArray();
+    }
+
+    /**
+     * Return the lifecycle hook names available to adapters.
+     */
+    public function hooks(): array
+    {
+        return Arr::make($this->field('hooks') ?? [])->toArray();
+    }
+
+    /**
+     * Return supported catalog filter keys for interpreter-driven retrieval.
+     */
+    public function toolCatalogFilters(): array
+    {
+        return Arr::make($this->field('tool_catalog_filters') ?? [])->toArray();
+    }
+
+    /**
+     * Return production integration checks that downstream adapters should satisfy.
+     */
+    public function acceptanceCriteria(): array
+    {
+        return Arr::make($this->field('acceptance_criteria') ?? [])->toArray();
+    }
+
+    /**
+     * Encode the contract for storage, transport, or generated fixtures.
+     */
+    public function toJson(int $flags = 0): string
+    {
+        return (string)HTTP::jsonEncode($this->toArray());
+    }
+
+    /**
+     * Define the complete standard contract without binding to a prompt format.
+     */
+    protected function defaults(): array
+    {
+        return [
+            'name' => 'automata.agent.integration',
+            'version' => self::VERSION,
+            'owner' => 'automata',
+            'consumers' => [
+                self::CONSUMER_JENSS,
+                self::CONSUMER_JENERATOR,
+                self::CONSUMER_LINQR,
+                self::CONSUMER_CHAINLINQ,
+            ],
+            'features' => [
+                self::FEATURE_AGENT => [
+                    'summary' => 'Agent runtime entry point and configured execution boundary.',
+                    'classes' => [Agent::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['agent', 'agent.run', 'agent.configure'],
+                    'inputs' => ['prompt', 'template', 'task_id', 'session'],
+                    'outputs' => ['reply', 'trace', 'events'],
+                ],
+                self::FEATURE_TOOLS => [
+                    'summary' => 'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
+                    'classes' => [ToolDefinition::class, ToolCatalog::class, ToolExecutor::class, ToolExecutionResult::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_LINQR, self::CONSUMER_CHAINLINQ],
+                    'constructs' => ['tool', 'tool.catalog', 'tool.call', 'tool.result'],
+                    'inputs' => ['definition', 'catalog_filters', 'arguments', 'permission_context'],
+                    'outputs' => ['definition_array', 'prompt_catalog', 'execution_result'],
+                ],
+                self::FEATURE_HOOKS => [
+                    'summary' => 'Lifecycle hooks for deterministic adapter logging, memory capture, telemetry, and governance.',
+                    'classes' => [AgentHook::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
+                    'constructs' => ['on.session_start', 'on.user_prompt_submit', 'on.pre_tool_use', 'on.post_tool_use', 'on.turn_stop'],
+                    'inputs' => ['event_name', 'payload'],
+                    'outputs' => ['event_payload', 'adapter_side_effect'],
+                ],
+                self::FEATURE_SESSION => [
+                    'summary' => 'Shared session scope for permissions, context, uploaded inputs, tools, and working memory.',
+                    'classes' => [AgentSession::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['session', 'session.context', 'session.allow', 'session.memory'],
+                    'inputs' => ['session_id', 'context', 'permissions', 'working_memory'],
+                    'outputs' => ['scoped_context', 'permission_result', 'memory_handle'],
+                ],
+                self::FEATURE_MEMORY => [
+                    'summary' => 'Memory and context injection through Automata working-memory contracts and lifecycle stores.',
+                    'classes' => [AgentSession::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['memory.remember', 'memory.recall', 'memory.inject'],
+                    'inputs' => ['label', 'context', 'edges', 'injector'],
+                    'outputs' => ['context', 'memory_events'],
+                ],
+                self::FEATURE_GOVERNANCE => [
+                    'summary' => 'Human review, steering, policy gates, and governed task calls for tools, APIs, RPC, and MCP.',
+                    'classes' => [TaskCallMonitor::class, HumanReviewGate::class, GovernanceDecision::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
+                    'constructs' => ['review.request', 'review.decision', 'task.call', 'task.policy'],
+                    'inputs' => ['call', 'policy', 'reviewer'],
+                    'outputs' => ['decision', 'call_result', 'trace_span'],
+                ],
+                self::FEATURE_MCP => [
+                    'summary' => 'Observed and governed MCP discovery, resource, request, and tool-call surfaces.',
+                    'classes' => [MCPClient::class, TaskCallMonitor::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
+                    'constructs' => ['mcp.server', 'mcp.resource', 'mcp.request', 'mcp.tool'],
+                    'inputs' => ['server', 'resource', 'request', 'tool_arguments'],
+                    'outputs' => ['mcp_result', 'trace_span', 'governance_decision'],
+                ],
+                self::FEATURE_ORCHESTRATION => [
+                    'summary' => 'Sequential, fan-out, hierarchical, reflexive, and PIANO orchestration patterns.',
+                    'classes' => [Orchestrator::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['orchestrate', 'orchestrate.sequential', 'orchestrate.hierarchical', 'orchestrate.piano'],
+                    'inputs' => ['pattern', 'workers', 'context', 'session'],
+                    'outputs' => ['orchestration_result', 'worker_results', 'trace'],
+                ],
+                self::FEATURE_STATE_GOALS => [
+                    'summary' => 'Behavioral state channels, cognitive controller seams, goals, criteria, and expectations.',
+                    'classes' => [AgentState::class, GoalManager::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['state.channel', 'goal', 'criterion', 'expectation', 'decision.option'],
+                    'inputs' => ['state', 'goal', 'criteria', 'context'],
+                    'outputs' => ['state_snapshot', 'goal_decisions', 'expectation_updates'],
+                ],
+                self::FEATURE_TELEMETRY => [
+                    'summary' => 'Task-scoped CPCT traces for model, tool, MCP, batch, cache, and routing economics.',
+                    'classes' => [TaskTrace::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ, self::CONSUMER_LINQR],
+                    'constructs' => ['trace.task', 'trace.span', 'trace.cpct', 'trace.routing'],
+                    'inputs' => ['task_id', 'span', 'usage', 'outcome'],
+                    'outputs' => ['trace_snapshot', 'cpct_report'],
+                ],
+                self::FEATURE_SECURITY => [
+                    'summary' => 'Runtime logic validation and LPCI-oriented sanitization before content re-enters context.',
+                    'classes' => [RuntimeLogicValidator::class],
+                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
+                    'constructs' => ['security.scan', 'security.validate', 'security.sanitize'],
+                    'inputs' => ['content', 'tool_result', 'memory_event'],
+                    'outputs' => ['finding', 'sanitized_content', 'blocked_result'],
+                ],
+            ],
+            'bindings' => [
+                self::CONSUMER_JENSS => [
+                    'agent' => self::FEATURE_AGENT,
+                    'tool' => self::FEATURE_TOOLS,
+                    'on' => self::FEATURE_HOOKS,
+                    'session' => self::FEATURE_SESSION,
+                    'memory' => self::FEATURE_MEMORY,
+                    'review' => self::FEATURE_GOVERNANCE,
+                    'mcp' => self::FEATURE_MCP,
+                    'orchestrate' => self::FEATURE_ORCHESTRATION,
+                    'goal' => self::FEATURE_STATE_GOALS,
+                    'trace' => self::FEATURE_TELEMETRY,
+                    'security' => self::FEATURE_SECURITY,
+                ],
+                self::CONSUMER_JENERATOR => [
+                    'runtime.agent' => self::FEATURE_AGENT,
+                    'runtime.tool' => self::FEATURE_TOOLS,
+                    'runtime.hook' => self::FEATURE_HOOKS,
+                    'runtime.session' => self::FEATURE_SESSION,
+                    'runtime.trace' => self::FEATURE_TELEMETRY,
+                ],
+                self::CONSUMER_LINQR => [
+                    'query.tool_catalog' => self::FEATURE_TOOLS,
+                    'query.trace' => self::FEATURE_TELEMETRY,
+                ],
+                self::CONSUMER_CHAINLINQ => [
+                    'adapter.tool_catalog' => self::FEATURE_TOOLS,
+                    'adapter.task_call' => self::FEATURE_GOVERNANCE,
+                    'adapter.mcp' => self::FEATURE_MCP,
+                    'adapter.trace' => self::FEATURE_TELEMETRY,
+                ],
+            ],
+            'hooks' => AgentHook::all(),
+            'tool_catalog_filters' => [
+                ToolCatalog::FILTER_CATEGORY,
+                ToolCatalog::FILTER_PERMISSION,
+                ToolCatalog::FILTER_TAGS,
+                ToolCatalog::FILTER_TAGS_ALL,
+                ToolCatalog::FILTER_GROUPS,
+                ToolCatalog::FILTER_TAXONOMY,
+                ToolCatalog::FILTER_INCLUDE,
+                ToolCatalog::FILTER_EXCLUDE,
+                ToolCatalog::FILTER_LIMIT,
+                ToolCatalog::FILTER_PARALLEL_SAFE,
+            ],
+            'acceptance_criteria' => [
+                'Adapters bind to these feature ids rather than concrete prompt strings.',
+                'Language constructs produce deterministic arrays accepted by Automata classes.',
+                'Tool and MCP calls emit task trace spans and governance outcomes.',
+                'Session scope controls shared context instead of agents sharing full context windows.',
+                'Conformance fixtures cover successful execution, blocked execution, review steering, and trace export.',
+            ],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -30,11 +30,6 @@ class AgentIntegrationContract extends Obj
 {
     public const VERSION = '1.0.0';
 
-    public const CONSUMER_JENSS = 'jenss';
-    public const CONSUMER_JENERATOR = 'jenerator';
-    public const CONSUMER_LINQR = 'linqr';
-    public const CONSUMER_CHAINLINQ = 'chainlinq';
-
     public const FEATURE_AGENT = 'agent.runtime';
     public const FEATURE_TOOLS = 'agent.tool_contracts';
     public const FEATURE_HOOKS = 'agent.lifecycle_hooks';
@@ -48,8 +43,21 @@ class AgentIntegrationContract extends Obj
     public const FEATURE_TELEMETRY = 'agent.cpct_telemetry';
     public const FEATURE_SECURITY = 'agent.runtime_security';
 
+    public const TEMPLATE_AGENT = 'agent';
+    public const TEMPLATE_TOOL = 'tool';
+    public const TEMPLATE_HOOK = 'hook';
+    public const TEMPLATE_SESSION = 'session';
+    public const TEMPLATE_MEMORY = 'memory';
+    public const TEMPLATE_HOLOSCENE = 'holoscene';
+    public const TEMPLATE_GOVERNANCE = 'governance';
+    public const TEMPLATE_MCP = 'mcp';
+    public const TEMPLATE_ORCHESTRATION = 'orchestration';
+    public const TEMPLATE_GOAL = 'goal';
+    public const TEMPLATE_TRACE = 'trace';
+    public const TEMPLATE_SECURITY = 'security';
+
     /**
-     * Build the standard Automata integration surface for interpreter adapters.
+     * Build the standard Automata integration surface for adapter contracts.
      */
     public function __construct(array $overrides = [])
     {
@@ -58,7 +66,7 @@ class AgentIntegrationContract extends Obj
     }
 
     /**
-     * Create the default contract advertised to JenSS and query runtimes.
+     * Create the default upstream contract template for Automata agent features.
      */
     public static function standard(array $overrides = []): self
     {
@@ -74,21 +82,20 @@ class AgentIntegrationContract extends Obj
     }
 
     /**
-     * Return deterministic feature descriptors, optionally filtered by consumer.
+     * Return deterministic feature descriptors, optionally filtered by feature id.
      */
-    public function features(?string $consumer = null): array
+    public function features(?array $featureIds = null): array
     {
         $features = Arr::make($this->field('features') ?? [])->toArray();
 
-        if (!$consumer) {
+        if (!$featureIds) {
             return $features;
         }
 
         $filtered = [];
-        foreach ($features as $name => $feature) {
-            $consumers = Arr::make($feature['consumers'] ?? [])->toArray();
-            if (Arr::contains($consumers, $consumer, true)) {
-                $filtered[$name] = $feature;
+        foreach (Arr::make($featureIds)->toArray() as $featureId) {
+            if (Arr::hasKey($features, $featureId)) {
+                $filtered[$featureId] = $features[$featureId];
             }
         }
 
@@ -114,17 +121,33 @@ class AgentIntegrationContract extends Obj
     }
 
     /**
-     * Return target-language binding names for one consumer or all consumers.
+     * Return the template other libraries can use to publish adapter contracts upstream.
      */
-    public function bindings(?string $consumer = null): array
+    public function contractTemplate(): array
     {
-        $bindings = Arr::make($this->field('bindings') ?? [])->toArray();
+        return Arr::make($this->field('contract_template') ?? [])->toArray();
+    }
 
-        if (!$consumer) {
-            return $bindings;
+    /**
+     * Return neutral construct-to-feature hints for adapter-owned bindings.
+     */
+    public function bindingTemplate(?string $construct = null): array
+    {
+        $template = Arr::make($this->field('binding_template') ?? [])->toArray();
+
+        if (!$construct) {
+            return $template;
         }
 
-        return Arr::make($bindings[$consumer] ?? [])->toArray();
+        return Arr::make($template[$construct] ?? [])->toArray();
+    }
+
+    /**
+     * Return neutral binding hints for callers that still use the older method name.
+     */
+    public function bindings(?string $construct = null): array
+    {
+        return $this->bindingTemplate($construct);
     }
 
     /**
@@ -144,7 +167,7 @@ class AgentIntegrationContract extends Obj
     }
 
     /**
-     * Return production integration checks that downstream adapters should satisfy.
+     * Return production integration checks that adapter contracts should satisfy.
      */
     public function acceptanceCriteria(): array
     {
@@ -168,17 +191,10 @@ class AgentIntegrationContract extends Obj
             'name' => 'automata.agent.integration',
             'version' => self::VERSION,
             'owner' => 'automata',
-            'consumers' => [
-                self::CONSUMER_JENSS,
-                self::CONSUMER_JENERATOR,
-                self::CONSUMER_LINQR,
-                self::CONSUMER_CHAINLINQ,
-            ],
             'features' => [
                 self::FEATURE_AGENT => [
                     'summary' => 'Agent runtime entry point and configured execution boundary.',
                     'classes' => [Agent::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['agent', 'agent.run', 'agent.configure'],
                     'inputs' => ['prompt', 'template', 'task_id', 'session'],
                     'outputs' => ['reply', 'trace', 'events'],
@@ -186,7 +202,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_TOOLS => [
                     'summary' => 'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
                     'classes' => [ToolDefinition::class, ToolCatalog::class, ToolExecutor::class, ToolExecutionResult::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_LINQR, self::CONSUMER_CHAINLINQ],
                     'constructs' => ['tool', 'tool.catalog', 'tool.call', 'tool.result'],
                     'inputs' => ['definition', 'catalog_filters', 'arguments', 'permission_context'],
                     'outputs' => ['definition_array', 'prompt_catalog', 'execution_result'],
@@ -194,7 +209,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_HOOKS => [
                     'summary' => 'Lifecycle hooks for deterministic adapter logging, memory capture, telemetry, and governance.',
                     'classes' => [AgentHook::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
                     'constructs' => ['on.session_start', 'on.user_prompt_submit', 'on.pre_tool_use', 'on.post_tool_use', 'on.turn_stop'],
                     'inputs' => ['event_name', 'payload'],
                     'outputs' => ['event_payload', 'adapter_side_effect'],
@@ -202,7 +216,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_SESSION => [
                     'summary' => 'Shared session scope for permissions, context, uploaded inputs, tools, and working memory.',
                     'classes' => [AgentSession::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['session', 'session.context', 'session.allow', 'session.memory'],
                     'inputs' => ['session_id', 'context', 'permissions', 'working_memory'],
                     'outputs' => ['scoped_context', 'permission_result', 'memory_handle'],
@@ -210,7 +223,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_MEMORY => [
                     'summary' => 'Memory and context injection through Automata working-memory contracts and lifecycle stores.',
                     'classes' => [AgentSession::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['memory.remember', 'memory.recall', 'memory.inject'],
                     'inputs' => ['label', 'context', 'edges', 'injector'],
                     'outputs' => ['context', 'memory_events'],
@@ -218,7 +230,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_HOLOSCENE => [
                     'summary' => 'Holoscene comprehension for scoped sensory, narrative, scene, and episode context.',
                     'classes' => [Holoscene::class, Scene::class, Reader::class, IWorkingMemory::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_LINQR, self::CONSUMER_CHAINLINQ],
                     'constructs' => ['holoscene', 'scene', 'episode', 'reader.to_holoscene', 'holoscene.narrate'],
                     'inputs' => ['statements', 'episode_id', 'scene', 'working_memory', 'session_scope'],
                     'outputs' => ['holoscene_snapshot', 'assessment', 'narrative_log', 'working_memory_context'],
@@ -226,7 +237,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_GOVERNANCE => [
                     'summary' => 'Human review, steering, policy gates, and governed task calls for tools, APIs, RPC, and MCP.',
                     'classes' => [TaskCallMonitor::class, HumanReviewGate::class, GovernanceDecision::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
                     'constructs' => ['review.request', 'review.decision', 'task.call', 'task.policy'],
                     'inputs' => ['call', 'policy', 'reviewer'],
                     'outputs' => ['decision', 'call_result', 'trace_span'],
@@ -234,7 +244,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_MCP => [
                     'summary' => 'Observed and governed MCP discovery, resource, request, and tool-call surfaces.',
                     'classes' => [MCPClient::class, TaskCallMonitor::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ],
                     'constructs' => ['mcp.server', 'mcp.resource', 'mcp.request', 'mcp.tool'],
                     'inputs' => ['server', 'resource', 'request', 'tool_arguments'],
                     'outputs' => ['mcp_result', 'trace_span', 'governance_decision'],
@@ -242,7 +251,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_ORCHESTRATION => [
                     'summary' => 'Sequential, fan-out, hierarchical, reflexive, and PIANO orchestration patterns.',
                     'classes' => [Orchestrator::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['orchestrate', 'orchestrate.sequential', 'orchestrate.hierarchical', 'orchestrate.piano'],
                     'inputs' => ['pattern', 'workers', 'context', 'session'],
                     'outputs' => ['orchestration_result', 'worker_results', 'trace'],
@@ -250,7 +258,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_STATE_GOALS => [
                     'summary' => 'Behavioral state channels, cognitive controller seams, goals, criteria, and expectations.',
                     'classes' => [AgentState::class, GoalManager::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['state.channel', 'goal', 'criterion', 'expectation', 'decision.option'],
                     'inputs' => ['state', 'goal', 'criteria', 'context'],
                     'outputs' => ['state_snapshot', 'goal_decisions', 'expectation_updates'],
@@ -258,7 +265,6 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_TELEMETRY => [
                     'summary' => 'Task-scoped CPCT traces for model, tool, MCP, batch, cache, and routing economics.',
                     'classes' => [TaskTrace::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR, self::CONSUMER_CHAINLINQ, self::CONSUMER_LINQR],
                     'constructs' => ['trace.task', 'trace.span', 'trace.cpct', 'trace.routing'],
                     'inputs' => ['task_id', 'span', 'usage', 'outcome'],
                     'outputs' => ['trace_snapshot', 'cpct_report'],
@@ -266,47 +272,36 @@ class AgentIntegrationContract extends Obj
                 self::FEATURE_SECURITY => [
                     'summary' => 'Runtime logic validation and LPCI-oriented sanitization before content re-enters context.',
                     'classes' => [RuntimeLogicValidator::class],
-                    'consumers' => [self::CONSUMER_JENSS, self::CONSUMER_JENERATOR],
                     'constructs' => ['security.scan', 'security.validate', 'security.sanitize'],
                     'inputs' => ['content', 'tool_result', 'memory_event'],
                     'outputs' => ['finding', 'sanitized_content', 'blocked_result'],
                 ],
             ],
-            'bindings' => [
-                self::CONSUMER_JENSS => [
-                    'agent' => self::FEATURE_AGENT,
-                    'tool' => self::FEATURE_TOOLS,
-                    'on' => self::FEATURE_HOOKS,
-                    'session' => self::FEATURE_SESSION,
-                    'memory' => self::FEATURE_MEMORY,
-                    'holoscene' => self::FEATURE_HOLOSCENE,
-                    'review' => self::FEATURE_GOVERNANCE,
-                    'mcp' => self::FEATURE_MCP,
-                    'orchestrate' => self::FEATURE_ORCHESTRATION,
-                    'goal' => self::FEATURE_STATE_GOALS,
-                    'trace' => self::FEATURE_TELEMETRY,
-                    'security' => self::FEATURE_SECURITY,
+            'contract_template' => [
+                'name' => 'family.adapter.contract',
+                'direction' => 'adapter-to-upstream-runtime',
+                'required_fields' => ['name', 'version', 'owner', 'target', 'feature_bindings', 'acceptance_criteria'],
+                'feature_binding_shape' => [
+                    'construct' => '<local language or adapter construct>',
+                    'feature' => '<stable Automata feature id>',
+                    'inputs' => '<adapter-owned input mapping>',
+                    'outputs' => '<adapter-owned output mapping>',
                 ],
-                self::CONSUMER_JENERATOR => [
-                    'runtime.agent' => self::FEATURE_AGENT,
-                    'runtime.tool' => self::FEATURE_TOOLS,
-                    'runtime.hook' => self::FEATURE_HOOKS,
-                    'runtime.session' => self::FEATURE_SESSION,
-                    'runtime.holoscene' => self::FEATURE_HOLOSCENE,
-                    'runtime.trace' => self::FEATURE_TELEMETRY,
-                ],
-                self::CONSUMER_LINQR => [
-                    'query.tool_catalog' => self::FEATURE_TOOLS,
-                    'query.holoscene' => self::FEATURE_HOLOSCENE,
-                    'query.trace' => self::FEATURE_TELEMETRY,
-                ],
-                self::CONSUMER_CHAINLINQ => [
-                    'adapter.tool_catalog' => self::FEATURE_TOOLS,
-                    'adapter.task_call' => self::FEATURE_GOVERNANCE,
-                    'adapter.mcp' => self::FEATURE_MCP,
-                    'adapter.holoscene' => self::FEATURE_HOLOSCENE,
-                    'adapter.trace' => self::FEATURE_TELEMETRY,
-                ],
+                'boundary' => 'Automata owns runtime feature ids and class contracts; adapter libraries own syntax, query language, ingestion, and generated bindings.',
+            ],
+            'binding_template' => [
+                self::TEMPLATE_AGENT => ['feature' => self::FEATURE_AGENT, 'constructs' => ['agent', 'agent.run', 'agent.configure']],
+                self::TEMPLATE_TOOL => ['feature' => self::FEATURE_TOOLS, 'constructs' => ['tool', 'tool.catalog', 'tool.call', 'tool.result']],
+                self::TEMPLATE_HOOK => ['feature' => self::FEATURE_HOOKS, 'constructs' => ['on.session_start', 'on.pre_tool_use', 'on.post_tool_use']],
+                self::TEMPLATE_SESSION => ['feature' => self::FEATURE_SESSION, 'constructs' => ['session', 'session.context', 'session.allow']],
+                self::TEMPLATE_MEMORY => ['feature' => self::FEATURE_MEMORY, 'constructs' => ['memory.remember', 'memory.recall', 'memory.inject']],
+                self::TEMPLATE_HOLOSCENE => ['feature' => self::FEATURE_HOLOSCENE, 'constructs' => ['holoscene', 'scene', 'episode']],
+                self::TEMPLATE_GOVERNANCE => ['feature' => self::FEATURE_GOVERNANCE, 'constructs' => ['review.request', 'review.decision', 'task.call']],
+                self::TEMPLATE_MCP => ['feature' => self::FEATURE_MCP, 'constructs' => ['mcp.server', 'mcp.resource', 'mcp.tool']],
+                self::TEMPLATE_ORCHESTRATION => ['feature' => self::FEATURE_ORCHESTRATION, 'constructs' => ['orchestrate', 'orchestrate.hierarchical', 'orchestrate.piano']],
+                self::TEMPLATE_GOAL => ['feature' => self::FEATURE_STATE_GOALS, 'constructs' => ['state.channel', 'goal', 'criterion', 'expectation']],
+                self::TEMPLATE_TRACE => ['feature' => self::FEATURE_TELEMETRY, 'constructs' => ['trace.task', 'trace.span', 'trace.cpct']],
+                self::TEMPLATE_SECURITY => ['feature' => self::FEATURE_SECURITY, 'constructs' => ['security.scan', 'security.validate', 'security.sanitize']],
             ],
             'hooks' => AgentHook::all(),
             'tool_catalog_filters' => [

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -2,10 +2,41 @@
 
 namespace BlueFission\Tests\Automata\LLM;
 
+use BlueFission\Automata\LLM\Agent;
+use BlueFission\Automata\LLM\Agent\AgentSession;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\Integration\AgentIntegrationContract;
 use BlueFission\Automata\LLM\Agent\ToolCatalog;
+use BlueFission\Automata\LLM\Clients\IClient;
+use BlueFission\Automata\LLM\Reply;
+use BlueFission\Obj;
 use PHPUnit\Framework\TestCase;
+
+class IntegrationContractClientStub implements IClient
+{
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        return $this->reply('generated');
+    }
+
+    public function complete($input, $config = []): Reply
+    {
+        return $this->reply('completed');
+    }
+
+    public function respond($input, $config = []): Reply
+    {
+        return $this->reply('responded');
+    }
+
+    protected function reply(string $message): Reply
+    {
+        $reply = new Reply();
+        $reply->addMessage($message, true);
+
+        return $reply;
+    }
+}
 
 class AgentIntegrationContractTest extends TestCase
 {
@@ -60,5 +91,36 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertStringContainsString('"version":"1.0.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
         $this->assertStringContainsString('"query.tool_catalog"', $json);
+    }
+
+    public function testAgentUsesDevelationPrototypeCarrier(): void
+    {
+        $agent = new Agent(new IntegrationContractClientStub());
+
+        $this->assertInstanceOf(Obj::class, $agent);
+        $this->assertSame('agent', $agent->kind());
+        $this->assertSame('llm-runtime', $agent->role());
+        $this->assertSame('automata.llm.agent', $agent->scope());
+        $this->assertSame('configurable', $agent->autonomy());
+        $this->assertContains('answer-user-visible-tasks', $agent->goals());
+
+        $agent->decide(['feature' => AgentIntegrationContract::FEATURE_TOOLS]);
+        $snapshot = $agent->snapshot();
+
+        $this->assertSame($agent->session()->id(), $snapshot['properties']['session_id']);
+        $this->assertSame(
+            AgentIntegrationContract::FEATURE_TOOLS,
+            $snapshot['lastDecision']['feature']
+        );
+    }
+
+    public function testAgentPrototypeTracksExternalSessionScope(): void
+    {
+        $agent = new Agent(new IntegrationContractClientStub());
+        $session = new AgentSession('contract-session');
+
+        $agent->useSession($session);
+
+        $this->assertSame('contract-session', $agent->snapshot()['properties']['session_id']);
     }
 }

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace BlueFission\Tests\Automata\LLM;
+
+use BlueFission\Automata\LLM\Agent\AgentHook;
+use BlueFission\Automata\LLM\Agent\Integration\AgentIntegrationContract;
+use BlueFission\Automata\LLM\Agent\ToolCatalog;
+use PHPUnit\Framework\TestCase;
+
+class AgentIntegrationContractTest extends TestCase
+{
+    public function testContractExportsStableFeatureIds(): void
+    {
+        $contract = AgentIntegrationContract::standard();
+
+        $this->assertSame(AgentIntegrationContract::VERSION, $contract->version());
+        $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TOOLS));
+        $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TELEMETRY));
+        $this->assertSame(
+            'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
+            $contract->feature(AgentIntegrationContract::FEATURE_TOOLS)['summary']
+        );
+    }
+
+    public function testConsumerFilteringKeepsLinqrFocusedOnQueryRelevantSurfaces(): void
+    {
+        $contract = AgentIntegrationContract::standard();
+        $features = $contract->features(AgentIntegrationContract::CONSUMER_LINQR);
+
+        $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_TOOLS, $features);
+        $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_TELEMETRY, $features);
+        $this->assertArrayNotHasKey(AgentIntegrationContract::FEATURE_HOOKS, $features);
+    }
+
+    public function testBindingsMapLanguageConstructsToAutomataFeatures(): void
+    {
+        $contract = AgentIntegrationContract::standard();
+        $jenss = $contract->bindings(AgentIntegrationContract::CONSUMER_JENSS);
+        $chainlinq = $contract->bindings(AgentIntegrationContract::CONSUMER_CHAINLINQ);
+
+        $this->assertSame(AgentIntegrationContract::FEATURE_TOOLS, $jenss['tool']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_ORCHESTRATION, $jenss['orchestrate']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_MCP, $chainlinq['adapter.mcp']);
+    }
+
+    public function testLifecycleHooksAndCatalogFiltersAreDiscoverable(): void
+    {
+        $contract = AgentIntegrationContract::standard();
+
+        $this->assertContains(AgentHook::SESSION_START, $contract->hooks());
+        $this->assertContains(AgentHook::HUMAN_REVIEW_DECISION, $contract->hooks());
+        $this->assertContains(ToolCatalog::FILTER_TAXONOMY, $contract->toolCatalogFilters());
+        $this->assertContains(ToolCatalog::FILTER_PARALLEL_SAFE, $contract->toolCatalogFilters());
+    }
+
+    public function testContractJsonCanSeedConformanceFixtures(): void
+    {
+        $json = AgentIntegrationContract::standard()->toJson();
+
+        $this->assertStringContainsString('"version":"1.0.0"', $json);
+        $this->assertStringContainsString('"agent.tool_contracts"', $json);
+        $this->assertStringContainsString('"query.tool_catalog"', $json);
+    }
+}

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -68,10 +68,14 @@ class AgentIntegrationContractTest extends TestCase
         );
     }
 
-    public function testConsumerFilteringKeepsLinqrFocusedOnQueryRelevantSurfaces(): void
+    public function testFeatureSelectionUsesCallerOwnedFeatureIds(): void
     {
         $contract = AgentIntegrationContract::standard();
-        $features = $contract->features(AgentIntegrationContract::CONSUMER_LINQR);
+        $features = $contract->features([
+            AgentIntegrationContract::FEATURE_TOOLS,
+            AgentIntegrationContract::FEATURE_HOLOSCENE,
+            AgentIntegrationContract::FEATURE_TELEMETRY,
+        ]);
 
         $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_TOOLS, $features);
         $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_HOLOSCENE, $features);
@@ -79,17 +83,26 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertArrayNotHasKey(AgentIntegrationContract::FEATURE_HOOKS, $features);
     }
 
-    public function testBindingsMapLanguageConstructsToAutomataFeatures(): void
+    public function testBindingTemplateMapsNeutralConstructsToAutomataFeatures(): void
     {
         $contract = AgentIntegrationContract::standard();
-        $jenss = $contract->bindings(AgentIntegrationContract::CONSUMER_JENSS);
-        $chainlinq = $contract->bindings(AgentIntegrationContract::CONSUMER_CHAINLINQ);
+        $template = $contract->bindingTemplate();
 
-        $this->assertSame(AgentIntegrationContract::FEATURE_TOOLS, $jenss['tool']);
-        $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $jenss['holoscene']);
-        $this->assertSame(AgentIntegrationContract::FEATURE_ORCHESTRATION, $jenss['orchestrate']);
-        $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $chainlinq['adapter.holoscene']);
-        $this->assertSame(AgentIntegrationContract::FEATURE_MCP, $chainlinq['adapter.mcp']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_TOOLS, $template['tool']['feature']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $template['holoscene']['feature']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_ORCHESTRATION, $template['orchestration']['feature']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_MCP, $template['mcp']['feature']);
+        $this->assertSame($template['tool'], $contract->bindings(AgentIntegrationContract::TEMPLATE_TOOL));
+    }
+
+    public function testContractTemplateDefinesAdapterOwnedUpstreamShape(): void
+    {
+        $template = AgentIntegrationContract::standard()->contractTemplate();
+
+        $this->assertSame('family.adapter.contract', $template['name']);
+        $this->assertSame('adapter-to-upstream-runtime', $template['direction']);
+        $this->assertContains('feature_bindings', $template['required_fields']);
+        $this->assertStringContainsString('adapter libraries own syntax', $template['boundary']);
     }
 
     public function testLifecycleHooksAndCatalogFiltersAreDiscoverable(): void
@@ -109,7 +122,11 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertStringContainsString('"version":"1.0.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
         $this->assertStringContainsString('"agent.holoscene_comprehension"', $json);
-        $this->assertStringContainsString('"query.tool_catalog"', $json);
+        $this->assertStringContainsString('"contract_template"', $json);
+        $this->assertStringNotContainsString('"jenss"', $json);
+        $this->assertStringNotContainsString('"jenerator"', $json);
+        $this->assertStringNotContainsString('"linqr"', $json);
+        $this->assertStringNotContainsString('"chainlinq"', $json);
     }
 
     public function testHolosceneFeatureAdvertisesComprehensionClasses(): void

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -7,8 +7,10 @@ use BlueFission\Automata\LLM\Agent\AgentSession;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\Integration\AgentIntegrationContract;
 use BlueFission\Automata\LLM\Agent\ToolCatalog;
+use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\Reply;
+use BlueFission\Automata\Memory\Abs2Memory;
 use BlueFission\Obj;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +40,19 @@ class IntegrationContractClientStub implements IClient
     }
 }
 
+class IntegrationContractSceneStub
+{
+    public function stats(): array
+    {
+        return ['frame_count' => 1];
+    }
+
+    public function data(): array
+    {
+        return ['summary' => 'contract scene'];
+    }
+}
+
 class AgentIntegrationContractTest extends TestCase
 {
     public function testContractExportsStableFeatureIds(): void
@@ -59,6 +74,7 @@ class AgentIntegrationContractTest extends TestCase
         $features = $contract->features(AgentIntegrationContract::CONSUMER_LINQR);
 
         $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_TOOLS, $features);
+        $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_HOLOSCENE, $features);
         $this->assertArrayHasKey(AgentIntegrationContract::FEATURE_TELEMETRY, $features);
         $this->assertArrayNotHasKey(AgentIntegrationContract::FEATURE_HOOKS, $features);
     }
@@ -70,7 +86,9 @@ class AgentIntegrationContractTest extends TestCase
         $chainlinq = $contract->bindings(AgentIntegrationContract::CONSUMER_CHAINLINQ);
 
         $this->assertSame(AgentIntegrationContract::FEATURE_TOOLS, $jenss['tool']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $jenss['holoscene']);
         $this->assertSame(AgentIntegrationContract::FEATURE_ORCHESTRATION, $jenss['orchestrate']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $chainlinq['adapter.holoscene']);
         $this->assertSame(AgentIntegrationContract::FEATURE_MCP, $chainlinq['adapter.mcp']);
     }
 
@@ -90,7 +108,18 @@ class AgentIntegrationContractTest extends TestCase
 
         $this->assertStringContainsString('"version":"1.0.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
+        $this->assertStringContainsString('"agent.holoscene_comprehension"', $json);
         $this->assertStringContainsString('"query.tool_catalog"', $json);
+    }
+
+    public function testHolosceneFeatureAdvertisesComprehensionClasses(): void
+    {
+        $feature = AgentIntegrationContract::standard()
+            ->feature(AgentIntegrationContract::FEATURE_HOLOSCENE);
+
+        $this->assertContains(Holoscene::class, $feature['classes']);
+        $this->assertContains('reader.to_holoscene', $feature['constructs']);
+        $this->assertContains('holoscene_snapshot', $feature['outputs']);
     }
 
     public function testAgentUsesDevelationPrototypeCarrier(): void
@@ -122,5 +151,22 @@ class AgentIntegrationContractTest extends TestCase
         $agent->useSession($session);
 
         $this->assertSame('contract-session', $agent->snapshot()['properties']['session_id']);
+    }
+
+    public function testAgentSessionScopesHolosceneEpisodes(): void
+    {
+        $agent = new Agent(new IntegrationContractClientStub());
+        $holoscene = new Holoscene('contract-holoscene');
+
+        $agent->useHoloscene($holoscene);
+        $agent->session()->useWorkingMemory(new Abs2Memory());
+        $agent->session()->addHolosceneEpisode('episode_contract', new IntegrationContractSceneStub());
+
+        $snapshot = $agent->session()->holosceneSnapshot();
+
+        $this->assertSame($holoscene, $agent->holoscene());
+        $this->assertSame('contract-holoscene', $agent->snapshot()['properties']['holoscene_id']);
+        $this->assertSame(1, $snapshot['sceneCount']);
+        $this->assertSame('scene', $snapshot['domain_members']['episode_contract']['kind']);
     }
 }


### PR DESCRIPTION
## Intent summary

Defines the first Automata-owned integration contract for JenSS, Jenerator, Chainlinq, and linqr so downstream runtimes can bind to stable Automata feature ids instead of prompt text or class internals.

Closes #34.

## User stories / acceptance criteria

- As a JenSS spec author, I can map language constructs to stable Automata feature ids.
- As a Jenerator adapter, I can discover Agent, session, hook, tool, governance, MCP, orchestration, goal, trace, and security surfaces deterministically.
- As a linqr or Chainlinq implementer, I can identify which Automata surfaces are query-relevant without taking ownership of Automata runtime behavior.
- Contract metadata includes hooks, catalog filter constants, class ownership, binding names, and production acceptance checks.

## Key files changed

- `src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php`
- `tests/Automata/LLM/AgentIntegrationContractTest.php`
- `examples/generic/agent_integration_contract.php`
- `docs/agent-capabilities.md`
- `README.md`

## How to test

```bash
php -l src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
php -l tests/Automata/LLM/AgentIntegrationContractTest.php
php -l examples/generic/agent_integration_contract.php
vendor/bin/phpunit --do-not-cache-result tests/Automata/LLM/AgentIntegrationContractTest.php tests/Automata/LLM/AgentToolContractsTest.php tests/Automata/LLM/AgentMemoryHooksTest.php tests/Automata/LLM/AgentOrchestrationTest.php tests/Automata/LLM/AgentPianoStateTest.php tests/Automata/LLM/AgentCpctTelemetryTest.php tests/Automata/LLM/AgentGovernanceTest.php tests/Automata/LLM/AgentLpciSafeguardsTest.php tests/Automata/LLM/MCPClientTest.php tests/Automata/LLM/MCPToolsTest.php
php examples/generic/agent_integration_contract.php
```

## QA checklist

- Contract exports a stable version and feature ids.
- Consumer filtering keeps linqr focused on query-relevant surfaces.
- JenSS and Chainlinq binding maps point to Automata feature ids.
- Lifecycle hooks and tool catalog filter constants are discoverable.
- Example emits a usable JSON contract slice.

## Approval conditions

- Confirm the feature id names are acceptable as the cross-repo contract vocabulary.
- Confirm JenSS, Jenerator, linqr, and Chainlinq issues linked in Keryx room #4 can use this as their Automata dependency.
