### PR TITLE
Modernize Automata examples for current runtime APIs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,10 @@
 # Automata Examples
 
 This directory contains runnable examples that demonstrate how to use the
-Automata library in a Develation-style, event-driven way.
+Automata library in a DevElation-style, event-driven way. Examples are intended
+to be executable documentation: they should run from a clean checkout, avoid
+network credentials, and return output that a browser, consumer, or contributor
+can inspect without knowing private host applications.
 
 Goals:
 
@@ -10,8 +13,11 @@ Goals:
   /ABS, language, LLM).
 - Act as **executable documentation** that proves the systems work, alongside
   the PHPUnit test suite.
-- Encourage **Develation-style programming**, using `Obj`, behaviors, and
+- Encourage **DevElation-style programming**, using `Obj`, behaviors, and
   events wherever appropriate.
+- Demonstrate current Automata runtime contracts: agents, tools, memory,
+  Holoscene, lane pressure, feedback review records, statement bundles, HERD
+  signal contracts, and service-free runtime examples.
 
 To run an example:
 
@@ -19,28 +25,97 @@ To run an example:
 php examples/collections_basic.php
 ```
 
-Media pipeline examples:
+## Learning Paths
+
+Start with one of these paths depending on the integration surface you are
+trying to understand.
+
+### Runtime Contracts And Agents
+
+- `examples/generic/agent_integration_contract.php` – stable feature ids,
+  binding templates, catalog filter keys, and production checks.
+- `examples/generic/runtime_contracts.php` – capability vocabulary, normalized
+  statement bundles, feedback review records, HERD signal results, and lane
+  pressure in one service-free payload.
+- `examples/generic/agent_lane_pressure.php` – semantic, operational, and
+  execution lane-pressure assessment plus the read-only LLM tool wrapper.
+- `examples/generic/agent_tool_contracts.php` – `ToolCatalog`,
+  `ToolDefinition`, permission metadata, validation, and execution results.
+- `examples/generic/agent_memory_hooks.php` – lifecycle memory event capture.
+- `examples/generic/agent_governance_review.php` – human review and governed
+  task-call patterns.
+
+### Memory, Language, And Comprehension
+
+- `examples/disaster_response/working_memory/run.php` – ABS2 working-memory
+  recall over disaster-response context.
+- `examples/disaster_response/language_reader/run.php` – language reader
+  projection into statements and memory.
+- `examples/entity_condition_worldview.php` – prototype-backed `Entity`,
+  `Condition`, position, relation, and explanation snapshots.
+- `examples/generic/vibe_profile_fillin.php` – declarative generation profiles
+  with file-backed and named override examples.
+
+### Decisioning, Planning, And Policy
+
+- `examples/decision_tree_dispatch_policy.php` – decision trees with shared
+  method state and injected assessors.
+- `examples/expert_logistics_rules.php` – symbolic expert rules for logistics.
+- `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action
+  ranking.
+- `examples/monte_carlo_tree_search_dispatch.php` – MCTS over a sequential
+  dispatch decision tree.
+- `examples/generic/disaster_response/initiative_feedback_loop.php` – goal
+  projections, observations, assessment strategies, and feedback scoring.
+
+### Graphs, Routes, Anomaly, And Reliability
+
+- `examples/graph_routing_logistics.php` – route planning with fitness-based
+  costs.
+- `examples/graph_route_allocation_logistics.php` – route allocation where the
+  fitness hook can see asset and demand context.
+- `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an
+  activity.
+- `examples/anomaly_logistics_requests.php` – KNN-based anomaly scoring over
+  logistics requests.
+- `examples/reliability_logistics_routes.php` – beta reliability scoring for
+  route options.
+
+### Media And Data Pipelines
 
 - `examples/media_pipeline_intelligence.php` – media ingestion + text pipeline feeding Intelligence.
 - `examples/media_pipeline_engine.php` – media ingestion + text pipeline feeding Engine attention.
+- `examples/generic/data_ingestion/run.php` – deterministic tabular ingestion
+  and routing.
+- `examples/disaster_response/social_media_ingestion/run.php` – social media
+  input normalization for response workflows.
 
-Notable examples:
+### Disaster-Response Capstones
 
-- `examples/anomaly_gateway_basic.php` – multi-detector anomaly scoring on an activity.
-- `examples/anomaly_logistics_requests.php` – KNN-based anomaly scoring over logistics requests.
-- `examples/graph_routing_logistics.php` – route planning with `Func` fitness plus state-aware assessment.
-- `examples/graph_route_allocation_logistics.php` – route allocation where the fitness hook can see asset and demand context.
-- `examples/decision_tree_dispatch_policy.php` – decision trees with shared method state and injected assessors.
-- `examples/carrier_backed_simulation.php` – simulation over object-backed state via the carrier adapter seam.
-- `examples/entity_condition_worldview.php` – worldview-oriented `Entity` and `Condition` snapshot/explain contracts.
-- `examples/carrier_adapters_basic.php` – direct `CarrierAdapter` and `StateAdapter` usage over DevElation carriers.
-- `examples/jenss_agent_adapter.php` – interpreter-friendly agent state using the prototype-backed `Player`.
-- `examples/graph_routing_logistics.php` – route planning with fitness-based costs.
-- `examples/monte_carlo_route_planning.php` – budgeted Monte Carlo action ranking over uncertain route outcomes.
-- `examples/monte_carlo_tree_search_dispatch.php` – MCTS planning over a small sequential dispatch decision tree.
+- `examples/disaster_response/coordination_pipeline/run.php` – event
+  classification, routing, memory, and response summary.
+- `examples/disaster_response/capstone_multi_strategy_dashboard/run.php` –
+  multi-strategy dashboard-style output.
+- `examples/disaster_response/game_theory_allocation/run.php` – allocation
+  profiles and payoff strategy shape.
+- `examples/disaster_response/genetic_policy_optimization/run.php` – bounded
+  policy search over deterministic fixtures.
+- `examples/generic/disaster_response/gridworld_demo.php` – richer local
+  simulation with service-free entities and strategy classes.
 
-Additional examples will be added as modules are fleshed out and tested.
+## Example Standards
 
 Many branch-local examples load `examples/bootstrap.php` so they execute against
 the worktree source rather than another checkout.
+
+Examples should:
+
+- use `examples/bootstrap.php` instead of requiring Composer directly;
+- prefer deterministic, service-free fixtures unless the example is explicitly
+  about an external integration;
+- emit structured JSON when the output is intended for downstream tooling;
+- avoid raw credentials, raw sensitive signals, and consumer-specific package
+  fields;
+- use current Automata contracts and DevElation helpers when they clarify the
+  pattern.
 

--- a/examples/anomaly_gateway_basic.php
+++ b/examples/anomaly_gateway_basic.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Anomaly\Activity;
 use BlueFission\Automata\Anomaly\Gateway;

--- a/examples/anomaly_logistics_requests.php
+++ b/examples/anomaly_logistics_requests.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Analysis\KNearestExplorer;
 use BlueFission\Automata\Analysis\KNearestAnomaly;

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 require_once dirname(__DIR__) . '/tests/bootstrap.php';
 
 function automata_example_require(string ...$relativePaths): void

--- a/examples/collections_basic.php
+++ b/examples/collections_basic.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Deq;
 use BlueFission\Dict;

--- a/examples/decision_tree_logistics.php
+++ b/examples/decision_tree_logistics.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\DecisionTree\DecisionTree;
 use BlueFission\Automata\DecisionTree\Node;

--- a/examples/disaster_response/capstone_multi_strategy_dashboard/run.php
+++ b/examples/disaster_response/capstone_multi_strategy_dashboard/run.php
@@ -12,7 +12,7 @@ use BlueFission\Automata\Genetic\UniformCrossover;
 use BlueFission\Automata\Genetic\RandomMutation;
 use BlueFission\Automata\Genetic\FitnessFunction;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 // CLI args: --seed, --steps
 $seed = 123;

--- a/examples/disaster_response/coordination_pipeline/run.php
+++ b/examples/disaster_response/coordination_pipeline/run.php
@@ -14,7 +14,7 @@ use BlueFission\Automata\Memory\Abs2Memory;
 use BlueFission\Automata\Intelligence;
 use BlueFission\Automata\Strategy\IStrategy;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 DevElation::up();
 

--- a/examples/disaster_response/game_theory_allocation/run.php
+++ b/examples/disaster_response/game_theory_allocation/run.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use BlueFission\DevElation;
 use BlueFission\Automata\GameTheory\PayoffMatrix;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 // Optional seed for future stochastic strategies (currently deterministic).
 $seed = 123;

--- a/examples/disaster_response/genetic_policy_optimization/run.php
+++ b/examples/disaster_response/genetic_policy_optimization/run.php
@@ -9,7 +9,7 @@ use BlueFission\Automata\Genetic\UniformCrossover;
 use BlueFission\Automata\Genetic\RandomMutation;
 use BlueFission\Automata\Genetic\FitnessFunction;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 // Seeded randomness for determinism.
 $seed = 123;

--- a/examples/disaster_response/intent_routing/run.php
+++ b/examples/disaster_response/intent_routing/run.php
@@ -10,7 +10,7 @@ use BlueFission\Automata\Intent\Skill\BaseSkill;
 use BlueFission\Automata\Analysis\IAnalyzer;
 use BlueFission\Arr;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 DevElation::up();
 

--- a/examples/disaster_response/language_reader/run.php
+++ b/examples/disaster_response/language_reader/run.php
@@ -8,7 +8,7 @@ use BlueFission\Automata\Language\Reader;
 use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\Memory\Abs2Memory;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 DevElation::up();
 

--- a/examples/disaster_response/social_media_ingestion/run.php
+++ b/examples/disaster_response/social_media_ingestion/run.php
@@ -7,7 +7,7 @@ use BlueFission\Automata\Encoding\CategoricalEncoder;
 use BlueFission\Automata\Normalization\NumericalScaler;
 use BlueFission\Automata\Feature\InteractionFeatures;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 DevElation::up();
 

--- a/examples/disaster_response/working_memory/run.php
+++ b/examples/disaster_response/working_memory/run.php
@@ -6,7 +6,7 @@ use BlueFission\Automata\Context;
 use BlueFission\Automata\Memory\Abs2Memory;
 use BlueFission\DevElation;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 // Seeded randomness for reproducibility.
 $seed = 123;

--- a/examples/expert_logistics_rules.php
+++ b/examples/expert_logistics_rules.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Expert\Expert;
 use BlueFission\Automata\Expert\Fact;

--- a/examples/generic/agent_governance_review.php
+++ b/examples/generic/agent_governance_review.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../../vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use BlueFission\Automata\LLM\Agent\Governance\GovernanceDecision;
 use BlueFission\Automata\LLM\Agent\Governance\HumanReviewGate;

--- a/examples/generic/agent_nested_orchestration.php
+++ b/examples/generic/agent_nested_orchestration.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use BlueFission\Arr;
 use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationConfig;

--- a/examples/generic/agent_piano_state.php
+++ b/examples/generic/agent_piano_state.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use BlueFission\Automata\Goal\ComparisonOperator;
 use BlueFission\Automata\Goal\Condition;

--- a/examples/generic/agent_state_dependency_injection.php
+++ b/examples/generic/agent_state_dependency_injection.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use BlueFission\Automata\Goal\ComparisonOperator;
 use BlueFission\Automata\Goal\Condition;

--- a/examples/generic/data_ingestion/run.php
+++ b/examples/generic/data_ingestion/run.php
@@ -6,7 +6,7 @@ use BlueFission\DevElation;
 use BlueFission\Automata\Normalization\NumericalScaler;
 use BlueFission\Automata\Encoding\CategoricalEncoder;
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 DevElation::up();
 

--- a/examples/generic/disaster_response/classification_gateway.php
+++ b/examples/generic/disaster_response/classification_gateway.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 use BlueFission\Automata\Classification\Gateway;
 use BlueFission\Automata\Classification\IClassifier;

--- a/examples/generic/disaster_response/crisismmd_sample.php
+++ b/examples/generic/disaster_response/crisismmd_sample.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 use BlueFission\Automata\Classification\Gateway;
 use BlueFission\Automata\Classification\IClassifier;

--- a/examples/generic/disaster_response/dataset_execution.php
+++ b/examples/generic/disaster_response/dataset_execution.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 use BlueFission\Automata\Classification\Gateway;
 use BlueFission\Automata\Classification\IClassifier;

--- a/examples/generic/disaster_response/gridworld_demo.php
+++ b/examples/generic/disaster_response/gridworld_demo.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 require_once __DIR__ . '/sim/Cell.php';
 require_once __DIR__ . '/sim/Position.php';
 require_once __DIR__ . '/sim/Grid.php';

--- a/examples/generic/disaster_response/initiative_feedback_loop.php
+++ b/examples/generic/disaster_response/initiative_feedback_loop.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 use BlueFission\Automata\Goal\Initiative;
 use BlueFission\Automata\Goal\Objective;
@@ -14,6 +14,7 @@ use BlueFission\Automata\Feedback\FeedbackRegistry;
 use BlueFission\Automata\Feedback\Strategies\LabelOverlapStrategy;
 use BlueFission\Automata\Feedback\Strategies\TimeWindowMatchStrategy;
 use BlueFission\Automata\Feedback\Strategies\ContextSimilarityStrategy;
+use BlueFission\Arr;
 use BlueFission\Cli\Args;
 use BlueFission\Cli\Args\OptionDefinition;
 
@@ -28,7 +29,10 @@ $parser->addOptions([
 ]);
 $parser->parse($argv ?? []);
 $options = $parser->options();
-if (!empty($options['help'])) {
+$showHelp = Arr::hasKey($options, 'help') && (bool)$options['help'];
+$verbose = Arr::hasKey($options, 'verbose') && (bool)$options['verbose'];
+
+if ($showHelp) {
     echo $parser->usage() . PHP_EOL;
     exit(0);
 }
@@ -71,7 +75,7 @@ $observations = [
     ]),
 ];
 
-if ($options['verbose']) {
+if ($verbose) {
     echo "Initiative: " . $initiative->field('name') . "\n";
     foreach ($projections as $projection) {
         $tags = implode(',', $projection->tags());
@@ -89,7 +93,7 @@ foreach ($projections as $projection) {
             : FeedbackSignal::negative(0.1);
 
         $registry->apply('initiative:' . $initiative->field('name'), $signal);
-        if ($options['verbose']) {
+        if ($verbose) {
             $tags = implode(',', $observation->tags());
             $projectionTags = implode(',', $projection->tags());
             echo "Observation tags={$tags} vs Projection tags={$projectionTags} => {$assessment->strategy()} score={$assessment->score()}\n";

--- a/examples/generic/mcp_agent/run.php
+++ b/examples/generic/mcp_agent/run.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../../../vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
 use BlueFission\Automata\LLM\Agent;
 use BlueFission\Automata\LLM\Reply;

--- a/examples/generic/runtime_contracts.php
+++ b/examples/generic/runtime_contracts.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Arr;
+use BlueFission\Automata\Feedback\FeedbackSignal;
+use BlueFission\Automata\Feedback\ReviewRecord;
+use BlueFission\Automata\Language\Statement;
+use BlueFission\Automata\LLM\Agent\Integration\AgentIntegrationContract;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureManager;
+use BlueFission\Automata\LLM\Agent\Lanes\LanePressureProfile;
+use BlueFission\Automata\Security\HerdSignalContract;
+use BlueFission\Net\HTTP;
+
+$contract = AgentIntegrationContract::standard();
+$capabilityKeys = ['statement', 'feedback', 'domain_evaluation', 'lane_pressure'];
+$capabilities = Arr::map($capabilityKeys, fn (string $key): array => [
+    'key' => $key,
+    'feature' => $contract->capabilityVocabulary($key)['feature'],
+    'fields' => $contract->capabilityVocabulary($key)['stable_fields'],
+]);
+
+$statement = new Statement();
+$statement->assign([
+    'subject' => ['name' => 'request.context', 'description' => 'Resolved request context'],
+    'behavior' => 'requires',
+    'relationship' => 'needs',
+    'object' => ['name' => 'step_up_review', 'description' => 'Bounded review action'],
+    'context' => [
+        'confidence' => 0.88,
+        'phase' => 'resolved',
+        'scope' => 'runtime.contract',
+        'provenance' => [
+            'source' => 'example',
+            'grammar' => 'adapter-owned',
+        ],
+        'status' => 'resolved',
+    ],
+]);
+
+$review = ReviewRecord::correction(
+    ['decision' => 'allow'],
+    ['decision' => 'challenge'],
+    'policy-reviewer',
+    'Risk evidence exceeded the challenge threshold.',
+    0.84,
+    [
+        'trace' => ['task_id' => 'example-runtime-contracts'],
+        'evidence' => ['source' => 'herd.result'],
+        'policy_strategy' => 'human_review',
+        'tags' => ['policy', 'review'],
+        'context' => ['surface' => 'example'],
+    ]
+);
+
+$trainingSignal = ReviewRecord::trainingSignal(
+    'trainer',
+    FeedbackSignal::positive(0.72),
+    ['trace' => ['task_id' => 'example-runtime-contracts']]
+);
+
+$signals = [
+    HerdSignalContract::signal([
+        'id' => 'signal.device_ref',
+        'type' => 'device_reputation',
+        'score' => 0.44,
+        'confidence' => 0.9,
+        'sensitivity' => HerdSignalContract::SENSITIVITY_INTERNAL,
+        'evidence' => ['device_ref' => 'device:hash'],
+    ]),
+    HerdSignalContract::signal([
+        'id' => 'signal.geo_velocity',
+        'type' => 'geo_velocity',
+        'score' => 0.67,
+        'confidence' => 0.8,
+        'sensitivity' => HerdSignalContract::SENSITIVITY_SENSITIVE,
+        'evidence' => ['event_ref' => 'event:geo-summary'],
+    ]),
+];
+
+$herdResult = HerdSignalContract::result(0.67, $signals, [
+    'subject_ref' => 'principal:example',
+    'session_ref' => 'session:example',
+    'action' => 'update_recovery_channel',
+    'privacy' => HerdSignalContract::privacyGuidance(),
+]);
+
+$pressure = LanePressureManager::standard()->assess(
+    LanePressureProfile::longHorizonTask([
+        'spec' => true,
+        'source_map' => true,
+        'durable_memory' => true,
+        'runbook' => false,
+        'milestones' => 0.5,
+        'audit_log' => true,
+        'verification' => 0.75,
+        'observability' => 0.4,
+        'isolated_workspace' => true,
+        'repair_loop' => true,
+        'rollback_plan' => false,
+        'local_governance' => 0.8,
+    ]),
+    ['task_id' => 'example-runtime-contracts']
+);
+
+print HTTP::jsonEncode([
+    'capability_vocabulary' => $capabilities,
+    'statement_bundle' => [
+        'name' => $statement->snapshot()['name'],
+        'relationship' => array_key_first($statement->snapshot()['relations']),
+        'context' => $statement->snapshot()['context']['data'],
+    ],
+    'feedback' => [
+        'review' => $review->toArray(),
+        'training_signal' => $trainingSignal->toArray(),
+    ],
+    'herd' => [
+        'decision' => $herdResult['decision'],
+        'challenge' => $herdResult['challenge'],
+        'restrict' => $herdResult['restrict'],
+        'reasons' => $herdResult['reasons'],
+        'retention_rules' => HerdSignalContract::retentionRules(),
+    ],
+    'lane_pressure' => [
+        'dominant_lane' => $pressure['dominant_lane'],
+        'overall_level' => $pressure['overall_level'],
+        'recommendations' => $pressure['recommendations'],
+    ],
+]) . PHP_EOL;

--- a/examples/generic/vibe_profile_fillin.php
+++ b/examples/generic/vibe_profile_fillin.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\FillIn;

--- a/examples/knn_eta_prediction.php
+++ b/examples/knn_eta_prediction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Strategy\KNearestRegression;
 use BlueFission\Automata\Analysis\KNearestExplorer;

--- a/examples/markov_infrastructure_logistics.php
+++ b/examples/markov_infrastructure_logistics.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Markov\DiscreteMarkov;
 

--- a/examples/markov_logistics_language.php
+++ b/examples/markov_logistics_language.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Language\MarkovPredictor;
 use BlueFission\Automata\Language\TrigramMarkovPredictor;

--- a/examples/media_pipeline_engine.php
+++ b/examples/media_pipeline_engine.php
@@ -10,7 +10,7 @@ use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
 use BlueFission\Automata\Media\Processing\Text\TextPipeline;
 use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 $input = $argv[1] ?? 'Flooded roadway near bridge; volunteers needed.';
 

--- a/examples/media_pipeline_intelligence.php
+++ b/examples/media_pipeline_intelligence.php
@@ -10,7 +10,7 @@ use BlueFission\Automata\Media\Processing\Image\SimpleClientsOcrHandler;
 use BlueFission\Automata\Media\Processing\Text\TextPipeline;
 use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 $input = $argv[1] ?? 'Bridge collapse near river. Volunteers needed.';
 

--- a/examples/reliability_logistics_routes.php
+++ b/examples/reliability_logistics_routes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use BlueFission\Automata\Analysis\BetaReliability;
 

--- a/tests/Examples/RuntimeContractsExampleTest.php
+++ b/tests/Examples/RuntimeContractsExampleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BlueFission\Tests\Examples;
+
+use PHPUnit\Framework\TestCase;
+
+class RuntimeContractsExampleTest extends TestCase
+{
+    public function testRuntimeContractsExampleEmitsCurrentContractPayload(): void
+    {
+        $output = $this->runExample('examples/generic/runtime_contracts.php');
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('request.context requires step_up_review', $payload['statement_bundle']['name']);
+        $this->assertSame('needs', $payload['statement_bundle']['relationship']);
+        $this->assertSame('corrected', $payload['feedback']['review']['status']);
+        $this->assertSame('training_signal', $payload['feedback']['training_signal']['status']);
+        $this->assertSame('restrict', $payload['herd']['decision']);
+        $this->assertSame('operational', $payload['lane_pressure']['dominant_lane']);
+        $this->assertNotEmpty($payload['capability_vocabulary']);
+    }
+
+    public function testFeedbackLoopExampleRunsWithoutMissingOptionWarnings(): void
+    {
+        $output = $this->runExample('examples/generic/disaster_response/initiative_feedback_loop.php');
+
+        $this->assertStringNotContainsString('Warning', $output);
+        $this->assertStringContainsString('Feedback score:', $output);
+    }
+
+    public function testAnomalyGatewayExampleHidesVendorDeprecationNoise(): void
+    {
+        $output = $this->runExample('examples/anomaly_gateway_basic.php');
+
+        $this->assertStringNotContainsString('Deprecated', $output);
+        $this->assertStringContainsString('Anomalies flagged:', $output);
+    }
+
+    private function runExample(string $path): string
+    {
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($path) . ' 2>&1';
+        exec($cmd, $output, $code);
+
+        $this->assertSame(0, $code, "{$path} should exit cleanly.\n" . implode("\n", $output));
+
+        return implode("\n", $output);
+    }
+}


### PR DESCRIPTION
## Intent summary

Modernize the Automata examples so they use the shared example bootstrap, stay clean on PHP 8.2, and demonstrate current runtime contract APIs added across the recent package updates.

## User stories / acceptance criteria

- As a consumer, I can browse examples by workflow and understand which current Automata APIs to use.
- As a contributor, I can run examples from a clean checkout without external credentials or service dependencies.
- As an adapter author, I can see current capability vocabulary, statement bundle, feedback review, HERD signal, and lane-pressure contracts in one executable example.
- Example scripts avoid warning/deprecation noise and use package-owned patterns instead of downstream-specific fields.

## Key files changed

- examples/README.md
- examples/bootstrap.php
- examples/generic/runtime_contracts.php
- examples/generic/disaster_response/initiative_feedback_loop.php
- tests/Examples/RuntimeContractsExampleTest.php
- executable examples now load examples/bootstrap.php instead of Composer directly

## How to test

- php examples/generic/runtime_contracts.php
- php examples/generic/disaster_response/initiative_feedback_loop.php 2>&1
- php examples/anomaly_gateway_basic.php 2>&1
- php -l examples/generic/runtime_contracts.php
- php -l examples/generic/disaster_response/initiative_feedback_loop.php
- vendor/bin/phpunit.bat --do-not-cache-result tests/Examples/RuntimeContractsExampleTest.php
- vendor/bin/phpunit.bat --do-not-cache-result tests/Examples tests/Automata/Capstone tests/Automata/GameTheory/GameTheoryExampleTest.php tests/Automata/Genetic/GeneticExampleTest.php tests/Automata/Simulation/SimulationExampleTest.php
- full executable example smoke pass across examples returned 0 for every script with no Warning/Deprecated/Fatal/Parse noise
- linted 59 example PHP files
- git diff --check

## QA checklist

- Keryx messages, Automata suggestions, and unread rooms were cleared before implementation.
- Examples use examples/bootstrap.php for consistent worktree loading and deprecation handling.
- New runtime contracts example is service-free and emits structured JSON.
- Focused PHPUnit smoke coverage validates the new example and previous warning/deprecation offenders.
- No secrets, credentials, network calls, or downstream package-specific payloads were introduced.

## Approval conditions

- Maintainers agree the example learning paths and runtime contract example are the right baseline for current Automata APIs.
- Any future examples that require external services should remain opt-in and separately documented.

Closes #74.