### PR TITLE
Replace Goal and Memory static array counts

### DIFF
--- a/src/Automata/Goal/Initiative.php
+++ b/src/Automata/Goal/Initiative.php
@@ -157,7 +157,7 @@ class Initiative extends InitiativeObject implements IProjectionBuilder
             }
 
             $tags = $criterion instanceof InitiativeObject ? $criterion->field('tags') : null;
-            if (!Arr::is($tags) || Arr::count($tags) === 0) {
+            if (!Arr::is($tags) || $this->countValues($tags) === 0) {
                 $tags = [$this->criterionKey($criterion)];
             }
 
@@ -178,7 +178,7 @@ class Initiative extends InitiativeObject implements IProjectionBuilder
 
         Dev::do('goal.initiative.projections_built', [
             'initiative' => $this,
-            'count' => Arr::count($projections),
+            'count' => $this->countValues($projections),
         ]);
 
         return $projections;
@@ -223,5 +223,10 @@ class Initiative extends InitiativeObject implements IProjectionBuilder
             $values[] = $entry['value'] ?? $entry;
         }
         return $values;
+    }
+
+    protected function countValues(array $values): int
+    {
+        return Arr::make($values)->count();
     }
 }

--- a/src/Automata/Goal/ManagesGoals.php
+++ b/src/Automata/Goal/ManagesGoals.php
@@ -40,13 +40,13 @@ trait ManagesGoals
     {
         $this->goals[$this->goalKey($goal)] = $goal;
 
-        while (Arr::count($this->goals) > $this->maxGoals) {
+        while ($this->countValues($this->goals) > $this->maxGoals) {
             $this->removeOldestGoal();
         }
 
         Dev::do('goal.manager.goal_added', [
             'goal' => $goal,
-            'count' => Arr::count($this->goals),
+            'count' => $this->countValues($this->goals),
         ]);
 
         return $this;
@@ -140,7 +140,7 @@ trait ManagesGoals
             }
         }
 
-        if (Arr::count($updates) > 0) {
+        if ($this->countValues($updates) > 0) {
             Dev::do('goal.manager.criteria_updated', ['updates' => $updates]);
         }
 
@@ -235,7 +235,7 @@ trait ManagesGoals
             }
         }
 
-        if (Arr::count($options) === 0) {
+        if ($this->countValues($options) === 0) {
             $options[] = GoalDecision::option(IGoalManager::DEFAULT_ACTION, 0.0, [
                 'source' => 'fallback',
             ]);
@@ -531,6 +531,11 @@ trait ManagesGoals
         }
 
         return $limited;
+    }
+
+    protected function countValues(array $values): int
+    {
+        return Arr::make($values)->count();
     }
 
     /**

--- a/src/Automata/Memory/Abs2Memory.php
+++ b/src/Automata/Memory/Abs2Memory.php
@@ -239,6 +239,6 @@ class Abs2Memory extends Graph implements IWorkingMemory
 
     protected function countValues(array $values): int
     {
-        return Arr::count($values);
+        return Arr::make($values)->count();
     }
 }

--- a/src/Automata/Memory/MemoryNode.php
+++ b/src/Automata/Memory/MemoryNode.php
@@ -146,7 +146,7 @@ class MemoryNode extends GraphNode
 
     private function countValues(array $values): int
     {
-        return Arr::count($values);
+        return Arr::make($values)->count();
     }
 
     /**

--- a/tests/Automata/Goal/GoalManagerTest.php
+++ b/tests/Automata/Goal/GoalManagerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Goal;
+
+use BlueFission\Automata\Goal\ComparisonOperator;
+use BlueFission\Automata\Goal\Condition;
+use BlueFission\Automata\Goal\GoalManager;
+use BlueFission\Automata\Goal\Initiative;
+use PHPUnit\Framework\TestCase;
+
+class GoalManagerTest extends TestCase
+{
+    public function testGoalManagerTrimsGoalsWithoutStaticArrayCount(): void
+    {
+        $first = new Initiative(['initiative_id' => 'first', 'name' => 'First']);
+        $second = new Initiative(['initiative_id' => 'second', 'name' => 'Second']);
+
+        $manager = new GoalManager([$first, $second], 1);
+
+        $this->assertArrayNotHasKey('first', $manager->goals());
+        $this->assertArrayHasKey('second', $manager->goals());
+    }
+
+    public function testGoalManagerUpdatesCriteriaAndProvidesFallbackWithoutStaticArrayCount(): void
+    {
+        $goal = new Initiative(['initiative_id' => 'risk_goal', 'name' => 'Risk Goal']);
+        $goal->addCondition(new Condition([
+            'path' => 'metrics.risk',
+            'operator' => ComparisonOperator::NO_MORE_THAN,
+            'value' => 2,
+            'type' => 'risk',
+        ]));
+
+        $manager = new GoalManager([$goal]);
+
+        $updates = $manager->updateCriteriaSatisfied(['metrics' => ['risk' => 1]]);
+        $fallback = (new GoalManager())->recommend([]);
+
+        $fallbackDecision = reset($fallback);
+
+        $this->assertCount(1, $updates);
+        $this->assertSame('fallback', $fallbackDecision->toArray()['metadata']['source']);
+    }
+}


### PR DESCRIPTION
## Intent summary

Replace static Arr::count() calls in Goal and Memory runtime paths with Arr instance count helpers, preserving behavior for goal limits, criteria updates, projection counts, memory similarity, and association limits.

## User stories / acceptance criteria

- As a runtime adapter author, Goal initialization and recommendation paths avoid unsupported static helper usage.
- As a maintainer, Memory count helpers use the same supported Arr instance path.
- As a reviewer, regression coverage proves goal trimming, criterion updates, fallback recommendations, and memory association limits still work.

## Key files changed

- src/Automata/Goal/ManagesGoals.php
- src/Automata/Goal/Initiative.php
- src/Automata/Memory/MemoryNode.php
- src/Automata/Memory/Abs2Memory.php
- tests/Automata/Goal/GoalManagerTest.php

## How to test

- php -l src/Automata/Goal/ManagesGoals.php; php -l src/Automata/Goal/Initiative.php; php -l src/Automata/Memory/MemoryNode.php; php -l src/Automata/Memory/Abs2Memory.php; php -l tests/Automata/Goal/GoalManagerTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Goal tests/Automata/Memory
- rg -n Arr::count src/Automata/Goal src/Automata/Memory
- git diff --check

## QA checklist

- [x] Goal manager limits no longer depend on static Arr::count() calls.
- [x] Initiative projection counting no longer depends on static Arr::count() calls.
- [x] Memory count helpers no longer depend on static Arr::count() calls.
- [x] Focused Goal and Memory tests pass.

## Approval conditions

- Reviewers accept the object-helper count path as the package-compatible behavior.
- Broader static Arr::count() use outside Goal/Memory remains separate from this issue unless explicitly requested.

Closes #53.