### PR TITLE
Fix Packagist update authentication

### DIFF
--- a/.github/workflows/packagist.yaml
+++ b/.github/workflows/packagist.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
-          PACKAGIST_PACKAGE_URL: https://packagist.org/bluefission/automata
+          PACKAGIST_PACKAGE_URL: https://packagist.org/packages/bluefission/automata
           PACKAGIST_REPOSITORY: https://github.com/BlueFissionTech/automata
         run: |
           set -euo pipefail
@@ -48,9 +48,8 @@ jobs:
               --request POST \
               --user-agent "BlueFissionTech/automata Packagist workflow" \
               --header "Content-Type: application/json" \
-              --header "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}" \
-              --data "{\"repository\":\"${repository}\"}" \
-              "https://packagist.org/api/update-package")"
+              --data "{\"repository\":{\"url\":\"${repository}\"}}" \
+              "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}")"
 
             if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
               cat "${response_file}"

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -81,8 +81,12 @@ final class ComposerMetadataTest extends TestCase
         $workflow = file_get_contents(dirname(__DIR__) . DIRECTORY_SEPARATOR . '.github' . DIRECTORY_SEPARATOR . 'workflows' . DIRECTORY_SEPARATOR . 'packagist.yaml');
 
         $this->assertIsString($workflow);
-        $this->assertStringContainsString('PACKAGIST_PACKAGE_URL: https://packagist.org/bluefission/automata', $workflow);
+        $this->assertStringContainsString('PACKAGIST_PACKAGE_URL: https://packagist.org/packages/bluefission/automata', $workflow);
         $this->assertStringContainsString('PACKAGIST_REPOSITORY: https://github.com/BlueFissionTech/automata', $workflow);
+        $this->assertStringContainsString('api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}', $workflow);
+        $this->assertStringContainsString('repository', $workflow);
+        $this->assertStringContainsString('url', $workflow);
+        $this->assertStringContainsString('${repository}', $workflow);
         $this->assertStringContainsString('--user-agent "BlueFissionTech/automata Packagist workflow"', $workflow);
         $this->assertStringContainsString('Retrying Packagist update using the repository URL.', $workflow);
     }


### PR DESCRIPTION
## Intent

Repair the Packagist metadata refresh workflow so merged Composer metadata changes are actually crawled by Packagist.

## User Stories / Acceptance Criteria

- As a maintainer, I need the Packagist workflow to authenticate against Packagist's update-package endpoint using the supported username/apiToken request shape.
- As a maintainer, I need the workflow to request a refresh for the canonical bluefission/automata Packagist package URL.
- As a maintainer, I need the next push or manual dispatch to update Packagist so the package reflects the recently merged Chronicler constraint fix.

## Key Files Changed

- `.github/workflows/packagist.yaml`

## How To Test

- `composer validate --strict`
- `git diff --check`
- Review failed Packagist workflow run `31277444790`: Packagist returned `Missing or invalid username/apiToken in request`.

## QA Checklist

- Replaced the unsupported Authorization header update call with Packagist's documented username/apiToken query authentication.
- Corrected the Packagist package URL to `https://packagist.org/packages/bluefission/automata`.
- Preserved the repository URL fallback.
- Left unrelated `.gitignore` local changes unstaged.

## Approval Conditions

- Merge once reviewers confirm the Packagist update hook format.
- After merge, confirm the Packagist workflow completes successfully and `bluefission/automata` metadata shows `bluefission/chronicler` as `^0.1.2-alpha`.
