### PR TITLE
Replace strict membership checks with Arr helpers

### DIFF
--- a/src/Automata/Intelligence.php
+++ b/src/Automata/Intelligence.php
@@ -409,7 +409,7 @@ class Intelligence extends Obj
             $profile = $this->_strategyProfiles[$name] ?? [];
             $types = $profile['types'] ?? [];
 
-            if (!empty($types) && !in_array($type, $types, true)) {
+            if (!empty($types) && !Arr::make($types)->contains($type, true)) {
                 continue;
             }
 

--- a/src/Automata/LLM/StatementClassifier.php
+++ b/src/Automata/LLM/StatementClassifier.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Automata\LLM;
 
+use BlueFission\Arr;
 use BlueFission\Automata\LLM\Prompts\StatementClassification;
 use Phpml\ModelManager;
 use Phpml\Classification\NaiveBayes;
@@ -116,7 +117,7 @@ class StatementClassifier
         }
 
         $classification = strtolower(trim((string)$text));
-        if (in_array($classification, ['question', 'statement', 'stop'], true)) {
+        if (Arr::make(['question', 'statement', 'stop'])->contains($classification, true)) {
             return $classification;
         }
 

--- a/src/Automata/Media/Ingestion/TextIngestor.php
+++ b/src/Automata/Media/Ingestion/TextIngestor.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Media\Ingestion;
 
+use BlueFission\Arr;
 use BlueFission\Automata\InputType;
 use BlueFission\Automata\Media\MediaItem;
 use BlueFission\DevElation as Dev;
@@ -53,6 +54,6 @@ class TextIngestor extends AbstractIngestor
             return true;
         }
 
-        return in_array($mime, ['application/json', 'application/xml', 'application/xhtml+xml'], true);
+        return Arr::make(['application/json', 'application/xml', 'application/xhtml+xml'])->contains($mime, true);
     }
 }

--- a/src/Automata/Parsing/Generators/LLMGenerator.php
+++ b/src/Automata/Parsing/Generators/LLMGenerator.php
@@ -548,11 +548,11 @@ class LLMGenerator implements IGenerator, IDispatcher {
         }
 
         $output = Str::trim($last);
-        if (!empty($options) && !$this->matchPrefixOption($output, $options) && !Arr::make($options)->contains($output, true)) {
+        if (!Val::isEmpty($options) && !$this->matchPrefixOption($output, $options) && !Arr::make($options)->contains($output, true)) {
             return;
         }
 
-        if (!empty($pattern) && !preg_match($pattern, $output)) {
+        if (!Val::isEmpty($pattern) && !preg_match($pattern, $output)) {
             return;
         }
 

--- a/src/Automata/Parsing/Generators/LLMGenerator.php
+++ b/src/Automata/Parsing/Generators/LLMGenerator.php
@@ -290,7 +290,7 @@ class LLMGenerator implements IGenerator, IDispatcher {
 
         $requestedStrategy = Str::lower(Str::trim((string)($element->getAttribute('context_strategy') ?? 'prefix')));
         $requestedStrategy = $requestedStrategy === '' ? 'prefix' : $requestedStrategy;
-        $supported = in_array($requestedStrategy, ['none', 'prefix', 'windowed-prefix'], true);
+        $supported = Arr::make(['none', 'prefix', 'windowed-prefix'])->contains($requestedStrategy, true);
         $strategy = $supported ? $requestedStrategy : 'prefix';
         $context = '';
 
@@ -548,7 +548,7 @@ class LLMGenerator implements IGenerator, IDispatcher {
         }
 
         $output = Str::trim($last);
-        if (!empty($options) && !$this->matchPrefixOption($output, $options) && !in_array($output, $options, true)) {
+        if (!empty($options) && !$this->matchPrefixOption($output, $options) && !Arr::make($options)->contains($output, true)) {
             return;
         }
 

--- a/tests/Automata/LLM/StatementClassifierTest.php
+++ b/tests/Automata/LLM/StatementClassifierTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlueFission\Tests\Automata\LLM;
+
+use BlueFission\Automata\LLM\StatementClassifier;
+use PHPUnit\Framework\TestCase;
+
+class StatementClassifierTest extends TestCase
+{
+    public function testExtractClassificationUsesStrictAllowlist(): void
+    {
+        $classifier = new StatementClassifier();
+        $method = new \ReflectionMethod(StatementClassifier::class, 'extractClassification');
+        $method->setAccessible(true);
+
+        $this->assertSame('question', $method->invoke($classifier, ['text' => ' question ']));
+        $this->assertNull($method->invoke($classifier, ['text' => 'questionable']));
+    }
+}

--- a/tests/Automata/Media/IngestionGatewayTest.php
+++ b/tests/Automata/Media/IngestionGatewayTest.php
@@ -19,4 +19,20 @@ class IngestionGatewayTest extends TestCase
         $this->assertSame(InputType::TEXT, $item->type());
         $this->assertSame('Hello world', $item->content());
     }
+
+    public function testTextIngestorSupportsJsonMimeWithoutRawMembershipCheck(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'automata-json-');
+        file_put_contents($path, '{"status":"ok"}');
+
+        try {
+            $ingestor = new TextIngestor();
+
+            $this->assertTrue($ingestor->supports($path));
+        } finally {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Intent summary

Replace strict raw in_array checks in Automata runtime code with DevElation Arr membership helpers while preserving strict comparison behavior.

## User stories / acceptance criteria

- As a maintainer, strict membership checks use the package helper surface consistently.
- As a runtime user, context strategies, output options, statement classification, text MIME detection, and typed strategy filtering keep existing behavior.
- As a reviewer, focused tests cover statement allowlist and JSON text MIME support, while existing FillIn, Intelligence, and Media tests cover the other touched paths.

## Key files changed

- src/Automata/Parsing/Generators/LLMGenerator.php
- src/Automata/Intelligence.php
- src/Automata/LLM/StatementClassifier.php
- src/Automata/Media/Ingestion/TextIngestor.php
- tests/Automata/LLM/StatementClassifierTest.php
- tests/Automata/Media/IngestionGatewayTest.php

## How to test

- php -l on the touched source and test files
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/LLM/StatementClassifierTest.php tests/Automata/LLM/FillInProfileTest.php tests/Automata/IntelligenceTest.php tests/Automata/IntelligenceClassifierTest.php tests/Automata/IntelligenceInsightTest.php tests/Automata/Media/IngestionGatewayTest.php
- rg -n in_array src
- git diff --check

## QA checklist

- [x] Strict raw in_array checks removed from src.
- [x] Statement classification allowlist remains strict.
- [x] JSON MIME text ingestion remains supported.
- [x] Existing context strategy, strategy filtering, and media ingestion tests pass.

## Approval conditions

- Reviewers accept Arr::make(...)->contains(..., true) as the strict membership helper pattern.
- Non-strict legacy membership checks remain out of scope for this issue.

Closes #55.