### PR TITLE
Optimize bounded trigram predictor training

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -246,6 +246,9 @@ Responsibilities:
   - response interpretation and routing.
 - Bridge between symbolic NLP (Language) and sub‑symbolic systems (LLMs and
   embeddings).
+- Keep local Markov-style prediction bounded and inspectable so moderate
+  catalogs can be trained synchronously without turning setup into hidden
+  inference work.
 
 ## 3. Representative Data Flows
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Anomaly Detection**: Score behavioral activity, fingerprints, and context to flag unusual or risky patterns.
 - **Media Ingestion**: Normalize text, image, audio, video, document, and URL inputs into consistent pipelines.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
+- **Bounded Language Prediction**: Lightweight Markov and trigram predictors support single-sentence updates and bounded bulk training for moderate local catalogs without requiring a hosted model.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
 - **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, Holoscene comprehension, orchestration patterns, DevElation-backed agent state/goal decisions, and interpreter-facing integration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
 - **Feature Engineering**: Provides robust tools for transforming raw data into features that better represent the underlying processes to predictive models.
@@ -44,6 +45,12 @@ Monte Carlo examples:
 ```bash
 php examples/monte_carlo_route_planning.php
 php examples/monte_carlo_tree_search_dispatch.php
+```
+
+Language prediction example:
+
+```bash
+php examples/markov_logistics_language.php
 ```
 
 ## Contributing

--- a/SPEC.md
+++ b/SPEC.md
@@ -198,6 +198,13 @@ It is already used in other libraries (e.g. `bluefissiontech/synthetiq`), so:
 Documenter, Grammar, Interpreter, Tokenizer, Walker, and related classes should
 be treated as production‑critical components.
 
+The lightweight Markov predictors are intended for local phrase continuity and
+small-to-moderate catalogs. Use `MarkovPredictor` when a single previous token
+is enough context. Use `TrigramMarkovPredictor::addSentence()` for incremental
+updates, and `TrigramMarkovPredictor::addSentences()` or `train()` when loading
+a catalog in bulk. Configure trigram bounds when training should remain memory
+and setup-time predictable.
+
 ### 3.7 Expert Systems
 
 The `Expert` folder focuses on **fact‑based expert systems**:

--- a/examples/markov_logistics_language.php
+++ b/examples/markov_logistics_language.php
@@ -31,9 +31,7 @@ foreach ($sentences as $s) {
 }
 
 $trigram = new TrigramMarkovPredictor();
-foreach ($sentences as $s) {
-    $trigram->addSentence($s);
-}
+$trigram->addSentences($sentences);
 
 mt_srand(123);
 $nextHub = $unigram->predictNextWord('hub');
@@ -50,6 +48,7 @@ echo "Trigram Markov: after 'hub road' -> '$nextHubRoad'\n";
 mt_srand(1011);
 $nextShelterIntake = $trigram->predictNextWord('shelter intake');
 echo "Trigram Markov: after 'shelter intake' -> '$nextShelterIntake'\n";
+echo "Trigram states trained: " . $trigram->stateCount() . "\n";
 
 echo "\nExample completed.\n";
 

--- a/src/Automata/Language/TrigramMarkovPredictor.php
+++ b/src/Automata/Language/TrigramMarkovPredictor.php
@@ -2,64 +2,283 @@
 
 namespace BlueFission\Automata\Language;
 
-use BlueFission\Automata\Collections\OrganizedCollection;
+use BlueFission\Arr;
+use BlueFission\DevElation as Dev;
+use BlueFission\Num;
+use BlueFission\Str;
+use BlueFission\Val;
 
 class TrigramMarkovPredictor {
-    protected $states;
-    protected $beginnings;
+    public const CONFIG_MAX_STATES = 'max_states';
+    public const CONFIG_MAX_BEGINNINGS = 'max_beginnings';
+    public const CONFIG_MAX_TRANSITIONS = 'max_transitions';
 
-    public function __construct() {
-        $this->states = new OrganizedCollection();
-        $this->states->setMax(10000); // Set max states to keep
-        $this->states->setDecay(true, 0.001); // Enable decay with a specific rate
-        $this->beginnings = new OrganizedCollection();
-        $this->beginnings->setMax(1000); // Manage the size of beginnings similarly
+    protected array $states = [];
+    protected array $beginnings = [];
+    protected int $maxStates;
+    protected int $maxBeginnings;
+    protected int $maxTransitions;
+
+    /**
+     * Configure bounded trigram storage for lightweight local prediction.
+     *
+     * @param array<string,mixed> $config
+     */
+    public function __construct(array $config = []) {
+        $this->maxStates = $this->normalizeLimit($config[self::CONFIG_MAX_STATES] ?? 10000, 10000);
+        $this->maxBeginnings = $this->normalizeLimit($config[self::CONFIG_MAX_BEGINNINGS] ?? 1000, 1000);
+        $this->maxTransitions = $this->normalizeLimit($config[self::CONFIG_MAX_TRANSITIONS] ?? 500, 500);
+
+        Dev::do('language.trigram.construct', [
+            'max_states' => $this->maxStates,
+            'max_beginnings' => $this->maxBeginnings,
+            'max_transitions' => $this->maxTransitions,
+        ]);
     }
 
-    public function addSentence($sentence) {
-        $words = $this->tokenize($sentence);
-        if (count($words) < 3) {
-            return; // Skip sentences that are too short to form a trigram
+    /**
+     * Add one sentence while preserving the legacy training entrypoint.
+     */
+    public function addSentence($sentence): self {
+        return $this->addSentences([$sentence]);
+    }
+
+    /**
+     * Add many sentences without per-transition collection sorting.
+     *
+     * @param iterable<int|string,mixed> $sentences
+     */
+    public function addSentences(iterable $sentences): self {
+        $added = 0;
+
+        foreach ($sentences as $sentence) {
+            if ($this->addTokenSequence($this->tokenize($sentence))) {
+                $added++;
+            }
         }
 
-        // Add the first word sequence to beginnings for potential initial states
-        $this->beginnings->add($words[0] . ' ' . $words[1]);
+        $this->prune();
 
-        for ($i = 2; $i < count($words); $i++) {
+        Dev::do('language.trigram.sentences_added', [
+            'count' => $added,
+            'states' => $this->stateCount(),
+            'beginnings' => $this->beginningCount(),
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Alias bulk training for strategy-style callers.
+     *
+     * @param iterable<int|string,mixed> $sentences
+     */
+    public function train(iterable $sentences): self {
+        return $this->addSentences($sentences);
+    }
+
+    /**
+     * Normalize a sentence into lowercase word tokens.
+     *
+     * @return array<int,string>
+     */
+    public function tokenize($sentence): array {
+        $sentence = Dev::apply('language.trigram.tokenize_sentence', $sentence);
+        $normalized = Str::make((string)$sentence)
+            ->lower()
+            ->trim()
+            ->replacePattern('/\s+/', ' ');
+
+        $tokens = [];
+        foreach ($normalized->split(' ')->toArray() as $token) {
+            if (Val::isNotEmpty($token)) {
+                $tokens[] = (string)$token;
+            }
+        }
+
+        Dev::do('language.trigram.tokenized', ['tokens' => $tokens]);
+
+        return $tokens;
+    }
+
+    /**
+     * Predict the next word from the last two words in the provided input.
+     */
+    public function predictNextWord($sentence) {
+        $sentence = Dev::apply('language.trigram.predict_input', $sentence);
+        $words = $this->tokenize($sentence);
+        $count = Arr::count($words);
+
+        if ($count < 2) {
+            return Dev::apply('language.trigram.predict_none', null);
+        }
+
+        $previousTwoWords = $words[$count - 2] . ' ' . $words[$count - 1];
+
+        if (!Arr::hasKey($this->states, $previousTwoWords)) {
+            return Dev::apply('language.trigram.predict_none', null);
+        }
+
+        $nextWords = $this->states[$previousTwoWords];
+        $total = $this->sumWeights($nextWords);
+
+        if ($total < 1) {
+            return Dev::apply('language.trigram.predict_none', null);
+        }
+
+        $rand = mt_rand(1, $total);
+
+        foreach ($nextWords as $word => $weight) {
+            $rand -= $weight;
+            if ($rand <= 0) {
+                $word = Dev::apply('language.trigram.predict_word', $word);
+                Dev::do('language.trigram.predicted', ['word' => $word, 'context' => $previousTwoWords]);
+                return $word;
+            }
+        }
+
+        return Dev::apply('language.trigram.predict_none', null);
+    }
+
+    /**
+     * Return the learned trigram state table.
+     *
+     * @return array<string,array<string,int>>
+     */
+    public function states(): array {
+        return Arr::make($this->states)->toArray();
+    }
+
+    /**
+     * Return tracked sentence-start contexts.
+     *
+     * @return array<string,int>
+     */
+    public function beginnings(): array {
+        return Arr::make($this->beginnings)->toArray();
+    }
+
+    /**
+     * Count trained trigram contexts.
+     */
+    public function stateCount(): int {
+        return Arr::count($this->states);
+    }
+
+    /**
+     * Count tracked beginning contexts.
+     */
+    public function beginningCount(): int {
+        return Arr::count($this->beginnings);
+    }
+
+    /**
+     * Clear trained state while preserving configured bounds.
+     */
+    public function reset(): self {
+        $this->states = [];
+        $this->beginnings = [];
+
+        return $this;
+    }
+
+    /**
+     * Add transitions from an already-tokenized sentence.
+     *
+     * @param array<int,string> $words
+     */
+    protected function addTokenSequence(array $words): bool {
+        $count = Arr::count($words);
+        if ($count < 3) {
+            return false;
+        }
+
+        $this->rememberBeginning($words[0] . ' ' . $words[1]);
+
+        for ($i = 2; $i < $count; $i++) {
             $trigram = $words[$i - 2] . ' ' . $words[$i - 1];
             $nextWord = $words[$i];
 
-            if (!$this->states->has($trigram)) {
-                $this->states->add([], $trigram);
+            if (!Arr::hasKey($this->states, $trigram)) {
+                $this->states[$trigram] = [];
             }
-            $currentData = $this->states->get($trigram);
-            if (!isset($currentData[$nextWord])) {
-                $currentData[$nextWord] = 0;
+
+            $this->states[$trigram][$nextWord] = ($this->states[$trigram][$nextWord] ?? 0) + 1;
+            $this->pruneTransitions($trigram);
+        }
+
+        return true;
+    }
+
+    /**
+     * Track a starting two-word context for possible future generation.
+     */
+    protected function rememberBeginning(string $context): void {
+        $this->beginnings[$context] = ($this->beginnings[$context] ?? 0) + 1;
+    }
+
+    /**
+     * Enforce global state and beginning limits after a bulk operation.
+     */
+    protected function prune(): void {
+        while (Arr::count($this->states) > $this->maxStates) {
+            foreach ($this->states as $key => $value) {
+                unset($this->states[$key]);
+                break;
             }
-            $currentData[$nextWord]++;
-            $this->states->add($currentData, $trigram);
+        }
+
+        while (Arr::count($this->beginnings) > $this->maxBeginnings) {
+            foreach ($this->beginnings as $key => $value) {
+                unset($this->beginnings[$key]);
+                break;
+            }
         }
     }
 
-    public function tokenize($sentence) {
-        // Simple tokenizer (consider improving or using a library for better tokenization)
-        return preg_split('/\s+/', strtolower($sentence));
-    }
+    /**
+     * Enforce per-context transition limits by dropping the lowest-weight terms.
+     */
+    protected function pruneTransitions(string $trigram): void {
+        if (Arr::count($this->states[$trigram]) <= $this->maxTransitions) {
+            return;
+        }
 
-    public function predictNextWord($sentence) {
-        $previousTwoWords = implode(' ', array_slice($this->tokenize($sentence), -2));
+        asort($this->states[$trigram]);
 
-        if ($this->states->has($previousTwoWords)) {
-            $nextWords = $this->states->get($previousTwoWords);
-            $total = array_sum($nextWords);
-            $rand = mt_rand(0, $total - 1);
-
-            foreach ($nextWords as $word => $count) {
-                if (($rand -= $count) < 0) {
-                    return $word;
-                }
+        while (Arr::count($this->states[$trigram]) > $this->maxTransitions) {
+            foreach ($this->states[$trigram] as $word => $weight) {
+                unset($this->states[$trigram][$word]);
+                break;
             }
         }
-        return null; // No next word found if no suitable transition exists
+    }
+
+    /**
+     * Sum integer transition weights without requiring collection conversion.
+     *
+     * @param array<string,int> $weights
+     */
+    protected function sumWeights(array $weights): int {
+        $total = 0;
+
+        foreach ($weights as $weight) {
+            $total += (int)$weight;
+        }
+
+        return $total;
+    }
+
+    /**
+     * Normalize a user-supplied positive integer limit.
+     */
+    protected function normalizeLimit(mixed $value, int $fallback): int {
+        if (!Num::is($value)) {
+            return $fallback;
+        }
+
+        $limit = (int)$value;
+
+        return $limit > 0 ? $limit : $fallback;
     }
 }

--- a/tests/Automata/Language/TrigramMarkovPredictorTest.php
+++ b/tests/Automata/Language/TrigramMarkovPredictorTest.php
@@ -29,5 +29,40 @@ class TrigramMarkovPredictorTest extends TestCase
 
         $this->assertSame($next1, $next2);
     }
-}
 
+    public function testBulkTrainingHandlesModerateDialogueCatalogQuickly(): void
+    {
+        $predictor = new TrigramMarkovPredictor();
+        $sentences = [];
+
+        for ($i = 0; $i < 350; $i++) {
+            $sentences[] = 'intent ' . ($i % 25) . ' option ' . ($i % 10) . ' response ' . $i;
+        }
+
+        $started = hrtime(true);
+        $predictor->addSentences($sentences);
+        $elapsed = (hrtime(true) - $started) / 1_000_000_000;
+
+        $this->assertLessThan(1.0, $elapsed);
+        $this->assertSame('option', $predictor->predictNextWord('intent 7'));
+        $this->assertGreaterThan(0, $predictor->stateCount());
+    }
+
+    public function testTrainingHonorsConfiguredBounds(): void
+    {
+        $predictor = new TrigramMarkovPredictor([
+            TrigramMarkovPredictor::CONFIG_MAX_STATES => 12,
+            TrigramMarkovPredictor::CONFIG_MAX_BEGINNINGS => 4,
+        ]);
+        $sentences = [];
+
+        for ($i = 0; $i < 80; $i++) {
+            $sentences[] = 'topic ' . $i . ' branch ' . ($i % 5) . ' answer';
+        }
+
+        $predictor->train($sentences);
+
+        $this->assertLessThanOrEqual(12, $predictor->stateCount());
+        $this->assertLessThanOrEqual(4, $predictor->beginningCount());
+    }
+}


### PR DESCRIPTION
## Intent summary
Optimize the trigram Markov predictor so moderate local catalogs can be trained through a bounded bulk path without per-transition collection maintenance.

Closes #39.

## User stories / acceptance criteria
- As a caller loading a moderate phrase catalog, I can use addSentences() or train() to bulk-load examples quickly.
- As an existing caller, addSentence() and predictNextWord() remain compatible.
- As a maintainer, trained state and beginning counts are inspectable and configurable bounds are enforced.
- Documentation and examples explain when to use MarkovPredictor, TrigramMarkovPredictor, and bulk training.

## Key files changed
- src/Automata/Language/TrigramMarkovPredictor.php
- tests/Automata/Language/TrigramMarkovPredictorTest.php
- examples/markov_logistics_language.php
- README.md, SPEC.md, ARCHITECTURE.md

## How to test
- php -l src/Automata/Language/TrigramMarkovPredictor.php
- php -l tests/Automata/Language/TrigramMarkovPredictorTest.php
- php -l examples/markov_logistics_language.php
- vendor/bin/phpunit --do-not-cache-result tests/Automata/Language/TrigramMarkovPredictorTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Automata/Language
- vendor/bin/phpunit --do-not-cache-result tests/Automata/Strategy/MarkovTextPredictionTest.php tests/Automata/Strategy/NGramTextPredictionTest.php
- php examples/markov_logistics_language.php

## QA checklist
- Focused language tests pass.
- Related strategy tests pass.
- Example runs and shows trained trigram state count.
- Full PHPUnit suite was attempted but exceeded the local five-minute timeout before producing failure output.

## Approval conditions
- Confirm the bounded array-backed storage is acceptable for this lightweight predictor.
- Confirm the documented bulk-loading guidance is sufficient for local catalog training.