### PR TITLE
Define runtime capability vocabulary

### DIFF
--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -118,6 +118,10 @@ Control-surface and persona adapters should also bind to the
 for neutral persona, intent, task, tool, result, confidence, and guardrail
 shapes.
 
+Runtime contract adapters should use the
+[Runtime Capability Vocabulary](runtime-capability-vocabulary.md) for neutral
+goal, statement, feedback, domain evaluation, and lane-pressure terms.
+
 The first contract version covers:
 
 - agent runtime configuration and execution
@@ -130,6 +134,7 @@ The first contract version covers:
 - behavioral state, goals, criteria, expectations, and bounded decisions
 - CPCT telemetry and runtime security validation
 - provider-neutral lane pressure assessment
+- package-neutral runtime capability vocabulary
 
 Adapters should bind to the contract's feature ids rather than hard-coding prompt text or concrete class internals. Automata provides `contractTemplate()` and `bindingTemplate()` so adapter libraries can decide their own construct names, syntax, query language, ingestion flow, and conformance fixtures while pointing back to stable Automata feature ids. Sibling libraries may coordinate with one another, but Automata should not carry descendant-specific binding maps.
 

--- a/docs/runtime-capability-vocabulary.md
+++ b/docs/runtime-capability-vocabulary.md
@@ -1,0 +1,178 @@
+# Runtime Capability Vocabulary
+
+Automata exposes reusable intelligence capabilities through neutral contract
+terms. These terms are meant for adapter fixtures, runtime contracts, and
+cross-repo coordination where the consumer should not need to know parser
+internals, prompt text, or a host application's implementation details.
+
+Use `AgentIntegrationContract::capabilityVocabulary()` when code needs the
+machine-readable version of this document.
+
+## Vocabulary Rules
+
+- Prefer capability terms that describe Automata-owned behavior.
+- Keep downstream package names out of public contract fields.
+- Treat aliases as compatibility hints, not as new owning concepts.
+- Map every shared term to stable classes, feature ids, or fixture fields.
+- Keep provider and harness details behind adapters.
+
+## Goal
+
+A goal is a desired outcome with criteria, context, expectations, and bounded
+decision options.
+
+Stable fields:
+
+- `id`
+- `objective`
+- `criteria`
+- `context`
+- `status`
+- `expectations`
+- `decision_options`
+- `score`
+
+Accepted aliases are `objective`, `initiative`, and `desired_outcome`.
+
+Compatibility constraints:
+
+- Use goal for desired outcomes, not for every executable task.
+- Use task for runtime work items that may satisfy one or more goals.
+- Use criterion or condition for deterministic satisfaction checks.
+
+## Statement
+
+A statement is a normalized semantic assertion or command fragment with
+subject, behavior, object, context, and relation data.
+
+Stable fields:
+
+- `type`
+- `context`
+- `priority`
+- `subject`
+- `negation`
+- `modality`
+- `behavior`
+- `condition`
+- `object`
+- `relationship`
+- `indirect_object`
+- `position`
+
+Accepted aliases are `utterance`, `semantic_statement`, and `claim`.
+
+Compatibility constraints:
+
+- Adapters may keep parser internals private when they emit this normalized
+  shape.
+- Subject, behavior, and object remain the primary satisfaction fields.
+- Context carries scope and normalization metadata; it should not become
+  provider prompt text.
+
+## Feedback
+
+Feedback is review, correction, or training-signal evidence attached to a
+projection, observation, decision, or generated value.
+
+Stable fields:
+
+- `original_value`
+- `corrected_value`
+- `actor`
+- `reason`
+- `confidence`
+- `timestamp`
+- `trace`
+- `policy_strategy`
+
+Accepted aliases are `review`, `correction`, and `training_signal`.
+
+Compatibility constraints:
+
+- Policy gates may stay outside Automata when the host owns the execution
+  boundary.
+- Correction records should preserve the original value and the evidence that
+  justified the change.
+- Training signals should identify their strategy and trace instead of only
+  storing a score.
+
+## Domain Evaluation
+
+A domain evaluation is a bounded assessment of inputs against domain criteria
+that returns scores, tags, decisions, or unmet conditions.
+
+Stable fields:
+
+- `domain`
+- `subject`
+- `criteria`
+- `input`
+- `result`
+- `score`
+- `confidence`
+- `unmet_conditions`
+- `trace`
+
+Accepted aliases are `evaluation`, `assessment`, and `classification_result`.
+
+Compatibility constraints:
+
+- Use domain as a reusable scope label, not a downstream package name.
+- Evaluation should return a result envelope and should not perform
+  host-specific side effects.
+- Scores and confidence are advisory unless policy or goal criteria bind them
+  to a threshold.
+
+## Lane Pressure
+
+Lane pressure is a provider-neutral pressure assessment across semantic,
+operational, and execution lanes.
+
+Stable fields:
+
+- `lane`
+- `signals`
+- `score`
+- `level`
+- `dominant_signal`
+- `recommendations`
+- `context`
+
+Accepted aliases are `semantic_operational_execution_pressure`,
+`task_pressure`, and `agent_readiness`.
+
+Compatibility constraints:
+
+- Use lanes as an Automata risk-management utility, not as proof of a provider
+  internal architecture.
+- Semantic pressure belongs to meaning and context, operational pressure
+  belongs to policy and runbooks, and execution pressure belongs to tools and
+  verification.
+- Critical pressure should stop or defer mutations until the named gap is
+  resolved.
+
+## Fixture Shape
+
+Adapter conformance fixtures should bind local constructs to Automata feature
+ids rather than to implementation classes directly:
+
+```php
+$fixture = [
+    'construct' => 'capability.statement',
+    'feature' => 'agent.capability_vocabulary',
+    'inputs' => [
+        'subject' => 'user',
+        'behavior' => 'requests',
+        'object' => 'status',
+        'context' => ['scope' => 'session'],
+    ],
+    'outputs' => [
+        'statement',
+        'trace',
+    ],
+];
+```
+
+This keeps public contracts reusable while still giving adapters enough shape
+to validate compatibility without live model calls.

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -5,8 +5,16 @@ namespace BlueFission\Automata\LLM\Agent\Integration;
 use BlueFission\Arr;
 use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\Comprehension\Scene;
+use BlueFission\Automata\Classification\Result as ClassificationResult;
+use BlueFission\Automata\Feedback\Assessment;
+use BlueFission\Automata\Feedback\FeedbackSignal;
+use BlueFission\Automata\Feedback\Observation;
+use BlueFission\Automata\Feedback\Projection;
+use BlueFission\Automata\Goal\Condition;
+use BlueFission\Automata\Goal\GoalDecision;
 use BlueFission\Automata\Goal\GoalManager;
 use BlueFission\Automata\Language\Reader;
+use BlueFission\Automata\Language\Statement;
 use BlueFission\Automata\LLM\Agent;
 use BlueFission\Automata\LLM\Agent\AgentHook;
 use BlueFission\Automata\LLM\Agent\AgentSession;
@@ -31,7 +39,7 @@ use BlueFission\Obj;
 
 class AgentIntegrationContract extends Obj
 {
-    public const VERSION = '1.1.0';
+    public const VERSION = '1.2.0';
 
     public const FEATURE_AGENT = 'agent.runtime';
     public const FEATURE_TOOLS = 'agent.tool_contracts';
@@ -46,6 +54,7 @@ class AgentIntegrationContract extends Obj
     public const FEATURE_TELEMETRY = 'agent.cpct_telemetry';
     public const FEATURE_SECURITY = 'agent.runtime_security';
     public const FEATURE_LANE_PRESSURE = 'agent.lane_pressure';
+    public const FEATURE_CAPABILITY_VOCABULARY = 'agent.capability_vocabulary';
 
     public const TEMPLATE_AGENT = 'agent';
     public const TEMPLATE_TOOL = 'tool';
@@ -60,6 +69,7 @@ class AgentIntegrationContract extends Obj
     public const TEMPLATE_TRACE = 'trace';
     public const TEMPLATE_SECURITY = 'security';
     public const TEMPLATE_LANES = 'lanes';
+    public const TEMPLATE_CAPABILITY = 'capability';
 
     /**
      * Build the standard Automata integration surface for adapter contracts.
@@ -153,6 +163,20 @@ class AgentIntegrationContract extends Obj
     public function bindings(?string $construct = null): array
     {
         return $this->bindingTemplate($construct);
+    }
+
+    /**
+     * Return package-neutral capability terms for adapter contract fixtures.
+     */
+    public function capabilityVocabulary(?string $capability = null): array
+    {
+        $vocabulary = Arr::make($this->field('capability_vocabulary') ?? [])->toArray();
+
+        if (!$capability) {
+            return $vocabulary;
+        }
+
+        return Arr::make($vocabulary[$capability] ?? [])->toArray();
     }
 
     /**
@@ -288,6 +312,75 @@ class AgentIntegrationContract extends Obj
                     'inputs' => ['lane_metrics', 'task_context', 'readiness_profile'],
                     'outputs' => ['dominant_lane', 'overall_level', 'recommendations'],
                 ],
+                self::FEATURE_CAPABILITY_VOCABULARY => [
+                    'summary' => 'Package-neutral vocabulary for goal, statement, feedback, domain evaluation, and lane-pressure adapter contracts.',
+                    'classes' => [GoalManager::class, Statement::class, Assessment::class, ClassificationResult::class, AgentLane::class],
+                    'constructs' => ['capability.goal', 'capability.statement', 'capability.feedback', 'capability.domain_evaluation', 'capability.lane_pressure'],
+                    'inputs' => ['capability_term', 'adapter_contract', 'fixture_payload'],
+                    'outputs' => ['term_definition', 'stable_fields', 'aliases', 'compatibility_constraints'],
+                ],
+            ],
+            'capability_vocabulary' => [
+                'goal' => [
+                    'feature' => self::FEATURE_STATE_GOALS,
+                    'definition' => 'A desired outcome with criteria, context, expectations, and bounded decision options.',
+                    'classes' => [GoalManager::class, Condition::class, GoalDecision::class],
+                    'stable_fields' => ['id', 'objective', 'criteria', 'context', 'status', 'expectations', 'decision_options', 'score'],
+                    'aliases' => ['objective', 'initiative', 'desired_outcome'],
+                    'constraints' => [
+                        'Use goal for desired outcomes, not for every executable task.',
+                        'Use task for runtime work items that may satisfy one or more goals.',
+                        'Use criterion or condition for deterministic satisfaction checks.',
+                    ],
+                ],
+                'statement' => [
+                    'feature' => self::FEATURE_HOLOSCENE,
+                    'definition' => 'A normalized semantic assertion or command fragment with subject, behavior, object, context, and relation data.',
+                    'classes' => [Statement::class, Reader::class],
+                    'stable_fields' => ['type', 'context', 'priority', 'subject', 'negation', 'modality', 'behavior', 'condition', 'object', 'relationship', 'indirect_object', 'position'],
+                    'aliases' => ['utterance', 'semantic_statement', 'claim'],
+                    'constraints' => [
+                        'Adapters may keep parser internals private when they emit this normalized shape.',
+                        'Subject, behavior, and object remain the primary satisfaction fields.',
+                        'Context carries scope and normalization metadata; it should not become provider prompt text.',
+                    ],
+                ],
+                'feedback' => [
+                    'feature' => self::FEATURE_GOVERNANCE,
+                    'definition' => 'Review, correction, or training-signal evidence attached to a projection, observation, decision, or generated value.',
+                    'classes' => [Assessment::class, FeedbackSignal::class, Projection::class, Observation::class],
+                    'stable_fields' => ['original_value', 'corrected_value', 'actor', 'reason', 'confidence', 'timestamp', 'trace', 'policy_strategy'],
+                    'aliases' => ['review', 'correction', 'training_signal'],
+                    'constraints' => [
+                        'Policy gates may stay outside Automata when the host owns the execution boundary.',
+                        'Correction records should preserve the original value and the evidence that justified the change.',
+                        'Training signals should identify their strategy and trace instead of only storing a score.',
+                    ],
+                ],
+                'domain_evaluation' => [
+                    'feature' => self::FEATURE_STATE_GOALS,
+                    'definition' => 'A bounded assessment of inputs against domain criteria that returns scores, tags, decisions, or unmet conditions.',
+                    'classes' => [ClassificationResult::class, Assessment::class, Condition::class],
+                    'stable_fields' => ['domain', 'subject', 'criteria', 'input', 'result', 'score', 'confidence', 'unmet_conditions', 'trace'],
+                    'aliases' => ['evaluation', 'assessment', 'classification_result'],
+                    'constraints' => [
+                        'Use domain as a reusable scope label, not a downstream package name.',
+                        'Evaluation should return a result envelope and should not perform host-specific side effects.',
+                        'Scores and confidence are advisory unless policy or goal criteria bind them to a threshold.',
+                    ],
+                ],
+                'lane_pressure' => [
+                    'feature' => self::FEATURE_LANE_PRESSURE,
+                    'definition' => 'A provider-neutral pressure assessment across semantic, operational, and execution lanes.',
+                    'classes' => [AgentLane::class, LanePressureManager::class, LanePressureProfile::class],
+                    'stable_fields' => ['lane', 'signals', 'score', 'level', 'dominant_signal', 'recommendations', 'context'],
+                    'aliases' => ['semantic_operational_execution_pressure', 'task_pressure', 'agent_readiness'],
+                    'constraints' => [
+                        'Use lanes as an Automata risk-management utility, not as proof of a provider internal architecture.',
+                        'Semantic pressure belongs to meaning and context, operational pressure belongs to policy and runbooks, and execution pressure belongs to tools and verification.',
+                        'Critical pressure should stop or defer mutations until the named gap is resolved.',
+                    ],
+                ],
             ],
             'contract_template' => [
                 'name' => 'family.adapter.contract',
@@ -315,6 +408,7 @@ class AgentIntegrationContract extends Obj
                 self::TEMPLATE_TRACE => ['feature' => self::FEATURE_TELEMETRY, 'constructs' => ['trace.task', 'trace.span', 'trace.cpct']],
                 self::TEMPLATE_SECURITY => ['feature' => self::FEATURE_SECURITY, 'constructs' => ['security.scan', 'security.validate', 'security.sanitize']],
                 self::TEMPLATE_LANES => ['feature' => self::FEATURE_LANE_PRESSURE, 'constructs' => ['lane.semantic', 'lane.operational', 'lane.execution', 'lane.pressure', 'lane.profile.long_horizon']],
+                self::TEMPLATE_CAPABILITY => ['feature' => self::FEATURE_CAPABILITY_VOCABULARY, 'constructs' => ['capability.goal', 'capability.statement', 'capability.feedback', 'capability.domain_evaluation', 'capability.lane_pressure']],
             ],
             'hooks' => AgentHook::all(),
             'tool_catalog_filters' => [
@@ -335,6 +429,7 @@ class AgentIntegrationContract extends Obj
                 'Tool and MCP calls emit task trace spans and governance outcomes.',
                 'Session scope controls shared context instead of agents sharing full context windows.',
                 'Holoscene episodes use scoped working memory and snapshots rather than raw prompt-only memory coupling.',
+                'Capability vocabulary stays package-neutral and maps to stable Automata-owned classes or feature ids.',
                 'Conformance fixtures cover successful execution, blocked execution, review steering, and trace export.',
             ],
         ];

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -63,6 +63,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TOOLS));
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TELEMETRY));
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_LANE_PRESSURE));
+        $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_CAPABILITY_VOCABULARY));
         $this->assertSame(
             'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
             $contract->feature(AgentIntegrationContract::FEATURE_TOOLS)['summary']
@@ -93,6 +94,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertSame(AgentIntegrationContract::FEATURE_HOLOSCENE, $template['holoscene']['feature']);
         $this->assertSame(AgentIntegrationContract::FEATURE_ORCHESTRATION, $template['orchestration']['feature']);
         $this->assertSame(AgentIntegrationContract::FEATURE_MCP, $template['mcp']['feature']);
+        $this->assertSame(AgentIntegrationContract::FEATURE_CAPABILITY_VOCABULARY, $template['capability']['feature']);
         $this->assertSame($template['tool'], $contract->bindings(AgentIntegrationContract::TEMPLATE_TOOL));
     }
 
@@ -120,10 +122,11 @@ class AgentIntegrationContractTest extends TestCase
     {
         $json = AgentIntegrationContract::standard()->toJson();
 
-        $this->assertStringContainsString('"version":"1.1.0"', $json);
+        $this->assertStringContainsString('"version":"1.2.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
         $this->assertStringContainsString('"agent.holoscene_comprehension"', $json);
         $this->assertStringContainsString('"agent.lane_pressure"', $json);
+        $this->assertStringContainsString('"agent.capability_vocabulary"', $json);
         $this->assertStringContainsString('"contract_template"', $json);
         $this->assertStringNotContainsString('"jenss"', $json);
         $this->assertStringNotContainsString('"jenerator"', $json);
@@ -139,6 +142,29 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertContains(Holoscene::class, $feature['classes']);
         $this->assertContains('reader.to_holoscene', $feature['constructs']);
         $this->assertContains('holoscene_snapshot', $feature['outputs']);
+    }
+
+    public function testCapabilityVocabularyDocumentsNeutralRuntimeTerms(): void
+    {
+        $contract = AgentIntegrationContract::standard();
+        $vocabulary = $contract->capabilityVocabulary();
+
+        $this->assertArrayHasKey('goal', $vocabulary);
+        $this->assertArrayHasKey('statement', $vocabulary);
+        $this->assertArrayHasKey('feedback', $vocabulary);
+        $this->assertArrayHasKey('domain_evaluation', $vocabulary);
+        $this->assertArrayHasKey('lane_pressure', $vocabulary);
+        $this->assertSame(
+            AgentIntegrationContract::FEATURE_HOLOSCENE,
+            $contract->capabilityVocabulary('statement')['feature']
+        );
+        $this->assertContains('subject', $contract->capabilityVocabulary('statement')['stable_fields']);
+        $this->assertContains('corrected_value', $contract->capabilityVocabulary('feedback')['stable_fields']);
+        $this->assertContains('unmet_conditions', $contract->capabilityVocabulary('domain_evaluation')['stable_fields']);
+        $this->assertStringContainsString(
+            'provider internal architecture',
+            $contract->capabilityVocabulary('lane_pressure')['constraints'][0]
+        );
     }
 
     public function testAgentUsesDevelationPrototypeCarrier(): void


### PR DESCRIPTION
## Intent summary

Expose a package-neutral runtime capability vocabulary for adapter contracts, covering goal, statement, feedback, domain evaluation, and lane-pressure terms.

## User stories / acceptance criteria

- As an adapter maintainer, I can retrieve machine-readable vocabulary from AgentIntegrationContract without depending on parser internals or prompt text.
- As a contract reviewer, I can see stable fields, aliases, classes, and compatibility constraints for goal, statement, feedback, domain evaluation, and lane pressure.
- As a downstream runtime author, I can bind local constructs to Automata feature ids while keeping host-specific execution and provider details outside Automata.

## Key files changed

- src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
- tests/Automata/LLM/AgentIntegrationContractTest.php
- docs/runtime-capability-vocabulary.md
- docs/agent-capabilities.md

## How to test

- php -l src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
- php -l tests/Automata/LLM/AgentIntegrationContractTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/LLM/AgentIntegrationContractTest.php tests/Automata/LLM/AgentLanePressureTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/LLM
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Goal tests/Automata/Feedback tests/Automata/Language/StatementTest.php
- git diff --check

Full local PHPUnit was attempted, but the current base still hits the known broad-suite timeout tracked by #61 and addressed by PR #63. Focused coverage for this contract change passed.

## QA checklist

- [x] Vocabulary is provider-neutral and package-neutral.
- [x] Goal, statement, feedback, domain evaluation, and lane-pressure terms have stable fields and compatibility constraints.
- [x] AgentIntegrationContract JSON exports the new feature id.
- [x] Documentation points adapters to the shared vocabulary.

## Approval conditions

- Reviewers accept the new contract version bump to 1.2.0.
- Reviewers accept the vocabulary as contract metadata, not a behavior change.
- Broader suite completion can be rechecked after PR #63 lands.

Closes #62.