### PR TITLE
Refresh Composer lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bluefission/develation",
-            "version": "v1.3.31-alpha",
+            "version": "v1.3.33-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "4afc6d5713f35ab46e790e39a9f0a23902f1de82"
+                "reference": "86097a9412c79e730277d4ce78ba5c24756b8fd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/4afc6d5713f35ab46e790e39a9f0a23902f1de82",
-                "reference": "4afc6d5713f35ab46e790e39a9f0a23902f1de82",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/86097a9412c79e730277d4ce78ba5c24756b8fd9",
+                "reference": "86097a9412c79e730277d4ce78ba5c24756b8fd9",
                 "shasum": ""
             },
             "require": {
@@ -70,7 +70,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-05-20T18:21:05+00:00"
+            "time": "2026-06-21T20:52:12+00:00"
         },
         {
             "name": "bluefission/simpleclients",
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/simpleclients.git",
-                "reference": "6ed036a0a54176ab2d92478523ea21bab9a94ebd"
+                "reference": "aa946200fa442f4cf5fb25903add8394517c6151"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/simpleclients/zipball/6ed036a0a54176ab2d92478523ea21bab9a94ebd",
-                "reference": "6ed036a0a54176ab2d92478523ea21bab9a94ebd",
+                "url": "https://api.github.com/repos/BlueFissionTech/simpleclients/zipball/aa946200fa442f4cf5fb25903add8394517c6151",
+                "reference": "aa946200fa442f4cf5fb25903add8394517c6151",
                 "shasum": ""
             },
             "require": {
@@ -117,13 +117,16 @@
             ],
             "description": "Simple Client Wrappers For BlueFission",
             "keywords": [
-                "clients, api, http, services"
+                "api",
+                "clients",
+                "http",
+                "services"
             ],
             "support": {
                 "source": "https://github.com/BlueFissionTech/simpleclients/tree/master",
                 "issues": "https://github.com/BlueFissionTech/simpleclients/issues"
             },
-            "time": "2026-01-13T14:50:27+00:00"
+            "time": "2026-06-21T22:38:58+00:00"
         },
         {
             "name": "cboden/ratchet",
@@ -131,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ratchetphp/Ratchet.git",
-                "reference": "9ac6a412a26d8bae6541ee0b65ffaf78e316b1a6"
+                "reference": "e621c6c40bf684bbbb877102416ad5303d05a9cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ratchetphp/Ratchet/zipball/9ac6a412a26d8bae6541ee0b65ffaf78e316b1a6",
-                "reference": "9ac6a412a26d8bae6541ee0b65ffaf78e316b1a6",
+                "url": "https://api.github.com/repos/ratchetphp/Ratchet/zipball/e621c6c40bf684bbbb877102416ad5303d05a9cc",
+                "reference": "e621c6c40bf684bbbb877102416ad5303d05a9cc",
                 "shasum": ""
             },
             "require": {
@@ -187,7 +190,7 @@
                 "issues": "https://github.com/ratchetphp/Ratchet/issues",
                 "source": "https://github.com/ratchetphp/Ratchet/tree/0.4.x"
             },
-            "time": "2025-10-25T19:55:26+00:00"
+            "time": "2026-06-14T13:01:18+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -319,16 +322,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.x-dev",
+            "version": "2.12.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c55def9def1cac7b9ba8c5cf375e22a0d70f9b05"
+                "reference": "5cfb193a1a961ba791b79eafc5f666e0968e6ae1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c55def9def1cac7b9ba8c5cf375e22a0d70f9b05",
-                "reference": "c55def9def1cac7b9ba8c5cf375e22a0d70f9b05",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5cfb193a1a961ba791b79eafc5f666e0968e6ae1",
+                "reference": "5cfb193a1a961ba791b79eafc5f666e0968e6ae1",
                 "shasum": ""
             },
             "require": {
@@ -337,7 +340,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -352,6 +355,7 @@
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -418,7 +422,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11"
+                "source": "https://github.com/guzzle/psr7/tree/2.12"
             },
             "funding": [
                 {
@@ -434,7 +438,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-21T19:03:16+00:00"
+            "time": "2026-06-20T23:32:15+00:00"
         },
         {
             "name": "orhanerday/open-ai",
@@ -941,16 +945,16 @@
         },
         {
             "name": "ratchet/rfc6455",
-            "version": "v0.4.0",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ratchetphp/RFC6455.git",
-                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef"
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/859d95f85dda0912c6d5b936d036d044e3af47ef",
-                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/9b05f371219cbaf9748b505f139617dd0715592b",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b",
                 "shasum": ""
             },
             "require": {
@@ -994,9 +998,9 @@
             "support": {
                 "chat": "https://gitter.im/reactphp/reactphp",
                 "issues": "https://github.com/ratchetphp/RFC6455/issues",
-                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.0"
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.1"
             },
-            "time": "2025-02-24T01:18:22+00:00"
+            "time": "2026-06-06T14:34:23+00:00"
         },
         {
             "name": "react/cache",
@@ -1531,12 +1535,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -1595,7 +1599,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -1603,12 +1607,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "d63c23357d74715a589454c141c843f0172bec6c"
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/d63c23357d74715a589454c141c843f0172bec6c",
-                "reference": "d63c23357d74715a589454c141c843f0172bec6c",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
                 "shasum": ""
             },
             "require": {
@@ -1696,7 +1700,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T16:34:22+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -1704,12 +1708,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "a108a53ce0bc8ed43c084bb535eec4b363383431"
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/a108a53ce0bc8ed43c084bb535eec4b363383431",
-                "reference": "a108a53ce0bc8ed43c084bb535eec4b363383431",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
                 "shasum": ""
             },
             "require": {
@@ -1779,7 +1783,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-19T17:42:24+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -1787,12 +1791,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "051a9622b64ac1f639665c593afbff1128cddb16"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/051a9622b64ac1f639665c593afbff1128cddb16",
-                "reference": "051a9622b64ac1f639665c593afbff1128cddb16",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -1861,7 +1865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T19:55:39+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1869,12 +1873,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -1947,7 +1951,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -2040,12 +2044,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -2113,7 +2117,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/routing",
@@ -2121,12 +2125,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204"
+                "reference": "edc6193883892c968d4cb7d784b07d7893e2a4da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/edc6193883892c968d4cb7d784b07d7893e2a4da",
+                "reference": "edc6193883892c968d4cb7d784b07d7893e2a4da",
                 "shasum": ""
             },
             "require": {
@@ -2198,7 +2202,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2206,12 +2210,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "09dd242537543ad34254b0e173ab287a7e39900b"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/09dd242537543ad34254b0e173ab287a7e39900b",
-                "reference": "09dd242537543ad34254b0e173ab287a7e39900b",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -2286,7 +2290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Intent summary

Refresh composer.lock to the current dependency heads allowed by existing Composer constraints, isolated from feature and documentation work.

## User stories / acceptance criteria

- As a maintainer, dependency lock movement can be reviewed separately from behavior changes.
- As a contributor, the lock file reflects the current allowed Composer dependency set.
- As a reviewer, validation evidence and the remaining full-suite timeout are explicit.

## Key files changed

- composer.lock`n
## How to test

- composer validate --no-check-publish --strict`n- composer audit`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Examples`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\LLM`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\Memory`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\Goal`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\Path`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\Strategy\BasicTest.php tests\Automata\Strategy\KNearestPredictionTest.php tests\Automata\Strategy\KNearestRegressionTest.php tests\Automata\Strategy\MarkovTextPredictionTest.php`n- php vendor\phpunit\phpunit\phpunit --do-not-cache-result tests\Automata\Strategy\NaiveBayesTextClassificationTest.php tests\Automata\Strategy\NGramTextPredictionTest.php tests\Automata\Strategy\PatternTest.php tests\Automata\Strategy\PredictionTest.php`n
## QA checklist

- [x] Composer manifest validation passes.
- [x] Composer audit reports no security advisories.
- [x] Examples tests pass.
- [x] Non-Strategy Automata suites pass.
- [x] Strategy suites pass except the neural image classification file.
- [ ] Full suite currently times out at BlueFission\Tests\Automata\Strategy\NeuralNetImageClassificationTest::testPredict; this PR leaves that as a visible review/follow-up risk rather than claiming full-suite success.

## Approval conditions

- Reviewers accept the dependency head movement in composer.lock.
- Reviewers accept staging this as lock-only with no runtime source changes.
- The neural image classification timeout is either accepted as pre-existing/out-of-scope for this lock refresh or split into a follow-up before merge.

Closes #59.