### PR TITLE
Cover generation profile diagnostics

### DIFF
--- a/docs/VIBE_PROFILES.md
+++ b/docs/VIBE_PROFILES.md
@@ -20,6 +20,13 @@ The runtime contract is:
 - When `profile` is absent, Automata uses the default generation client.
 - When `profile` points to a resolvable `.vibe` file, that file is loaded and prepended to the prompt context.
 - When a named override is registered, the host can replace the generation driver, the prompt, or both without changing templates.
+- When a profile value is blank or the referenced file cannot be resolved, Automata raises an actionable profile diagnostic instead of silently falling back.
+
+Profile diagnostics:
+
+- Blank profile names raise `Profile attribute was provided but no profile name or path was given.`
+- Missing profile files raise `Unable to resolve profile file '<profile>'.`
+- Registered overrides with unsupported values raise `Invalid profile override registered for '<profile>'.`
 
 Runnable example:
 

--- a/tests/Automata/LLM/FillInProfileTest.php
+++ b/tests/Automata/LLM/FillInProfileTest.php
@@ -8,6 +8,7 @@ use BlueFission\Automata\LLM\Reply;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Meta;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class RecordingClient implements IClient
 {
@@ -128,6 +129,30 @@ class FillInProfileTest extends TestCase
         $this->assertSame('Hello profiled', $fillIn->output());
         $this->assertCount(1, $client->prompts);
         $this->assertStringStartsWith("You are an editorial book agent.\n\nHello ", $client->prompts[0]);
+    }
+
+    public function testMissingProfileFileRaisesActionableDiagnostic(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'automata_fillin_missing_' . uniqid();
+        mkdir($dir, 0777, true);
+
+        $fillIn = new FillIn(new RecordingClient('unused'), 'Hello {=content}');
+        $fillIn->setProfilePaths([$dir]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unable to resolve profile file 'missing.vibe'.");
+
+        $fillIn->resolveProfile('missing.vibe');
+    }
+
+    public function testBlankProfileNameRaisesActionableDiagnostic(): void
+    {
+        $fillIn = new FillIn(new RecordingClient('unused'), 'Hello {=content}');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Profile attribute was provided but no profile name or path was given.');
+
+        $fillIn->resolveProfile(' ');
     }
 
     public function testNamedProfileOverrideCanSwapGenerationDriver(): void


### PR DESCRIPTION
## Intent summary

Finish declarative generation profile selection coverage by adding tests and docs for actionable missing-profile diagnostics.

## User stories / acceptance criteria

- As a template author, blank profile names produce a clear diagnostic.
- As a runtime integrator, missing .vibe profile files produce a clear diagnostic instead of silently falling back.
- As a reviewer, default profile behavior, profile file loading, named overrides, and missing-profile diagnostics are all covered by focused tests.

## Key files changed

- tests/Automata/LLM/FillInProfileTest.php
- docs/VIBE_PROFILES.md

## How to test

- php -l tests/Automata/LLM/FillInProfileTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/LLM/FillInProfileTest.php
- git diff --check

## QA checklist

- [x] Missing profile file diagnostic is covered.
- [x] Blank profile name diagnostic is covered.
- [x] VIBE_PROFILES docs list the failure modes.
- [x] Existing profile selection tests continue to pass.

## Approval conditions

- Reviewers agree the existing implementation plus this diagnostics coverage satisfies declarative profile selection acceptance criteria.

Closes #50.