### PR TITLE
Define feedback review records

### DIFF
--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -71,6 +71,11 @@ The monitor emits lifecycle hooks, applies policy, asks for review when configur
 
 `MCPClient` can use the same monitor, so MCP discovery, resource reads, raw requests, and tool calls are governed and observed instead of bypassing the agent's task accounting. Critical local tools can use the same human gate before `ToolExecutor` runs them.
 
+Feedback, correction, and training-signal evidence should use
+[Feedback Review Records](feedback-review-records.md) when adapters need a
+durable review envelope. Policy gates may still live in the host runtime or
+Automata governance layer; the review record stores the outcome and evidence.
+
 ## Session Scope And Memory
 
 `AgentSession` is the boundary for shared scope. An agent can keep its own prompt context, while the session decides what context, permissions, tools, uploaded inputs, working memory, and Holoscene episodes are available to one or more agents. The session can attach an Automata `IWorkingMemory` implementation, including `Abs2Memory`, so durable memory and Holoscene-compatible working-memory implementations are reached through existing Automata contracts instead of a separate memory silo.

--- a/docs/feedback-review-records.md
+++ b/docs/feedback-review-records.md
@@ -1,0 +1,40 @@
+# Feedback Review Records
+
+Automata feedback primitives describe different parts of a feedback loop:
+
+- `Projection` is the expected or predicted value that may later be checked.
+- `Observation` is the value or evidence observed at review time.
+- `Assessment` is the strategy result that compares a projection with an
+  observation.
+- `FeedbackSignal` is a small positive or negative score.
+- `FeedbackRegistry` accumulates signals by subject.
+- `ReviewRecord` is the neutral evidence envelope for human review, correction,
+  policy decisions, and training-signal evidence.
+
+`ReviewRecord` does not execute policy gates. Runtime adapters can keep policy
+gates in their host application, or they can use Automata governance classes
+such as `TaskCallMonitor` and `HumanReviewGate`. In both cases, the review
+record stores the result in a reusable shape.
+
+Stable fields:
+
+- `status`
+- `original_value`
+- `corrected_value`
+- `actor`
+- `reason`
+- `confidence`
+- `timestamp`
+- `trace`
+- `evidence`
+- `policy_strategy`
+- `tags`
+- `context`
+
+Use `policy_strategy` to name the policy or review strategy that produced the
+record. Use `trace` for task, tool, or model trace identifiers, and `evidence`
+for source snippets, scores, signal values, or reviewer notes.
+
+Correction records should preserve both the original and corrected values.
+Training signal records should keep the signal value in evidence rather than
+only storing a confidence score.

--- a/src/Automata/Feedback/ReviewRecord.php
+++ b/src/Automata/Feedback/ReviewRecord.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace BlueFission\Automata\Feedback;
+
+use BlueFission\Arr;
+use BlueFission\DevElation as Dev;
+use BlueFission\Num;
+
+class ReviewRecord extends FeedbackItem
+{
+    public const STATUS_RECORDED = 'recorded';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_DENIED = 'denied';
+    public const STATUS_CORRECTED = 'corrected';
+    public const STATUS_TRAINING_SIGNAL = 'training_signal';
+
+    public function __construct(array $data = [])
+    {
+        $data['status'] = $data['status'] ?? self::STATUS_RECORDED;
+        $data['actor'] = $data['actor'] ?? 'system';
+        $data['reason'] = $data['reason'] ?? '';
+        $data['confidence'] = $data['confidence'] ?? 1.0;
+        $data['trace'] = $data['trace'] ?? [];
+        $data['evidence'] = $data['evidence'] ?? [];
+        $data['policy_strategy'] = $data['policy_strategy'] ?? 'external';
+
+        parent::__construct($data);
+
+        Dev::do('feedback.review_record.created', ['record' => $this]);
+    }
+
+    public static function correction(
+        mixed $originalValue,
+        mixed $correctedValue,
+        string $actor,
+        string $reason = '',
+        float $confidence = 1.0,
+        array $data = []
+    ): self {
+        return new self([
+            'status' => self::STATUS_CORRECTED,
+            'original_value' => $originalValue,
+            'corrected_value' => $correctedValue,
+            'actor' => $actor,
+            'reason' => $reason,
+            'confidence' => $confidence,
+        ] + $data);
+    }
+
+    public static function trainingSignal(string $actor, FeedbackSignal $signal, array $data = []): self
+    {
+        $evidence = Arr::make($data['evidence'] ?? [])->toArray();
+
+        return new self([
+            'status' => self::STATUS_TRAINING_SIGNAL,
+            'actor' => $actor,
+            'confidence' => Num::min(1.0, Num::max(0.0, abs($signal->value()))),
+            'evidence' => [
+                'signal_value' => $signal->value(),
+            ] + $evidence,
+        ] + $data);
+    }
+
+    public function status(): string
+    {
+        return (string)$this->field('status');
+    }
+
+    public function originalValue(): mixed
+    {
+        return $this->field('original_value');
+    }
+
+    public function correctedValue(): mixed
+    {
+        return $this->field('corrected_value');
+    }
+
+    public function actor(): string
+    {
+        return (string)$this->field('actor');
+    }
+
+    public function reason(): string
+    {
+        return (string)$this->field('reason');
+    }
+
+    public function confidence(): float
+    {
+        $confidence = $this->field('confidence');
+        $confidence = Num::isValid($confidence) ? (float)$confidence : 0.0;
+
+        return Num::min(1.0, Num::max(0.0, $confidence));
+    }
+
+    public function trace(): array
+    {
+        return Arr::make($this->field('trace') ?? [])->toArray();
+    }
+
+    public function evidence(): array
+    {
+        return Arr::make($this->field('evidence') ?? [])->toArray();
+    }
+
+    public function policyStrategy(): string
+    {
+        return (string)$this->field('policy_strategy');
+    }
+
+    public function hasCorrection(): bool
+    {
+        return $this->field('corrected_value') !== null;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status(),
+            'original_value' => $this->originalValue(),
+            'corrected_value' => $this->correctedValue(),
+            'actor' => $this->actor(),
+            'reason' => $this->reason(),
+            'confidence' => $this->confidence(),
+            'timestamp' => $this->timestamp(),
+            'trace' => $this->trace(),
+            'evidence' => $this->evidence(),
+            'policy_strategy' => $this->policyStrategy(),
+            'tags' => $this->tags(),
+            'context' => $this->context()->all(),
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -10,6 +10,7 @@ use BlueFission\Automata\Feedback\Assessment;
 use BlueFission\Automata\Feedback\FeedbackSignal;
 use BlueFission\Automata\Feedback\Observation;
 use BlueFission\Automata\Feedback\Projection;
+use BlueFission\Automata\Feedback\ReviewRecord;
 use BlueFission\Automata\Goal\Condition;
 use BlueFission\Automata\Goal\GoalDecision;
 use BlueFission\Automata\Goal\GoalManager;
@@ -348,7 +349,7 @@ class AgentIntegrationContract extends Obj
                 'feedback' => [
                     'feature' => self::FEATURE_GOVERNANCE,
                     'definition' => 'Review, correction, or training-signal evidence attached to a projection, observation, decision, or generated value.',
-                    'classes' => [Assessment::class, FeedbackSignal::class, Projection::class, Observation::class],
+                    'classes' => [Assessment::class, FeedbackSignal::class, Projection::class, Observation::class, ReviewRecord::class],
                     'stable_fields' => ['original_value', 'corrected_value', 'actor', 'reason', 'confidence', 'timestamp', 'trace', 'policy_strategy'],
                     'aliases' => ['review', 'correction', 'training_signal'],
                     'constraints' => [

--- a/tests/Automata/Feedback/ReviewRecordTest.php
+++ b/tests/Automata/Feedback/ReviewRecordTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Feedback;
+
+use BlueFission\Automata\Feedback\FeedbackSignal;
+use BlueFission\Automata\Feedback\ReviewRecord;
+use PHPUnit\Framework\TestCase;
+
+class ReviewRecordTest extends TestCase
+{
+    public function testCorrectionRecordPreservesOriginalCorrectedAndEvidence(): void
+    {
+        $record = ReviewRecord::correction(
+            ['label' => 'maybe'],
+            ['label' => 'yes'],
+            'reviewer-1',
+            'Reviewer confirmed the label.',
+            0.82,
+            [
+                'trace' => ['task_id' => 'task-1'],
+                'evidence' => ['source' => 'fixture'],
+                'policy_strategy' => 'human_review',
+                'tags' => ['classification'],
+                'context' => ['surface' => 'test'],
+            ]
+        );
+
+        $this->assertSame(ReviewRecord::STATUS_CORRECTED, $record->status());
+        $this->assertSame(['label' => 'maybe'], $record->originalValue());
+        $this->assertSame(['label' => 'yes'], $record->correctedValue());
+        $this->assertSame('reviewer-1', $record->actor());
+        $this->assertSame('Reviewer confirmed the label.', $record->reason());
+        $this->assertSame(0.82, $record->confidence());
+        $this->assertTrue($record->hasCorrection());
+        $this->assertSame('task-1', $record->trace()['task_id']);
+        $this->assertSame('fixture', $record->evidence()['source']);
+        $this->assertSame('human_review', $record->policyStrategy());
+        $this->assertSame('test', $record->context()->get('surface'));
+    }
+
+    public function testTrainingSignalRecordCapturesSignalValue(): void
+    {
+        $record = ReviewRecord::trainingSignal('trainer', FeedbackSignal::negative(0.4));
+
+        $this->assertSame(ReviewRecord::STATUS_TRAINING_SIGNAL, $record->status());
+        $this->assertSame('trainer', $record->actor());
+        $this->assertSame(0.4, $record->confidence());
+        $this->assertSame(-0.4, $record->evidence()['signal_value']);
+    }
+
+    public function testRecordArrayClampsConfidenceAndExportsStableFields(): void
+    {
+        $record = new ReviewRecord([
+            'status' => ReviewRecord::STATUS_APPROVED,
+            'actor' => 'policy',
+            'confidence' => 2.0,
+            'timestamp' => 123.45,
+        ]);
+
+        $payload = $record->toArray();
+
+        $this->assertSame(ReviewRecord::STATUS_APPROVED, $payload['status']);
+        $this->assertSame('policy', $payload['actor']);
+        $this->assertSame(1.0, $payload['confidence']);
+        $this->assertSame(123.45, $payload['timestamp']);
+        $this->assertArrayHasKey('original_value', $payload);
+        $this->assertArrayHasKey('corrected_value', $payload);
+        $this->assertArrayHasKey('policy_strategy', $payload);
+    }
+}

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -11,6 +11,7 @@ use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\Reply;
 use BlueFission\Automata\Memory\Abs2Memory;
+use BlueFission\Automata\Feedback\ReviewRecord;
 use BlueFission\Obj;
 use PHPUnit\Framework\TestCase;
 
@@ -160,6 +161,7 @@ class AgentIntegrationContractTest extends TestCase
         );
         $this->assertContains('subject', $contract->capabilityVocabulary('statement')['stable_fields']);
         $this->assertContains('corrected_value', $contract->capabilityVocabulary('feedback')['stable_fields']);
+        $this->assertContains(ReviewRecord::class, $contract->capabilityVocabulary('feedback')['classes']);
         $this->assertContains('unmet_conditions', $contract->capabilityVocabulary('domain_evaluation')['stable_fields']);
         $this->assertStringContainsString(
             'provider internal architecture',


### PR DESCRIPTION
## Intent summary

Define a neutral Automata feedback review record for human corrections, policy-review outcomes, and training-signal evidence above the existing feedback primitives.

## User stories / acceptance criteria

- As an adapter maintainer, I can store original value, corrected value, actor, reason, confidence, timestamp, trace/evidence, and policy strategy in a reusable Automata record.
- As a runtime owner, I can keep policy gates in the host runtime or Automata governance layer while still recording review outcomes in a neutral feedback object.
- As a reviewer, I can see how ReviewRecord relates to Projection, Observation, Assessment, FeedbackSignal, and FeedbackRegistry.

## Key files changed

- src/Automata/Feedback/ReviewRecord.php
- tests/Automata/Feedback/ReviewRecordTest.php
- docs/feedback-review-records.md
- docs/agent-capabilities.md
- src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
- tests/Automata/LLM/AgentIntegrationContractTest.php

## How to test

- php -l src/Automata/Feedback/ReviewRecord.php
- php -l src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
- php -l tests/Automata/Feedback/ReviewRecordTest.php
- php -l tests/Automata/LLM/AgentIntegrationContractTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Feedback tests/Automata/LLM/AgentIntegrationContractTest.php
- git diff --check

## QA checklist

- [x] ReviewRecord stores correction, review, and training-signal evidence.
- [x] Confidence is normalized into a bounded 0..1 score.
- [x] Docs clarify relationships to existing feedback primitives and governance boundaries.
- [x] AgentIntegrationContract advertises ReviewRecord under feedback capability vocabulary.

## Approval conditions

- Reviewers accept ReviewRecord as a neutral evidence envelope, not a policy gate executor.
- Reviewers accept host-owned policy gates remaining outside Automata when appropriate.

Closes #56.