### PR TITLE
Document statement bundle compatibility

### DIFF
--- a/docs/statement-bundle-compatibility.md
+++ b/docs/statement-bundle-compatibility.md
@@ -1,0 +1,57 @@
+# Statement Bundle Compatibility
+
+Automata can consume resolved language or query outputs without owning raw
+parser internals. Adapters should emit a normalized semantic bundle after their
+own parsing and resolution steps have completed.
+
+## Statement Fields
+
+Map resolved semantic output to `Statement` fields:
+
+- `subject`: actor, entity, resource, or source object.
+- `behavior`: action, relation verb, or requested operation.
+- `object`: target entity, value, resource, or result object.
+- `relationship`: relation label between subject and object.
+- `indirect_object`: secondary target when one is present.
+- `condition`: deterministic precondition or guard expression.
+- `position`: location, ordering, or coordinate-like metadata.
+- `context`: scope, confidence, phase, provenance, and status metadata.
+
+The core Statement satisfaction path remains `subject`, `behavior`, and
+`object`. Adapter-specific values such as confidence, phase, scope, provenance,
+and status should use `Context` unless they become reusable Automata semantics.
+
+## Adapter Metadata
+
+Recommended `context` keys for resolved bundles:
+
+- `confidence`: bounded confidence score from the resolving adapter.
+- `phase`: resolution phase such as `parsed`, `resolved`, or `validated`.
+- `scope`: adapter-owned scope label such as `query.result`.
+- `provenance`: source, parser, grammar, or fixture references.
+- `status`: `resolved`, `partial`, `ambiguous`, or `failed`.
+
+This keeps query-language and grammar registries adapter-owned while still
+allowing Automata reasoning, memory, comprehension, and goal code to consume a
+stable bundle shape.
+
+## Grammar Registry Boundary
+
+Automata should expose grammar and language surfaces as stable normalized
+contracts, not as a registry of downstream parser internals. A parser adapter
+may maintain its own grammar registry, but the handoff into Automata should be
+a `Statement`, `Context`, `Entity`, `Scene`, or Holoscene-compatible snapshot.
+
+## Reasoning Entry Point
+
+Resolved semantic outputs should enter Automata reasoning after semantic
+resolution:
+
+1. Adapter parses and resolves the source language.
+2. Adapter emits normalized Statement fields plus Context metadata.
+3. Automata can read the Statement snapshot, route it into comprehension,
+   attach it to working memory, or evaluate goals and policies.
+4. Host applications keep execution, persistence, and presentation decisions.
+
+Do not expose raw parser ASTs, grammar-private node ids, or host execution
+choreography as Automata Statement fields.

--- a/tests/Automata/Language/StatementTest.php
+++ b/tests/Automata/Language/StatementTest.php
@@ -72,6 +72,37 @@ class StatementTest extends TestCase
         $this->assertStringContainsString('Hospital A', $snapshot['summary']);
     }
 
+    public function testStatementBundleCarriesAdapterResolutionMetadataInContext(): void
+    {
+        $statement = new Statement();
+        $statement->assign([
+            'subject' => ['name' => 'account.balance', 'description' => 'Resolved account balance field'],
+            'behavior' => 'filters',
+            'relationship' => 'where',
+            'object' => ['name' => 'minimum_threshold', 'description' => 'Resolved comparison value'],
+            'context' => [
+                'confidence' => 0.91,
+                'phase' => 'resolved',
+                'scope' => 'query.result',
+                'provenance' => [
+                    'source' => 'fixture',
+                    'grammar' => 'adapter-owned',
+                ],
+                'status' => 'resolved',
+            ],
+        ]);
+
+        $snapshot = $statement->snapshot();
+
+        $this->assertSame('account.balance filters minimum_threshold', $snapshot['name']);
+        $this->assertSame('where', array_key_first($snapshot['relations']));
+        $this->assertSame(0.91, $snapshot['context']['data']['confidence']);
+        $this->assertSame('resolved', $snapshot['context']['data']['phase']);
+        $this->assertSame('query.result', $snapshot['context']['data']['scope']);
+        $this->assertSame('fixture', $snapshot['context']['data']['provenance']['source']);
+        $this->assertSame('resolved', $snapshot['context']['data']['status']);
+    }
+
     public function testStatementAcceptsPositionLikeObjects(): void
     {
         $statement = new Statement();


### PR DESCRIPTION
## Intent summary

Document the normalized statement bundle boundary for language/query adapters and add coverage showing adapter resolution metadata belongs in Statement context instead of raw parser fields.

## User stories / acceptance criteria

- Review the supported Statement handoff fields: subject, behavior, relationship, object, context, confidence, phase, scope, provenance, and status.
- Clarify that parser grammar registries remain adapter-owned and Automata receives normalized semantic objects after resolution.
- Show how resolved semantic outputs can enter Automata reasoning, memory, comprehension, goals, and policy flows.
- Add fixture coverage for context-carried adapter metadata.
- Keep the contract provider-neutral and package-neutral.

## Key files changed

- docs/statement-bundle-compatibility.md
- tests/Automata/Language/StatementTest.php

## How to test

- php -l tests\\Automata\\Language\\StatementTest.php
- php vendor\\phpunit\\phpunit\\phpunit --do-not-cache-result tests\\Automata\\Language\\StatementTest.php
- git diff --check

## QA checklist

- Focused Statement tests pass.
- New documentation avoids downstream parser internals and local-only paths.
- Adapter metadata is carried through Context, not bespoke Statement fields.
- Keryx coordination was attempted earlier in the session but Keryx was unavailable, so this PR body carries the collaborator-facing outcome.

## Approval conditions

- Maintainers agree this normalized handoff is sufficient for language/query bundle compatibility.
- No additional Automata-owned grammar registry fields are required for this issue.

Closes #57.