### PR TITLE
Audit DevElation prototype coverage

### DIFF
--- a/docs/develation-prototypes.md
+++ b/docs/develation-prototypes.md
@@ -1,0 +1,61 @@
+# DevElation Prototype Coverage
+
+Automata should use DevElation Prototypes where a class represents a reusable
+runtime contract that other intelligence, memory, language, or agent systems may
+inspect. Prototype support should not be added just to make simple utility
+classes look uniform.
+
+## Current Prototype Carriers
+
+- `LLM\Agent`: agent identity, role, scope, autonomy, control, goals, strategies,
+  session scope, and Holoscene association.
+- `Language\Statement`: semantic statement state, relations, conditions,
+  position, context, explanation, and snapshot projection.
+- `Goal\Condition`: condition records that can be snapshotted and evaluated
+  against nested context state.
+- `Comprehension\Entity`: entity identity, labels, relations, position,
+  history, metadata, and explanation.
+- `Comprehension\Holoscene`: domain-level scene membership, domain state,
+  measures, assessment, history, and explanation.
+- `GameTheory\Player`: agent-like game participant identity, goals, criteria,
+  strategies, decision history, active strategy, and explanation.
+
+These classes expose durable semantic, state, relation, condition, position, or
+domain behavior. They are appropriate prototype carriers because adapters can
+inspect them without depending on host-specific internals.
+
+## Applicability Rules
+
+Add or keep prototype support when a class needs one or more of these contracts:
+
+- `Proto`: shared identity, summary, explanation, snapshot, properties, labels,
+  history, or cross-runtime metadata.
+- `Prototypes\Agent`: role, scope, autonomy, control, goals, criteria,
+  strategies, decisions, and agent-facing history.
+- `Prototypes\Entity`: semantic entity identity, relations, labels, and
+  entity-facing history.
+- `Prototypes\Position`: coordinate and dimension metadata that should survive
+  adapter and memory boundaries.
+- `Prototypes\HasConditions`: reusable condition normalization and evaluation.
+- `Prototypes\Domain`: domain membership, domain state, measures, and history.
+
+Avoid prototype support for narrow algorithms, encoders, strategies, gateways,
+media processors, DTO-style result wrappers, and simple adapters unless they
+become shared semantic or runtime state carriers. Those classes should keep
+explicit APIs and typed snapshots where useful.
+
+## Coverage Expectations
+
+Prototype-facing tests should verify the behavior that other packages can rely
+on:
+
+- snapshot kind and stable identifying fields;
+- labels, relations, conditions, positions, and domain state where applicable;
+- agent role, scope, goals, strategies, decisions, and session scope where
+  applicable;
+- context and metadata preservation without provider-specific fields;
+- explanations that summarize the same contract represented by snapshots.
+
+Future prototype additions should include focused tests for the trait contract
+being adopted and should document any intentionally excluded neighboring
+classes.

--- a/tests/Automata/PrototypeCoverageTest.php
+++ b/tests/Automata/PrototypeCoverageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace BlueFission\Tests\Automata;
+
+use BlueFission\Automata\Comprehension\Entity;
+use BlueFission\Automata\Comprehension\Holoscene;
+use BlueFission\Automata\GameTheory\Player;
+use BlueFission\Automata\Goal\Condition;
+use BlueFission\Automata\Language\Statement;
+use PHPUnit\Framework\TestCase;
+
+class PrototypeCoverageTest extends TestCase
+{
+    public function testCorePrototypeCarriersExposeStableSnapshots(): void
+    {
+        $entity = (new Entity('Clinic A', 'Primary care site', ['type' => 'facility']))
+            ->addLabel('care')
+            ->coordinate('x', 7)
+            ->relate('served_by', 'Responder A');
+
+        $statement = new Statement();
+        $statement->assign([
+            'subject' => $entity,
+            'behavior' => 'requests',
+            'object' => 'support',
+            'relationship' => 'needs',
+            'condition' => 'priority',
+            'position' => ['x' => 7, 'y' => 2],
+        ]);
+
+        $condition = new Condition([
+            'path' => 'triage.priority',
+            'operator' => 'gte',
+            'value' => 2,
+            'confidence' => 0.8,
+        ]);
+
+        $holoscene = new Holoscene('incident-response');
+        $holoscene->push('clinic', $entity);
+        $holoscene->review();
+
+        $player = new Player('Responder A');
+        $player
+            ->role('operator')
+            ->scope('incident')
+            ->awareness('local')
+            ->efficacy('can_make_now')
+            ->addStrategy('dispatch')
+            ->adoptDecision(['action' => 'route_support']);
+
+        $entitySnapshot = $entity->snapshot();
+        $statementSnapshot = $statement->snapshot();
+        $conditionSnapshot = $condition->snapshot();
+        $holosceneSnapshot = $holoscene->snapshot();
+        $playerSnapshot = $player->snapshot();
+
+        $this->assertSame('entity', $entitySnapshot['kind']);
+        $this->assertSame('Clinic A', $entitySnapshot['name']);
+        $this->assertSame('facility', $entitySnapshot['meta']['type']);
+        $this->assertSame(7, $entitySnapshot['coordinates']['x']);
+        $this->assertArrayHasKey('served_by', $entitySnapshot['relations']);
+
+        $this->assertSame('statement', $statementSnapshot['kind']);
+        $this->assertSame('needs', array_key_first($statementSnapshot['relations']));
+        $this->assertSame('priority', $statementSnapshot['conditions'][0]['path']);
+        $this->assertSame(7, $statementSnapshot['coordinates']['x']);
+
+        $this->assertSame('condition', $conditionSnapshot['kind']);
+        $this->assertSame('triage.priority', $conditionSnapshot['path']);
+        $this->assertSame(0.8, $conditionSnapshot['confidence']);
+        $this->assertTrue($condition->matches(['triage' => ['priority' => 3]]));
+
+        $this->assertSame('domain', $holosceneSnapshot['kind']);
+        $this->assertSame('incident-response', $holosceneSnapshot['name']);
+        $this->assertSame(1, $holosceneSnapshot['sceneCount']);
+        $this->assertSame(1, $holosceneSnapshot['measures']['scene_count'] ?? null);
+
+        $this->assertSame('agent', $playerSnapshot['kind']);
+        $this->assertSame('operator', $playerSnapshot['role']);
+        $this->assertSame('incident', $playerSnapshot['scope']);
+        $this->assertSame(1, $playerSnapshot['strategyCount']);
+        $this->assertSame(['action' => 'route_support'], $playerSnapshot['lastDecision']);
+    }
+}


### PR DESCRIPTION
## Intent summary

Inventory the Automata classes that currently carry DevElation Prototype contracts, define when future classes should adopt those traits, and add a focused regression test across the existing prototype carriers.

## User stories / acceptance criteria

- Inventory classes that already use DevElation Prototypes.
- Define applicability rules for Proto, Agent, Entity, Position, HasConditions, and Domain contracts.
- Document classes and class categories intentionally left out of prototype support.
- Add coverage for snapshot metadata, relations, conditions, positions, domain state, and agent decision behavior where applicable.
- Preserve existing public APIs and avoid provider-specific fields.

## Key files changed

- docs/develation-prototypes.md
- tests/Automata/PrototypeCoverageTest.php

## How to test

- php -l tests\\Automata\\PrototypeCoverageTest.php
- php vendor\\phpunit\\phpunit\\phpunit --do-not-cache-result tests\\Automata\\PrototypeCoverageTest.php
- php vendor\\phpunit\\phpunit\\phpunit --do-not-cache-result tests\\Automata\\PrototypeCoverageTest.php tests\\Automata\\Comprehension\\EntityAdapterTest.php tests\\Automata\\Comprehension\\HolosceneTest.php tests\\Automata\\Goal\\ConditionTest.php tests\\Automata\\GameTheory\\PlayerAdapterTest.php tests\\Automata\\Language\\StatementTest.php tests\\Automata\\LLM\\AgentIntegrationContractTest.php
- git diff --check

## QA checklist

- New prototype coverage test passes.
- Neighboring prototype carrier tests pass.
- Documentation keeps the guidance provider-neutral and avoids downstream package fields.
- No DevElation source changes are included.

## Approval conditions

- Maintainers agree the inventory and applicability rules are the right baseline for future prototype additions.
- Any additional subsystem-specific prototype adoption can be split into follow-up issues if needed.

Closes #67.