### PR TITLE
Add LLM lane pressure management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Bounded Language Prediction**: Lightweight Markov and trigram predictors support single-sentence updates and bounded bulk training for moderate local catalogs without requiring a hosted model.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
 - **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, Holoscene comprehension, orchestration patterns, DevElation-backed agent state/goal decisions, and interpreter-facing integration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md).
+- **LLM Lane Pressure Management**: Assess semantic, operational, and execution pressure in provider-neutral agent workflows, with deterministic recommendations and a read-only LLM tool wrapper.
 - **Feature Engineering**: Provides robust tools for transforming raw data into features that better represent the underlying processes to predictive models.
 - **Data Science**: Basic machine learning functionalities alongside data manipulation, preparation, and visualization tools.
 - **Input Management**: Sophisticated input type detection and handling, ensuring that data flows seamlessly through processing pipelines.

--- a/SPEC.md
+++ b/SPEC.md
@@ -325,6 +325,8 @@ The `LLM` module integrates:
 
 - Template and parsing systems (via Develation and other libraries).
 - HTTP clients and remote APIs (e.g., OpenAI, Gemini).
+- Provider-neutral agent lane pressure utilities for semantic, operational, and
+  execution load.
 
 Intent:
 
@@ -332,6 +334,13 @@ Intent:
 - Allow LLMs to configure and supervise other, cheaper models:
   - e.g., use an LLM to configure an expert system or Bayesian classifier, then
     route matching intents to the smaller model.
+- Help agent runtimes decide whether pressure belongs to meaning/context,
+  policy/runbook, or concrete execution lanes without coupling Automata to one
+  provider's internal terminology.
+- Seed pressure metrics from long-horizon task readiness, including specs,
+  source maps, durable memory, runbooks, checkpoints, audit logs, verification,
+  observability, isolated workspaces, repair loops, rollback plans, local
+  governance, and tool failures.
 
 ### 3.14 Intelligence Hub (Multi-Strategy Insights)
 

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -95,6 +95,20 @@ Goal reasoning lives in Automata's `Goal` namespace instead of inside the cognit
 
 The default classes are dependency-injection examples as much as concrete implementations. `GoalManager` implements `IGoalManager` and uses `ManagesGoals`; custom managers can implement the same interface and import the trait when they only need to adjust persistence, weighting, or constructor policy. `CognitiveController` implements `IStateController` and uses `ControlsAgentState`; custom controllers can import that trait to keep the standard bottleneck, goal recommendation, and state-write behavior while overriding only the decision context or option selection. `AgentState` accepts an `IGoalManager`, and `Agent::setCognitiveController()` accepts an `IStateController`, so applications can swap either side through normal dependency injection.
 
+## Lane Pressure Management
+
+Agent runtimes often separate meaning, policy, and concrete action even when they use different labels for those layers. Automata models that pattern as provider-neutral lanes rather than as a vendor-specific contract:
+
+- semantic: intent, context, ambiguity, and meaning pressure
+- operational: policy, permission, runbook, budget, and coordination pressure
+- execution: tool, sandbox, mutation, runtime, and validation pressure
+
+`AgentLane` describes the stable lane metadata. `LanePressureManager` accepts normalized lane metrics and returns the dominant lane, pressure levels, dominant signals, and bounded recommendations. `LanePressure` exposes the same assessment as a deterministic read-only LLM tool for agents that want the model to ask for a lane-pressure report without letting the model perform the assessment itself.
+
+`LanePressureProfile::longHorizonTask()` seeds metrics from common long-running-agent scaffolding: spec clarity, source maps, durable memory, runbooks, milestones, audit logs, verification, observability, isolated workspaces, repair loops, rollback plans, local governance, and tool failures. Missing or weak scaffolding becomes pressure in the lane that can actually reduce the risk.
+
+Use this when an application needs to decide whether to summarize context, request approval, split execution into smaller calls, or stop mutations until a lane pressure is resolved. Do not use it as proof that every provider shares the same internal architecture; it is an Automata utility for a common agent-design pressure pattern.
+
 ## Integration Contract Template
 
 `AgentIntegrationContract` exposes Automata's stable agent feature surface as deterministic metadata for external adapters. It does not execute tools or prompts, and it does not know which descendant or application library will consume it. Instead, it names supported feature ids, owning classes, lifecycle hooks, tool catalog filter constants, neutral construct hints, a reusable contract template, and production acceptance checks that other libraries can use to publish their own upstream-facing contracts.
@@ -110,6 +124,7 @@ The first contract version covers:
 - orchestration patterns, nested orchestrations, and PIANO flows
 - behavioral state, goals, criteria, expectations, and bounded decisions
 - CPCT telemetry and runtime security validation
+- provider-neutral lane pressure assessment
 
 Adapters should bind to the contract's feature ids rather than hard-coding prompt text or concrete class internals. Automata provides `contractTemplate()` and `bindingTemplate()` so adapter libraries can decide their own construct names, syntax, query language, ingestion flow, and conformance fixtures while pointing back to stable Automata feature ids. Sibling libraries may coordinate with one another, but Automata should not carry descendant-specific binding maps.
 

--- a/examples/generic/agent_lane_pressure.php
+++ b/examples/generic/agent_lane_pressure.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Automata\LLM\Agent\Lanes\AgentLane;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureManager;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureProfile;
+use BlueFission\Automata\LLM\Tools\LanePressure;
+
+$metrics = [
+    AgentLane::SEMANTIC => [
+        'context_load' => 0.78,
+        'ambiguity' => 0.46,
+    ],
+    AgentLane::OPERATIONAL => [
+        'policy_conflict' => 0.2,
+        'budget_pressure' => 0.35,
+    ],
+    AgentLane::EXECUTION => [
+        'tool_failures' => 0.12,
+        'runtime_load' => 0.4,
+    ],
+];
+
+$manager = LanePressureManager::standard();
+$assessment = $manager->assess($metrics, [
+    'task_id' => 'example-lane-pressure',
+    'runtime' => 'provider-neutral-agent',
+]);
+
+print json_encode($assessment, JSON_PRETTY_PRINT) . PHP_EOL;
+
+$readinessMetrics = LanePressureProfile::longHorizonTask([
+    'spec' => true,
+    'source_map' => 0.6,
+    'durable_memory' => true,
+    'runbook' => false,
+    'milestones' => 0.5,
+    'audit_log' => true,
+    'verification' => 0.8,
+    'observability' => false,
+    'isolated_workspace' => true,
+    'repair_loop' => true,
+    'rollback_plan' => false,
+    'local_governance' => 0.7,
+]);
+
+print json_encode($manager->assess($readinessMetrics, [
+    'task_id' => 'example-long-horizon-readiness',
+]), JSON_PRETTY_PRINT) . PHP_EOL;
+
+$tool = new LanePressure($manager);
+print $tool->execute([
+    'metrics' => $metrics,
+    'context' => ['task_id' => 'example-lane-pressure-tool'],
+]) . PHP_EOL;

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -13,6 +13,9 @@ use BlueFission\Automata\LLM\Agent\AgentSession;
 use BlueFission\Automata\LLM\Agent\Governance\GovernanceDecision;
 use BlueFission\Automata\LLM\Agent\Governance\HumanReviewGate;
 use BlueFission\Automata\LLM\Agent\Governance\TaskCallMonitor;
+use BlueFission\Automata\LLM\Agent\Lanes\AgentLane;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureManager;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureProfile;
 use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
 use BlueFission\Automata\LLM\Agent\Security\RuntimeLogicValidator;
 use BlueFission\Automata\LLM\Agent\State\AgentState;
@@ -28,7 +31,7 @@ use BlueFission\Obj;
 
 class AgentIntegrationContract extends Obj
 {
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     public const FEATURE_AGENT = 'agent.runtime';
     public const FEATURE_TOOLS = 'agent.tool_contracts';
@@ -42,6 +45,7 @@ class AgentIntegrationContract extends Obj
     public const FEATURE_STATE_GOALS = 'agent.state_goals';
     public const FEATURE_TELEMETRY = 'agent.cpct_telemetry';
     public const FEATURE_SECURITY = 'agent.runtime_security';
+    public const FEATURE_LANE_PRESSURE = 'agent.lane_pressure';
 
     public const TEMPLATE_AGENT = 'agent';
     public const TEMPLATE_TOOL = 'tool';
@@ -55,6 +59,7 @@ class AgentIntegrationContract extends Obj
     public const TEMPLATE_GOAL = 'goal';
     public const TEMPLATE_TRACE = 'trace';
     public const TEMPLATE_SECURITY = 'security';
+    public const TEMPLATE_LANES = 'lanes';
 
     /**
      * Build the standard Automata integration surface for adapter contracts.
@@ -276,6 +281,13 @@ class AgentIntegrationContract extends Obj
                     'inputs' => ['content', 'tool_result', 'memory_event'],
                     'outputs' => ['finding', 'sanitized_content', 'blocked_result'],
                 ],
+                self::FEATURE_LANE_PRESSURE => [
+                    'summary' => 'Provider-neutral semantic, operational, and execution lane pressure assessment.',
+                    'classes' => [AgentLane::class, LanePressureManager::class, LanePressureProfile::class],
+                    'constructs' => ['lane.semantic', 'lane.operational', 'lane.execution', 'lane.pressure', 'lane.profile.long_horizon'],
+                    'inputs' => ['lane_metrics', 'task_context', 'readiness_profile'],
+                    'outputs' => ['dominant_lane', 'overall_level', 'recommendations'],
+                ],
             ],
             'contract_template' => [
                 'name' => 'family.adapter.contract',
@@ -302,6 +314,7 @@ class AgentIntegrationContract extends Obj
                 self::TEMPLATE_GOAL => ['feature' => self::FEATURE_STATE_GOALS, 'constructs' => ['state.channel', 'goal', 'criterion', 'expectation']],
                 self::TEMPLATE_TRACE => ['feature' => self::FEATURE_TELEMETRY, 'constructs' => ['trace.task', 'trace.span', 'trace.cpct']],
                 self::TEMPLATE_SECURITY => ['feature' => self::FEATURE_SECURITY, 'constructs' => ['security.scan', 'security.validate', 'security.sanitize']],
+                self::TEMPLATE_LANES => ['feature' => self::FEATURE_LANE_PRESSURE, 'constructs' => ['lane.semantic', 'lane.operational', 'lane.execution', 'lane.pressure', 'lane.profile.long_horizon']],
             ],
             'hooks' => AgentHook::all(),
             'tool_catalog_filters' => [

--- a/src/Automata/LLM/Agent/Lanes/AgentLane.php
+++ b/src/Automata/LLM/Agent/Lanes/AgentLane.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Lanes;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+class AgentLane extends Obj
+{
+    public const SEMANTIC = 'semantic';
+    public const OPERATIONAL = 'operational';
+    public const EXECUTION = 'execution';
+
+    public function __construct(array $config = [])
+    {
+        parent::__construct();
+        $this->replaceFields(ToolDefinition::mergeConfig($this->defaults(), $config));
+    }
+
+    public static function semantic(): self
+    {
+        return new self([
+            'id' => self::SEMANTIC,
+            'label' => 'Semantic',
+            'purpose' => 'Intent, meaning, context, and reasoning shape before action.',
+            'responsibilities' => ['intent', 'context', 'semantic_map', 'ambiguity'],
+            'pressure_signals' => [
+                'context_load',
+                'ambiguity',
+                'semantic_drift',
+                'unknown_terms',
+                'mission_scope_gap',
+                'source_map_gap',
+                'durable_memory_gap',
+            ],
+            'recommendations' => [
+                LanePressureManager::LEVEL_LOW => 'Keep normal reasoning context and continue.',
+                LanePressureManager::LEVEL_MEDIUM => 'Summarize context, refresh the source map, and narrow the active evidence set.',
+                LanePressureManager::LEVEL_HIGH => 'Pause execution, clarify intent, and rebuild the durable task frame before adding more context.',
+                LanePressureManager::LEVEL_CRITICAL => 'Stop expansion and require an explicit spec, source map, or smaller semantic frame.',
+            ],
+        ]);
+    }
+
+    public static function operational(): self
+    {
+        return new self([
+            'id' => self::OPERATIONAL,
+            'label' => 'Operational',
+            'purpose' => 'Policies, runbooks, permissions, budgets, and coordination rules.',
+            'responsibilities' => ['policy', 'permissions', 'runbook', 'coordination', 'budget'],
+            'pressure_signals' => [
+                'policy_conflict',
+                'approval_pending',
+                'budget_pressure',
+                'coordination_gap',
+                'runbook_gap',
+                'milestone_gap',
+                'audit_log_gap',
+                'governance_sync_gap',
+            ],
+            'recommendations' => [
+                LanePressureManager::LEVEL_LOW => 'Keep normal policy checks and continue.',
+                LanePressureManager::LEVEL_MEDIUM => 'Refresh the runbook, confirm permissions, and record the next checkpoint.',
+                LanePressureManager::LEVEL_HIGH => 'Defer mutations until runbook, milestone, approval, or audit-log gaps are resolved.',
+                LanePressureManager::LEVEL_CRITICAL => 'Block execution and route to human review or a new operating decision with an audit trail.',
+            ],
+        ]);
+    }
+
+    public static function execution(): self
+    {
+        return new self([
+            'id' => self::EXECUTION,
+            'label' => 'Execution',
+            'purpose' => 'Tools, sandbox work, file changes, tests, and concrete runtime effects.',
+            'responsibilities' => ['tool_use', 'filesystem', 'tests', 'runtime', 'subtasks'],
+            'pressure_signals' => [
+                'tool_failures',
+                'test_failures',
+                'mutation_risk',
+                'runtime_load',
+                'verification_gap',
+                'observability_gap',
+                'isolation_gap',
+                'repair_loop_stall',
+                'rollback_gap',
+            ],
+            'recommendations' => [
+                LanePressureManager::LEVEL_LOW => 'Keep normal tool and test cadence.',
+                LanePressureManager::LEVEL_MEDIUM => 'Run focused checks, expose relevant logs, and split large actions into smaller tool calls.',
+                LanePressureManager::LEVEL_HIGH => 'Reduce concurrency, isolate failing tools, and validate a smaller change set with observable evidence.',
+                LanePressureManager::LEVEL_CRITICAL => 'Stop further mutations until the execution failure, verification gap, or sandbox risk is diagnosed.',
+            ],
+        ]);
+    }
+
+    public static function standard(): array
+    {
+        return [
+            self::SEMANTIC => self::semantic(),
+            self::OPERATIONAL => self::operational(),
+            self::EXECUTION => self::execution(),
+        ];
+    }
+
+    public function id(): string
+    {
+        return (string)$this->field('id');
+    }
+
+    public function label(): string
+    {
+        return (string)$this->field('label');
+    }
+
+    public function purpose(): string
+    {
+        return (string)$this->field('purpose');
+    }
+
+    public function responsibilities(): array
+    {
+        return Arr::make($this->field('responsibilities') ?? [])->toArray();
+    }
+
+    public function pressureSignals(): array
+    {
+        return Arr::make($this->field('pressure_signals') ?? [])->toArray();
+    }
+
+    public function recommendation(string $level): string
+    {
+        $recommendations = Arr::make($this->field('recommendations') ?? [])->toArray();
+
+        return (string)($recommendations[$level] ?? $recommendations[LanePressureManager::LEVEL_LOW] ?? '');
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id(),
+            'label' => $this->label(),
+            'purpose' => $this->purpose(),
+            'responsibilities' => $this->responsibilities(),
+            'pressure_signals' => $this->pressureSignals(),
+            'recommendations' => Arr::make($this->field('recommendations') ?? [])->toArray(),
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'label' => '',
+            'purpose' => '',
+            'responsibilities' => [],
+            'pressure_signals' => [],
+            'recommendations' => [],
+        ];
+    }
+
+    protected function replaceFields(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->_data[$key] = $value;
+        }
+    }
+}

--- a/src/Automata/LLM/Agent/Lanes/LanePressureManager.php
+++ b/src/Automata/LLM/Agent/Lanes/LanePressureManager.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Lanes;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\DevElation as Dev;
+use BlueFission\Num;
+
+class LanePressureManager
+{
+    public const LEVEL_NONE = 'none';
+    public const LEVEL_LOW = 'low';
+    public const LEVEL_MEDIUM = 'medium';
+    public const LEVEL_HIGH = 'high';
+    public const LEVEL_CRITICAL = 'critical';
+
+    protected array $lanes = [];
+    protected array $config = [];
+
+    public function __construct(array $lanes = [], array $config = [])
+    {
+        $this->lanes = $this->normalizeLanes($lanes ?: AgentLane::standard());
+        $this->config = ToolDefinition::mergeConfig([
+            'thresholds' => [
+                self::LEVEL_LOW => 0.25,
+                self::LEVEL_MEDIUM => 0.5,
+                self::LEVEL_HIGH => 0.75,
+                self::LEVEL_CRITICAL => 0.9,
+            ],
+        ], $config);
+    }
+
+    public static function standard(array $config = []): self
+    {
+        return new self([], $config);
+    }
+
+    public function lanes(): array
+    {
+        return $this->lanes;
+    }
+
+    public function lane(string $id): ?AgentLane
+    {
+        return $this->lanes[$id] ?? null;
+    }
+
+    public function assess(array $metrics, array $context = []): array
+    {
+        $metrics = Dev::apply('automata.llm.agent.lanes.metrics', $metrics);
+        $laneReports = [];
+        $recommendations = [];
+        $dominantLane = null;
+        $highestScore = 0.0;
+
+        foreach ($this->lanes as $laneId => $lane) {
+            $signals = $this->normalizeSignals(Arr::make($metrics[$laneId] ?? [])->toArray());
+            $score = $this->scoreSignals($signals);
+            $level = $this->levelFor($score);
+            $dominantSignal = $this->dominantSignal($signals);
+            $laneRecommendations = $this->recommendationsFor($lane, $level, $dominantSignal);
+
+            if ($score > $highestScore || $dominantLane === null) {
+                $highestScore = $score;
+                $dominantLane = $laneId;
+            }
+
+            foreach ($laneRecommendations as $recommendation) {
+                $recommendations[] = $recommendation;
+            }
+
+            $laneReports[$laneId] = [
+                'lane' => $lane->toArray(),
+                'score' => $score,
+                'level' => $level,
+                'dominant_signal' => $dominantSignal,
+                'signals' => $signals,
+                'recommendations' => $laneRecommendations,
+            ];
+        }
+
+        return Dev::apply('automata.llm.agent.lanes.assessment', [
+            'dominant_lane' => $dominantLane,
+            'overall_score' => $highestScore,
+            'overall_level' => $this->levelFor($highestScore),
+            'lanes' => $laneReports,
+            'recommendations' => $recommendations,
+            'unmapped_metrics' => $this->unmappedMetrics($metrics),
+            'context' => $context,
+        ]);
+    }
+
+    protected function normalizeLanes(array $lanes): array
+    {
+        $normalized = [];
+        foreach ($lanes as $key => $lane) {
+            $lane = $lane instanceof AgentLane ? $lane : new AgentLane(Arr::make($lane)->toArray());
+            $normalized[$lane->id() ?: (string)$key] = $lane;
+        }
+
+        return $normalized;
+    }
+
+    protected function normalizeSignals(array $signals): array
+    {
+        $normalized = [];
+        foreach ($signals as $name => $value) {
+            $weight = 1.0;
+            $raw = $value;
+
+            if (Arr::is($value)) {
+                $raw = $value['value'] ?? 0;
+                $weight = max(0.0, (float)($value['weight'] ?? 1.0));
+            }
+
+            $normalized[(string)$name] = [
+                'value' => $this->normalizePressureValue($raw),
+                'weight' => $weight,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    protected function normalizePressureValue(mixed $value): float
+    {
+        if ($value === true) {
+            return 1.0;
+        }
+
+        if ($value === false || $value === null) {
+            return 0.0;
+        }
+
+        if (!Num::is($value)) {
+            return 0.0;
+        }
+
+        return max(0.0, min(1.0, (float)$value));
+    }
+
+    protected function scoreSignals(array $signals): float
+    {
+        if (!$signals) {
+            return 0.0;
+        }
+
+        $weighted = 0.0;
+        $weightTotal = 0.0;
+        $max = 0.0;
+
+        foreach ($signals as $signal) {
+            $value = (float)($signal['value'] ?? 0.0);
+            $weight = max(0.0, (float)($signal['weight'] ?? 1.0));
+            $weighted += $value * $weight;
+            $weightTotal += $weight;
+            $max = max($max, $value);
+        }
+
+        $average = $weightTotal > 0.0 ? $weighted / $weightTotal : 0.0;
+
+        return round(max($average, $max), 4);
+    }
+
+    protected function dominantSignal(array $signals): ?array
+    {
+        $dominant = null;
+        foreach ($signals as $name => $signal) {
+            if ($dominant === null || (float)$signal['value'] > (float)$dominant['value']) {
+                $dominant = [
+                    'name' => (string)$name,
+                    'value' => (float)$signal['value'],
+                ];
+            }
+        }
+
+        return $dominant;
+    }
+
+    protected function levelFor(float $score): string
+    {
+        $thresholds = Arr::make($this->config['thresholds'] ?? [])->toArray();
+
+        if ($score >= (float)($thresholds[self::LEVEL_CRITICAL] ?? 0.9)) {
+            return self::LEVEL_CRITICAL;
+        }
+
+        if ($score >= (float)($thresholds[self::LEVEL_HIGH] ?? 0.75)) {
+            return self::LEVEL_HIGH;
+        }
+
+        if ($score >= (float)($thresholds[self::LEVEL_MEDIUM] ?? 0.5)) {
+            return self::LEVEL_MEDIUM;
+        }
+
+        if ($score >= (float)($thresholds[self::LEVEL_LOW] ?? 0.25)) {
+            return self::LEVEL_LOW;
+        }
+
+        return self::LEVEL_NONE;
+    }
+
+    protected function recommendationsFor(AgentLane $lane, string $level, ?array $dominantSignal): array
+    {
+        if ($level === self::LEVEL_NONE) {
+            return [];
+        }
+
+        $recommendation = $lane->recommendation($level);
+        if (!$recommendation) {
+            return [];
+        }
+
+        $prefix = $lane->label() . ' lane pressure is ' . $level;
+        if ($dominantSignal) {
+            $prefix .= ' from ' . $dominantSignal['name'];
+        }
+
+        return [$prefix . ': ' . $recommendation];
+    }
+
+    protected function unmappedMetrics(array $metrics): array
+    {
+        $unmapped = [];
+        foreach ($metrics as $laneId => $signals) {
+            if (!Arr::hasKey($this->lanes, $laneId)) {
+                $unmapped[$laneId] = $signals;
+            }
+        }
+
+        return $unmapped;
+    }
+}

--- a/src/Automata/LLM/Agent/Lanes/LanePressureManager.php
+++ b/src/Automata/LLM/Agent/Lanes/LanePressureManager.php
@@ -137,7 +137,7 @@ class LanePressureManager
             return 0.0;
         }
 
-        return max(0.0, min(1.0, (float)$value));
+        return Num::max(0.0, Num::min((float)$value, 1.0));
     }
 
     protected function scoreSignals(array $signals): float
@@ -152,15 +152,15 @@ class LanePressureManager
 
         foreach ($signals as $signal) {
             $value = (float)($signal['value'] ?? 0.0);
-            $weight = max(0.0, (float)($signal['weight'] ?? 1.0));
+            $weight = Num::max(0.0, (float)($signal['weight'] ?? 1.0));
             $weighted += $value * $weight;
             $weightTotal += $weight;
-            $max = max($max, $value);
+            $max = Num::max($max, $value);
         }
 
         $average = $weightTotal > 0.0 ? $weighted / $weightTotal : 0.0;
 
-        return round(max($average, $max), 4);
+        return Num::round(Num::max($average, $max), 4);
     }
 
     protected function dominantSignal(array $signals): ?array

--- a/src/Automata/LLM/Agent/Lanes/LanePressureProfile.php
+++ b/src/Automata/LLM/Agent/Lanes/LanePressureProfile.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Lanes;
+
+use BlueFission\Num;
+
+class LanePressureProfile
+{
+    /**
+     * Convert long-horizon task readiness into lane metrics.
+     */
+    public static function longHorizonTask(array $readiness = []): array
+    {
+        return [
+            AgentLane::SEMANTIC => [
+                'mission_scope_gap' => self::gap($readiness, 'spec', 0.9, 1.1),
+                'source_map_gap' => self::gap($readiness, 'source_map', 0.85, 1.1),
+                'durable_memory_gap' => self::gap($readiness, 'durable_memory', 0.8, 1.0),
+                'context_load' => self::direct($readiness, 'context_load'),
+            ],
+            AgentLane::OPERATIONAL => [
+                'runbook_gap' => self::gap($readiness, 'runbook', 0.85, 1.1),
+                'milestone_gap' => self::gap($readiness, 'milestones', 0.8, 1.0),
+                'audit_log_gap' => self::gap($readiness, 'audit_log', 0.75, 0.9),
+                'governance_sync_gap' => self::gap($readiness, 'local_governance', 0.7, 0.9),
+                'policy_conflict' => self::direct($readiness, 'policy_conflict'),
+            ],
+            AgentLane::EXECUTION => [
+                'verification_gap' => self::gap($readiness, 'verification', 0.9, 1.2),
+                'observability_gap' => self::gap($readiness, 'observability', 0.75, 0.9),
+                'isolation_gap' => self::gap($readiness, 'isolated_workspace', 0.8, 1.0),
+                'repair_loop_stall' => self::gap($readiness, 'repair_loop', 0.75, 0.9),
+                'rollback_gap' => self::gap($readiness, 'rollback_plan', 0.65, 0.8),
+                'tool_failures' => self::direct($readiness, 'tool_failures'),
+            ],
+        ];
+    }
+
+    protected static function gap(array $readiness, string $key, float $defaultPressure, float $weight): array
+    {
+        return [
+            'value' => self::pressure($readiness[$key] ?? null, $defaultPressure, true),
+            'weight' => $weight,
+        ];
+    }
+
+    protected static function direct(array $readiness, string $key): array
+    {
+        return [
+            'value' => self::pressure($readiness[$key] ?? 0, 0.0, false),
+            'weight' => 1.0,
+        ];
+    }
+
+    protected static function pressure(mixed $value, float $defaultPressure, bool $invertReadiness): float
+    {
+        if ($value === null) {
+            return $defaultPressure;
+        }
+
+        if ($value === true) {
+            return $invertReadiness ? 0.0 : 1.0;
+        }
+
+        if ($value === false) {
+            return $invertReadiness ? $defaultPressure : 0.0;
+        }
+
+        if (!Num::is($value)) {
+            return $invertReadiness ? 0.0 : 0.0;
+        }
+
+        $normalized = max(0.0, min(1.0, (float)$value));
+
+        return $invertReadiness ? round(1.0 - $normalized, 4) : $normalized;
+    }
+}

--- a/src/Automata/LLM/Agent/Lanes/LanePressureProfile.php
+++ b/src/Automata/LLM/Agent/Lanes/LanePressureProfile.php
@@ -70,8 +70,8 @@ class LanePressureProfile
             return $invertReadiness ? 0.0 : 0.0;
         }
 
-        $normalized = max(0.0, min(1.0, (float)$value));
+        $normalized = Num::max(0.0, Num::min((float)$value, 1.0));
 
-        return $invertReadiness ? round(1.0 - $normalized, 4) : $normalized;
+        return $invertReadiness ? Num::round(1.0 - $normalized, 4) : $normalized;
     }
 }

--- a/src/Automata/LLM/Tools/LanePressure.php
+++ b/src/Automata/LLM/Tools/LanePressure.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Tools;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureManager;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+
+class LanePressure extends BaseTool
+{
+    protected LanePressureManager $manager;
+
+    public function __construct(?LanePressureManager $manager = null)
+    {
+        $this->name = 'lane_pressure';
+        $this->description = 'Assesses semantic, operational, and execution pressure for an agent task.';
+        $this->manager = $manager ?: LanePressureManager::standard();
+    }
+
+    public function execute($input): string
+    {
+        $payload = $this->normalizeInput($input);
+        if (!Arr::is($payload)) {
+            return HTTP::jsonEncode([
+                'status' => 'error',
+                'error' => [
+                    'code' => 'invalid_input',
+                    'message' => 'Lane pressure input must be an array or JSON object.',
+                ],
+            ]);
+        }
+
+        $metrics = Arr::make($payload['metrics'] ?? $payload)->toArray();
+        $context = Arr::make($payload['context'] ?? [])->toArray();
+
+        return HTTP::jsonEncode($this->manager->assess($metrics, $context));
+    }
+
+    protected function normalizeInput(mixed $input): mixed
+    {
+        if (Str::is($input)) {
+            $decoded = json_decode((string)$input, true);
+
+            return json_last_error() === JSON_ERROR_NONE ? $decoded : null;
+        }
+
+        return $input;
+    }
+}

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -62,6 +62,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertSame(AgentIntegrationContract::VERSION, $contract->version());
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TOOLS));
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TELEMETRY));
+        $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_LANE_PRESSURE));
         $this->assertSame(
             'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
             $contract->feature(AgentIntegrationContract::FEATURE_TOOLS)['summary']
@@ -119,9 +120,10 @@ class AgentIntegrationContractTest extends TestCase
     {
         $json = AgentIntegrationContract::standard()->toJson();
 
-        $this->assertStringContainsString('"version":"1.0.0"', $json);
+        $this->assertStringContainsString('"version":"1.1.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
         $this->assertStringContainsString('"agent.holoscene_comprehension"', $json);
+        $this->assertStringContainsString('"agent.lane_pressure"', $json);
         $this->assertStringContainsString('"contract_template"', $json);
         $this->assertStringNotContainsString('"jenss"', $json);
         $this->assertStringNotContainsString('"jenerator"', $json);

--- a/tests/Automata/LLM/AgentLanePressureTest.php
+++ b/tests/Automata/LLM/AgentLanePressureTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace BlueFission\Tests\Automata\LLM;
+
+use BlueFission\Automata\LLM\Agent\Lanes\AgentLane;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureManager;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureProfile;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Automata\LLM\Tools\LanePressure;
+use PHPUnit\Framework\TestCase;
+
+class AgentLanePressureTest extends TestCase
+{
+    public function testStandardLaneDescriptorsAreProviderNeutral(): void
+    {
+        $lanes = AgentLane::standard();
+
+        $this->assertArrayHasKey(AgentLane::SEMANTIC, $lanes);
+        $this->assertArrayHasKey(AgentLane::OPERATIONAL, $lanes);
+        $this->assertArrayHasKey(AgentLane::EXECUTION, $lanes);
+        $this->assertStringContainsString('Intent', $lanes[AgentLane::SEMANTIC]->purpose());
+        $this->assertNotContains('codex', array_map('strtolower', $lanes[AgentLane::EXECUTION]->responsibilities()));
+    }
+
+    public function testPressureManagerFindsDominantLaneAndRecommendations(): void
+    {
+        $manager = LanePressureManager::standard();
+
+        $assessment = $manager->assess([
+            AgentLane::SEMANTIC => [
+                'context_load' => 0.82,
+                'ambiguity' => 0.3,
+            ],
+            AgentLane::OPERATIONAL => [
+                'policy_conflict' => 0.2,
+            ],
+            AgentLane::EXECUTION => [
+                'tool_failures' => 0.55,
+            ],
+        ], ['task_id' => 'lane-test']);
+
+        $this->assertSame(AgentLane::SEMANTIC, $assessment['dominant_lane']);
+        $this->assertSame(LanePressureManager::LEVEL_HIGH, $assessment['overall_level']);
+        $this->assertSame('context_load', $assessment['lanes'][AgentLane::SEMANTIC]['dominant_signal']['name']);
+        $this->assertStringContainsString('clarify intent', $assessment['recommendations'][0]);
+        $this->assertSame('lane-test', $assessment['context']['task_id']);
+    }
+
+    public function testPressureManagerBlocksCriticalOperationalPressure(): void
+    {
+        $assessment = LanePressureManager::standard()->assess([
+            AgentLane::OPERATIONAL => [
+                'approval_pending' => true,
+            ],
+        ]);
+
+        $this->assertSame(AgentLane::OPERATIONAL, $assessment['dominant_lane']);
+        $this->assertSame(LanePressureManager::LEVEL_CRITICAL, $assessment['overall_level']);
+        $this->assertStringContainsString('human review', $assessment['recommendations'][0]);
+    }
+
+    public function testLongHorizonProfileMapsReadinessGapsToLanes(): void
+    {
+        $metrics = LanePressureProfile::longHorizonTask([
+            'spec' => true,
+            'source_map' => 0.25,
+            'durable_memory' => true,
+            'runbook' => false,
+            'milestones' => 0.5,
+            'audit_log' => true,
+            'verification' => 0.8,
+            'observability' => false,
+            'isolated_workspace' => true,
+            'repair_loop' => true,
+            'rollback_plan' => false,
+            'local_governance' => 0.7,
+        ]);
+
+        $assessment = LanePressureManager::standard()->assess($metrics);
+
+        $this->assertSame(0.75, $metrics[AgentLane::SEMANTIC]['source_map_gap']['value']);
+        $this->assertSame(0.85, $metrics[AgentLane::OPERATIONAL]['runbook_gap']['value']);
+        $this->assertSame(0.75, $metrics[AgentLane::EXECUTION]['observability_gap']['value']);
+        $this->assertSame(AgentLane::OPERATIONAL, $assessment['dominant_lane']);
+        $this->assertStringContainsString(
+            'runbook',
+            $assessment['lanes'][AgentLane::OPERATIONAL]['recommendations'][0]
+        );
+    }
+
+    public function testLanePressureToolReturnsAssessmentJson(): void
+    {
+        $tool = new LanePressure();
+        $result = json_decode($tool->execute(json_encode([
+            'metrics' => [
+                AgentLane::EXECUTION => [
+                    'tool_failures' => 0.91,
+                ],
+            ],
+            'context' => [
+                'task_id' => 'tool-test',
+            ],
+        ])), true);
+
+        $this->assertSame(AgentLane::EXECUTION, $result['dominant_lane']);
+        $this->assertSame(LanePressureManager::LEVEL_CRITICAL, $result['overall_level']);
+        $this->assertSame('tool-test', $result['context']['task_id']);
+    }
+
+    public function testLanePressureToolCanBeRegisteredAsReadOnlyAgentTool(): void
+    {
+        $definition = ToolDefinition::fromTool('lane_pressure', new LanePressure(), [
+            'category' => 'agent',
+            'permission' => ToolDefinition::PERMISSION_READ,
+            'tags' => ['agent', 'pressure', 'lanes'],
+            'parallel_safe' => true,
+        ]);
+
+        $this->assertSame('lane_pressure', $definition->name());
+        $this->assertSame(ToolDefinition::PERMISSION_READ, $definition->permission());
+        $this->assertTrue($definition->parallelSafe());
+        $this->assertTrue($definition->hasAnyTag(['lanes']));
+    }
+}


### PR DESCRIPTION
## Intent summary
Add provider-neutral LLM lane pressure primitives so Automata agents can reason about semantic, operational, and execution pressure without binding to one model vendor or harness.

Closes #43.

## User stories / acceptance criteria
- As an agent runtime integrator, I can describe semantic, operational, and execution lanes with stable metadata.
- As an application, I can submit lane metrics and receive bounded recommendations for reducing pressure.
- As a long-horizon task runner, I can seed metrics from readiness gaps such as source maps, runbooks, audit logs, verification, observability, rollback plans, and local governance.
- As an Automata agent, I can expose the assessment through a deterministic read-only tool.

## Key files changed
- src/Automata/LLM/Agent/Lanes/AgentLane.php
- src/Automata/LLM/Agent/Lanes/LanePressureManager.php
- src/Automata/LLM/Agent/Lanes/LanePressureProfile.php
- src/Automata/LLM/Tools/LanePressure.php
- docs/agent-capabilities.md
- examples/generic/agent_lane_pressure.php
- tests/Automata/LLM/AgentLanePressureTest.php

## How to test
- php vendor\\phpunit\\phpunit\\phpunit --do-not-cache-result tests\\Automata\\LLM
- php examples\\generic\\agent_lane_pressure.php

## QA checklist
- [x] Provider-neutral lane naming and docs
- [x] Read-only tool wrapper
- [x] Long-horizon readiness profile
- [x] Focused LLM test coverage
- [x] Example script runs locally

## Approval conditions
- Review lane signal naming for long-term public API fit.
- Confirm the integration contract version bump is acceptable.