### PR TITLE
Repair Packagist update workflow

### DIFF
--- a/.github/workflows/packagist.yaml
+++ b/.github/workflows/packagist.yaml
@@ -25,7 +25,8 @@ jobs:
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
-          PACKAGE_REPOSITORY: https://github.com/BlueFissionTech/automata
+          PACKAGIST_PACKAGE_URL: https://packagist.org/bluefission/automata
+          PACKAGIST_REPOSITORY: https://github.com/BlueFissionTech/automata
         run: |
           set -euo pipefail
 
@@ -34,9 +35,36 @@ jobs:
             exit 1
           fi
 
-          curl --fail --show-error --silent \
-            --request POST \
-            --header "Content-Type: application/json" \
-            --header "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}" \
-            --data "{\"repository\":\"${PACKAGE_REPOSITORY}\"}" \
-            "https://packagist.org/api/update-package"
+          update_packagist() {
+            local repository="$1"
+            local response_file
+            local http_code
+
+            response_file="$(mktemp)"
+
+            http_code="$(curl --show-error --silent \
+              --output "${response_file}" \
+              --write-out "%{http_code}" \
+              --request POST \
+              --user-agent "BlueFissionTech/automata Packagist workflow" \
+              --header "Content-Type: application/json" \
+              --header "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}" \
+              --data "{\"repository\":\"${repository}\"}" \
+              "https://packagist.org/api/update-package")"
+
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+              cat "${response_file}"
+              rm -f "${response_file}"
+              return 0
+            fi
+
+            echo "::warning::Packagist update request for ${repository} returned HTTP ${http_code}."
+            cat "${response_file}"
+            rm -f "${response_file}"
+            return 1
+          }
+
+          if ! update_packagist "${PACKAGIST_PACKAGE_URL}"; then
+            echo "Retrying Packagist update using the repository URL."
+            update_packagist "${PACKAGIST_REPOSITORY}"
+          fi

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -75,4 +75,15 @@ final class ComposerMetadataTest extends TestCase
         $this->assertContains('/tests', $exclude);
         $this->assertContains('/scripts', $exclude);
     }
+
+    public function testPackagistWorkflowUsesRegisteredPackageUpdateEndpoint(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__) . DIRECTORY_SEPARATOR . '.github' . DIRECTORY_SEPARATOR . 'workflows' . DIRECTORY_SEPARATOR . 'packagist.yaml');
+
+        $this->assertIsString($workflow);
+        $this->assertStringContainsString('PACKAGIST_PACKAGE_URL: https://packagist.org/bluefission/automata', $workflow);
+        $this->assertStringContainsString('PACKAGIST_REPOSITORY: https://github.com/BlueFissionTech/automata', $workflow);
+        $this->assertStringContainsString('--user-agent "BlueFissionTech/automata Packagist workflow"', $workflow);
+        $this->assertStringContainsString('Retrying Packagist update using the repository URL.', $workflow);
+    }
 }


### PR DESCRIPTION
## Intent

Repair the failed Packagist post-merge workflow from the #78 merge. The failing run reached Packagist with configured secrets, but Packagist returned HTTP 403 from the update step.

## User Stories / Acceptance Criteria

- As a maintainer, I need the Packagist update workflow to target the registered package URL first so post-merge package refreshes do not depend only on repository URL resolution.
- As a maintainer, I need failed Packagist API responses to include the sanitized HTTP status and response body so credential or ownership issues can be diagnosed without exposing secrets.
- As a maintainer, I need the GitHub repository URL to remain as a fallback update target.

## Key Files Changed

- `.github/workflows/packagist.yaml`
- `tests/ComposerMetadataTest.php`

## How To Test

- `composer validate --strict`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\ComposerMetadataTest.php`
- `vendor\bin\phpunit.bat --do-not-cache-result`

## QA Checklist

- Confirmed the failed merge run was `Packagist / Update Packagist metadata` on `master`.
- Confirmed the failure was HTTP 403, not missing repository secrets.
- Confirmed Packagist documentation allows package URL or repository URL for the SAFE update endpoint.
- Added test coverage for the registered package update target and fallback.

## Approval Conditions

- The PR can merge once checks pass.
- If Packagist still returns 403 after this lands, rotate/update the repository `PACKAGIST_TOKEN` secret from the Packagist `bluefission` account and rerun the workflow.
