### PR TITLE
Define HERD signal contracts

### DIFF
--- a/docs/herd-signal-contracts.md
+++ b/docs/herd-signal-contracts.md
@@ -1,0 +1,76 @@
+# HERD Signal Contracts
+
+Automata defines HERD authentication contracts as provider-neutral arrays that
+auth adapters can validate without giving Automata ownership of credentials,
+identity proofing, or host-specific security flows.
+
+## Shapes
+
+`HerdSignalContract::signal()` normalizes one risk signal:
+
+- `id`
+- `type`
+- `value`
+- `score`
+- `weight`
+- `confidence`
+- `sensitivity`
+- `retention_days`
+- `evidence`
+- `timestamp`
+
+`HerdSignalContract::context()` normalizes request context:
+
+- `subject_ref`
+- `session_ref`
+- `action`
+- `environment`
+- `metadata`
+- `privacy`
+
+`HerdSignalContract::result()` returns:
+
+- `score`
+- `decision`
+- `challenge`
+- `restrict`
+- `thresholds`
+- `signals`
+- `context`
+- `reasons`
+
+## Thresholds
+
+HERD scores are normalized from `0.0` to `1.0`. Default decisions are:
+
+- below `0.35`: `allow`
+- `0.35` and above: `challenge`
+- `0.65` and above: `restrict`
+- `0.9` and above: `deny`
+
+Adapters can override thresholds per auth surface, but should keep the same
+decision names so contract fixtures stay portable.
+
+## Privacy And Retention
+
+Signals should avoid raw credentials, raw device secrets, and full raw network
+payloads. Use references or hashes in `subject_ref`, `session_ref`, and
+`evidence` when sensitive values must be correlated by the host runtime.
+
+Default retention guidance:
+
+- `public`: 90 days, max 365 days
+- `internal`: 30 days, max 180 days
+- `sensitive`: 7 days, max 30 days
+
+The host application remains responsible for applying jurisdiction-specific
+privacy rules and deleting any external evidence stores.
+
+## Adapter Contract Tests
+
+Downstream adapters can consume the contract by asserting:
+
+- signals normalize score, confidence, sensitivity, and retention fields
+- result scores map to `allow`, `challenge`, `restrict`, or `deny`
+- sensitive evidence is referenced rather than embedded as raw secrets
+- threshold overrides preserve the standard decision names

--- a/src/Automata/Security/HerdSignalContract.php
+++ b/src/Automata/Security/HerdSignalContract.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace BlueFission\Automata\Security;
+
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Str;
+
+class HerdSignalContract
+{
+    public const DECISION_ALLOW = 'allow';
+    public const DECISION_CHALLENGE = 'challenge';
+    public const DECISION_RESTRICT = 'restrict';
+    public const DECISION_DENY = 'deny';
+
+    public const SENSITIVITY_PUBLIC = 'public';
+    public const SENSITIVITY_INTERNAL = 'internal';
+    public const SENSITIVITY_SENSITIVE = 'sensitive';
+
+    public static function signal(array $data): array
+    {
+        $type = (string)($data['type'] ?? 'unknown');
+
+        return [
+            'id' => (string)($data['id'] ?? 'signal.' . $type),
+            'type' => $type,
+            'value' => $data['value'] ?? null,
+            'score' => self::pressure($data['score'] ?? 0.0),
+            'weight' => Num::max(0.0, (float)($data['weight'] ?? 1.0)),
+            'confidence' => self::pressure($data['confidence'] ?? 1.0),
+            'sensitivity' => self::sensitivity($data['sensitivity'] ?? self::SENSITIVITY_INTERNAL),
+            'retention_days' => (int)Num::max(0, (int)($data['retention_days'] ?? 30)),
+            'evidence' => Arr::make($data['evidence'] ?? [])->toArray(),
+            'timestamp' => $data['timestamp'] ?? null,
+        ];
+    }
+
+    public static function context(array $data): array
+    {
+        return [
+            'subject_ref' => (string)($data['subject_ref'] ?? $data['subject'] ?? ''),
+            'session_ref' => (string)($data['session_ref'] ?? $data['session'] ?? ''),
+            'action' => (string)($data['action'] ?? ''),
+            'environment' => Arr::make($data['environment'] ?? [])->toArray(),
+            'metadata' => Arr::make($data['metadata'] ?? [])->toArray(),
+            'privacy' => Arr::make($data['privacy'] ?? [])->toArray(),
+        ];
+    }
+
+    public static function result(float $score, array $signals = [], array $context = [], array $thresholds = []): array
+    {
+        $score = self::pressure($score);
+        $thresholds = self::thresholds($thresholds);
+        $decision = self::decisionFor($score, $thresholds);
+
+        return [
+            'score' => $score,
+            'decision' => $decision,
+            'challenge' => $decision === self::DECISION_CHALLENGE,
+            'restrict' => Arr::make([self::DECISION_RESTRICT, self::DECISION_DENY])->contains($decision, true),
+            'thresholds' => $thresholds,
+            'signals' => Arr::make($signals)->toArray(),
+            'context' => self::context($context),
+            'reasons' => self::reasons($signals),
+        ];
+    }
+
+    public static function thresholds(array $overrides = []): array
+    {
+        return [
+            self::DECISION_CHALLENGE => self::pressure($overrides[self::DECISION_CHALLENGE] ?? 0.35),
+            self::DECISION_RESTRICT => self::pressure($overrides[self::DECISION_RESTRICT] ?? 0.65),
+            self::DECISION_DENY => self::pressure($overrides[self::DECISION_DENY] ?? 0.9),
+        ];
+    }
+
+    public static function decisionFor(float $score, array $thresholds = []): string
+    {
+        $score = self::pressure($score);
+        $thresholds = self::thresholds($thresholds);
+
+        if ($score >= $thresholds[self::DECISION_DENY]) {
+            return self::DECISION_DENY;
+        }
+
+        if ($score >= $thresholds[self::DECISION_RESTRICT]) {
+            return self::DECISION_RESTRICT;
+        }
+
+        if ($score >= $thresholds[self::DECISION_CHALLENGE]) {
+            return self::DECISION_CHALLENGE;
+        }
+
+        return self::DECISION_ALLOW;
+    }
+
+    public static function privacyGuidance(): array
+    {
+        return [
+            'minimize_raw_identifiers' => 'Store references or hashes instead of raw credentials, device secrets, or full IP payloads.',
+            'separate_sensitive_evidence' => 'Keep sensitive evidence behind the host security boundary and put only references in the contract.',
+            'scope_by_action' => 'Evaluate signals against the requested action instead of treating every request as the same risk.',
+        ];
+    }
+
+    public static function retentionRules(): array
+    {
+        return [
+            self::SENSITIVITY_PUBLIC => ['default_days' => 90, 'max_days' => 365],
+            self::SENSITIVITY_INTERNAL => ['default_days' => 30, 'max_days' => 180],
+            self::SENSITIVITY_SENSITIVE => ['default_days' => 7, 'max_days' => 30],
+        ];
+    }
+
+    public static function challengeMap(): array
+    {
+        return [
+            self::DECISION_ALLOW => 'Continue without additional friction.',
+            self::DECISION_CHALLENGE => 'Request step-up verification or additional evidence.',
+            self::DECISION_RESTRICT => 'Limit the requested action or require stronger review.',
+            self::DECISION_DENY => 'Deny the requested action and preserve audit evidence.',
+        ];
+    }
+
+    protected static function pressure(mixed $value): float
+    {
+        if (!Num::is($value)) {
+            return 0.0;
+        }
+
+        return Num::min(1.0, Num::max(0.0, (float)$value));
+    }
+
+    protected static function sensitivity(mixed $value): string
+    {
+        $value = Str::lower(Str::trim((string)$value));
+
+        return Arr::make([
+            self::SENSITIVITY_PUBLIC,
+            self::SENSITIVITY_INTERNAL,
+            self::SENSITIVITY_SENSITIVE,
+        ])->contains($value, true) ? $value : self::SENSITIVITY_INTERNAL;
+    }
+
+    protected static function reasons(array $signals): array
+    {
+        $reasons = [];
+
+        foreach ($signals as $signal) {
+            $signal = self::signal(Arr::make($signal)->toArray());
+            if ($signal['score'] <= 0.0) {
+                continue;
+            }
+
+            $reasons[] = [
+                'signal_id' => $signal['id'],
+                'type' => $signal['type'],
+                'score' => $signal['score'],
+                'confidence' => $signal['confidence'],
+            ];
+        }
+
+        return $reasons;
+    }
+}

--- a/tests/Automata/Security/HerdSignalContractTest.php
+++ b/tests/Automata/Security/HerdSignalContractTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Security;
+
+use BlueFission\Automata\Security\HerdSignalContract;
+use PHPUnit\Framework\TestCase;
+
+class HerdSignalContractTest extends TestCase
+{
+    public function testSignalNormalizesScoresSensitivityAndRetention(): void
+    {
+        $signal = HerdSignalContract::signal([
+            'id' => 'signal.device',
+            'type' => 'device_reputation',
+            'score' => 1.7,
+            'weight' => -2,
+            'confidence' => 0.8,
+            'sensitivity' => 'sensitive',
+            'retention_days' => -4,
+            'evidence' => ['device_ref' => 'device:hash'],
+        ]);
+
+        $this->assertSame('signal.device', $signal['id']);
+        $this->assertSame('device_reputation', $signal['type']);
+        $this->assertSame(1.0, $signal['score']);
+        $this->assertSame(0.0, $signal['weight']);
+        $this->assertSame(0.8, $signal['confidence']);
+        $this->assertSame(HerdSignalContract::SENSITIVITY_SENSITIVE, $signal['sensitivity']);
+        $this->assertSame(0, $signal['retention_days']);
+        $this->assertSame('device:hash', $signal['evidence']['device_ref']);
+    }
+
+    public function testResultMapsScoreToChallengeAndRestrictDecisions(): void
+    {
+        $signals = [
+            HerdSignalContract::signal([
+                'id' => 'signal.geo',
+                'type' => 'geo_velocity',
+                'score' => 0.72,
+                'confidence' => 0.9,
+            ]),
+        ];
+
+        $result = HerdSignalContract::result(0.72, $signals, [
+            'subject_ref' => 'user:123',
+            'session_ref' => 'session:abc',
+            'action' => 'change_payout_account',
+        ]);
+
+        $this->assertSame(HerdSignalContract::DECISION_RESTRICT, $result['decision']);
+        $this->assertFalse($result['challenge']);
+        $this->assertTrue($result['restrict']);
+        $this->assertSame('user:123', $result['context']['subject_ref']);
+        $this->assertSame('signal.geo', $result['reasons'][0]['signal_id']);
+    }
+
+    public function testThresholdOverridesAndGuidanceAreAvailableForFixtures(): void
+    {
+        $this->assertSame(
+            HerdSignalContract::DECISION_CHALLENGE,
+            HerdSignalContract::decisionFor(0.2, [HerdSignalContract::DECISION_CHALLENGE => 0.1])
+        );
+
+        $this->assertArrayHasKey(HerdSignalContract::SENSITIVITY_SENSITIVE, HerdSignalContract::retentionRules());
+        $this->assertArrayHasKey(HerdSignalContract::DECISION_DENY, HerdSignalContract::challengeMap());
+        $this->assertArrayHasKey('minimize_raw_identifiers', HerdSignalContract::privacyGuidance());
+    }
+}


### PR DESCRIPTION
## Intent summary

Define provider-neutral HERD authentication signal contract shapes, threshold decisions, privacy guidance, retention rules, and fixture tests for authentication adapters.

## User stories / acceptance criteria

- As an auth adapter maintainer, I can normalize HERD signal, context, and result arrays without binding to a provider or host credential store.
- As a security reviewer, I can see challenge/restrict/deny threshold mapping and privacy/retention guidance for sensitive signals.
- As a downstream test author, I can consume HerdSignalContract tests as contract examples for score normalization, decision mapping, and guidance availability.

## Key files changed

- src/Automata/Security/HerdSignalContract.php
- tests/Automata/Security/HerdSignalContractTest.php
- docs/herd-signal-contracts.md

## How to test

- php -l src/Automata/Security/HerdSignalContract.php
- php -l tests/Automata/Security/HerdSignalContractTest.php
- php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Automata/Security/HerdSignalContractTest.php
- git diff --check

## QA checklist

- [x] Signal shape normalizes score, weight, confidence, sensitivity, retention, and evidence.
- [x] Context/result shapes expose subject/session/action references and reasons.
- [x] Threshold decisions map scores to allow/challenge/restrict/deny.
- [x] Docs cover privacy and retention expectations.

## Approval conditions

- Reviewers accept this as a contract helper, not an authentication execution engine.
- Reviewers accept host-owned privacy enforcement and credential handling remaining outside Automata.

## Coordination note

Keryx was unavailable during publication, so the requested coordination-room update could not be posted from this run. The PR body carries the shared outcome and test evidence for review.

Closes #54.