### PR TITLE
Replace path graph helper usage

### DIFF
--- a/src/Automata/Anomaly/Strategies/GraphPathDetector.php
+++ b/src/Automata/Anomaly/Strategies/GraphPathDetector.php
@@ -2,10 +2,12 @@
 
 namespace BlueFission\Automata\Anomaly\Strategies;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Anomaly\Detector;
 use BlueFission\Automata\Context;
 use BlueFission\Data\Graph\Graph;
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 
 class GraphPathDetector extends Detector
 {
@@ -39,14 +41,15 @@ class GraphPathDetector extends Detector
 
         $fitness = $this->fitness;
         $path = $this->graph->shortestPath((string)$start, (string)$end, $fitness);
-        if (empty($path)) {
+        if (Arr::isEmpty($path)) {
             return 1.0;
         }
 
         $cost = 0.0;
-        for ($i = 0; $i < count($path) - 1; $i++) {
+        $pathCount = Arr::count($path);
+        for ($i = 0; $i < $pathCount - 1; $i++) {
             $edge = $this->graph->getEdgeAttributes($path[$i], $path[$i + 1]);
-            if (!is_array($edge)) {
+            if (!Arr::is($edge)) {
                 continue;
             }
             $cost += $fitness($edge);
@@ -59,6 +62,6 @@ class GraphPathDetector extends Detector
 
         $normalized = $cost / $maxCost;
         $normalized = Dev::apply('anomaly.detector.graphpath.score', $normalized);
-        return min(1.0, max(0.0, $normalized));
+        return Num::min(1.0, Num::max(0.0, $normalized));
     }
 }

--- a/src/Automata/Path/Node.php
+++ b/src/Automata/Path/Node.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Automata\Path;
 
+use BlueFission\Arr;
 use BlueFission\Data\Graph\Node as BaseNode;
 
 /**
@@ -13,7 +14,7 @@ class Node extends BaseNode
     public function __construct(string $id, $dataOrEdges = null, array $edges = [], array $meta = [])
     {
         $data = null;
-        if (is_array($dataOrEdges) && $edges === [] && $meta === []) {
+        if (Arr::is($dataOrEdges) && Arr::isEmpty($edges) && Arr::isEmpty($meta)) {
             $edges = $dataOrEdges;
         } else {
             $data = $dataOrEdges;

--- a/src/Automata/Path/RouteAllocator.php
+++ b/src/Automata/Path/RouteAllocator.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Path;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Support\Evaluates;
 use BlueFission\Func;
 use BlueFission\Num;
@@ -97,7 +98,7 @@ class RouteAllocator extends Obj
                 $path = $this->graph->shortestPath($start, $end, fn ($edge) => $this->numericValue(
                     $this->invokeFunc($this->fitness, [$edge, $asset, $demand, $this])
                 ));
-                if (empty($path)) {
+                if (Arr::isEmpty($path)) {
                     continue;
                 }
 
@@ -157,8 +158,9 @@ class RouteAllocator extends Obj
     protected function pathResidualCapacity(array $path, array $edgeCapacities, array $used): float
     {
         $minResidual = null;
+        $pathCount = Arr::count($path);
 
-        for ($i = 0; $i < count($path) - 1; $i++) {
+        for ($i = 0; $i < $pathCount - 1; $i++) {
             $from = $path[$i];
             $to = $path[$i + 1];
             $key = $this->edgeKey($from, $to);
@@ -184,7 +186,9 @@ class RouteAllocator extends Obj
      */
     protected function applyAllocationUsage(array $path, float $amount, array &$used): void
     {
-        for ($i = 0; $i < count($path) - 1; $i++) {
+        $pathCount = Arr::count($path);
+
+        for ($i = 0; $i < $pathCount - 1; $i++) {
             $from = $path[$i];
             $to = $path[$i + 1];
             $key = $this->edgeKey($from, $to);

--- a/src/Automata/Path/RoutePlanner.php
+++ b/src/Automata/Path/RoutePlanner.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Automata\Path;
 
+use BlueFission\Arr;
 use BlueFission\Automata\Adapters\StateAdapter;
 use BlueFission\Automata\Support\Evaluates;
 use BlueFission\Func;
@@ -94,7 +95,7 @@ class RoutePlanner extends Obj
             ] + $context);
         });
 
-        if (empty($path)) {
+        if (Arr::isEmpty($path)) {
             $this->dispatch(new Event('graph.route_unreachable', [
                 'start' => $start,
                 'end' => $end,
@@ -105,10 +106,11 @@ class RoutePlanner extends Obj
         }
 
         $cost = 0;
+        $pathCount = Arr::count($path);
 
-        for ($i = 0; $i < count($path) - 1; $i++) {
+        for ($i = 0; $i < $pathCount - 1; $i++) {
             $edge = $this->graph->getEdgeAttributes($path[$i], $path[$i + 1]);
-            if (!is_array($edge)) {
+            if (!Arr::is($edge)) {
                 continue;
             }
             $edgeCost = $this->edgeCost($edge, [

--- a/tests/Automata/Anomaly/GraphPathDetectorTest.php
+++ b/tests/Automata/Anomaly/GraphPathDetectorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Anomaly;
+
+use BlueFission\Automata\Anomaly\Strategies\GraphPathDetector;
+use BlueFission\Automata\Context;
+use BlueFission\Automata\Path\Graph;
+use BlueFission\Automata\Path\Node;
+use PHPUnit\Framework\TestCase;
+
+class GraphPathDetectorTest extends TestCase
+{
+    private function graph(): Graph
+    {
+        $graph = new Graph();
+
+        $graph->addNode(new Node('A', [
+            'B' => ['weight' => 2.0],
+            'C' => ['weight' => 10.0],
+        ]));
+        $graph->addNode(new Node('B', [
+            'C' => ['weight' => 3.0],
+        ]));
+        $graph->addNode(new Node('C', []));
+        $graph->addNode(new Node('D', []));
+
+        return $graph;
+    }
+
+    public function testScoreNormalizesShortestPathCost(): void
+    {
+        $detector = new GraphPathDetector($this->graph(), null, 10.0);
+
+        $score = $detector->score(['start' => 'A', 'end' => 'C'], new Context());
+
+        $this->assertSame(0.5, $score);
+    }
+
+    public function testScoreUsesContextEndpointsAndFlagsUnreachablePath(): void
+    {
+        $detector = new GraphPathDetector($this->graph(), null, 10.0);
+
+        $score = $detector->score([], new Context([
+            'start' => 'A',
+            'end' => 'D',
+        ]));
+
+        $this->assertSame(1.0, $score);
+    }
+
+    public function testScoreReturnsZeroWhenEndpointIsMissing(): void
+    {
+        $detector = new GraphPathDetector($this->graph(), null, 10.0);
+
+        $score = $detector->score(['start' => 'A'], new Context());
+
+        $this->assertSame(0.0, $score);
+    }
+}


### PR DESCRIPTION
## Intent summary

Replace raw path/graph helper usage with DevElation helpers in route planning, route allocation, path nodes, and graph-path anomaly scoring without changing behavior.

## User stories / acceptance criteria

- As a maintainer, path and graph code uses shared DevElation helpers for array checks and path counts.
- As a runtime user, route planning, route allocation, and graph path anomaly scoring retain existing behavior.
- As a reviewer, GraphPathDetector has direct regression coverage for normalized scores, unreachable paths, and missing endpoints.

## Key files changed

- src/Automata/Path/Node.php
- src/Automata/Path/RoutePlanner.php
- src/Automata/Path/RouteAllocator.php
- src/Automata/Anomaly/Strategies/GraphPathDetector.php
- tests/Automata/Anomaly/GraphPathDetectorTest.php

## How to test

- php -l src/Automata/Path/Node.php
- php -l src/Automata/Path/RoutePlanner.php
- php -l src/Automata/Path/RouteAllocator.php
- php -l src/Automata/Anomaly/Strategies/GraphPathDetector.php
- php -l tests/Automata/Anomaly/GraphPathDetectorTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Path tests/Automata/Anomaly/GraphPathDetectorTest.php tests/Automata/Anomaly/GatewayTest.php tests/Automata/Classification/GraphTest.php tests/Automata/Memory/Abs2MemoryTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Path tests/Automata/Anomaly
- git diff --check

## QA checklist

- [x] Path node edge detection uses Arr helpers.
- [x] RoutePlanner and RouteAllocator path loops use Arr helpers.
- [x] GraphPathDetector path checks and clamp use DevElation helpers.
- [x] Focused route, anomaly, classification, and memory tests pass.

## Approval conditions

- Reviewers accept the helper cleanup as behavior-preserving.
- Existing Path/Anomaly deprecation notices are treated as pre-existing and out of scope for this helper cleanup.

Closes #52.