### PR TITLE
Define hierarchical agent delegation contracts

### DIFF
--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -92,6 +92,8 @@ PIANO is modeled as orchestration because the cognitive controller produces a bo
 
 `OrchestratedAgent` lets any orchestration run as a black-box worker inside a parent orchestration. This is useful for hierarchical societies: a PIANO society can include a villager worker whose inner mind is itself a hierarchical lead-plus-counselor orchestration. The wrapper accepts a scoped context allowlist, so the child orchestration only sees the perceptions and shared context granted to that agent rather than the full parent society state. Parent merge logic preserves black-box output under the worker name instead of flattening the inner workers into the larger society output.
 
+For coordinator-to-specialist work that needs explicit identities, capability grants, cancellation, deadlines, peer-result scoping, and trace lineage, use the provider-neutral contracts described in [Agent delegation contracts](agent-delegation.md).
+
 ## Agent State And Goals
 
 `AgentState` is a DevElation behavioral state machine with isolated channels for goals, observations, decisions, expectations, outputs, social signals, rules, and reflections. PIANO modules read and write those channels while the state machine gates behaviors such as deciding, tool use, speech, and memory updates through active states like observing, reasoning, acting, speaking, reflecting, and socializing.

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -1,0 +1,23 @@
+# Agent delegation contracts
+
+Automata models hierarchical delegation as explicit data rather than implicit prompt convention. The contracts are provider-neutral and can be used with local models, hosted model clients, deterministic workers, or mixed systems.
+
+## Contract boundary
+
+- `AgentProfile` identifies a worker and advertises its capabilities.
+- `DelegationGoal` describes the outcome and may reference a broader initiative through `initiative_id`.
+- `DelegationTask` describes the bounded unit of work for that goal.
+- `DelegationRequest` binds source and target identities, context, tools, budgets, policies, completion criteria, and lineage.
+- `CapabilityGrant` authorizes one capability from one source to one target. Grants are non-transitive unless a caller explicitly creates another grant.
+- `DelegationResult` preserves output, evidence, diagnostics, status, and correlation lineage.
+- `DelegationMessage` carries progress, evidence, or peer handoff payloads without widening the original request.
+
+`DelegationWorker` adapts these contracts to `OrchestrationConfig::HIERARCHICAL`. It rejects target mismatches and missing grants before invoking a handler, stops cancelled or expired work, and only exposes explicitly allowed peer results. The hierarchical pattern remains the execution adapter; the delegation objects are the stable semantic and operational contract.
+
+## Bounded peer collaboration
+
+Peer results are private by default. The receiving profile must advertise `peer.results.read`, and its request must set `allow_peer_results`, list the permitted peer agent IDs, and include an exact grant for that capability. This keeps a coordinator in control of each handoff while allowing ordered specialists to build on prior evidence.
+
+## Status handling
+
+Terminal statuses are `completed`, `partial`, `rejected`, `failed`, `cancelled`, and `timed_out`. A hierarchical run reports `partial` when usable specialist output exists alongside a terminal failure. Supervisor rejection or failure prevents worker dispatch.

--- a/examples/generic/agent_hierarchical_delegation.php
+++ b/examples/generic/agent_hierarchical_delegation.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Automata\LLM\Agent\Delegation\AgentProfile;
+use BlueFission\Automata\LLM\Agent\Delegation\CapabilityGrant;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationRequest;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationResult;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationStatus;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationWorker;
+use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationConfig;
+use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
+
+$grant = static fn (string $target, string $capability): CapabilityGrant => new CapabilityGrant([
+    'capability' => $capability,
+    'source_agent_id' => 'coordinator',
+    'target_agent_id' => $target,
+    'granted' => true,
+]);
+
+$researchRequest = new DelegationRequest([
+    'id' => 'research-1',
+    'source_agent_id' => 'coordinator',
+    'target_agent_id' => 'research',
+    'required_capabilities' => ['evidence.read'],
+    'capability_grants' => [$grant('research', 'evidence.read')],
+    'trace_id' => 'trace-qualification-1',
+]);
+$reviewRequest = new DelegationRequest([
+    'id' => 'review-1',
+    'source_agent_id' => 'coordinator',
+    'target_agent_id' => 'review',
+    'required_capabilities' => ['decision.review'],
+    'capability_grants' => [
+        $grant('review', 'decision.review'),
+        $grant('review', 'peer.results.read'),
+    ],
+    'peer_agent_ids' => ['research'],
+    'allow_peer_results' => true,
+    'trace_id' => 'trace-qualification-1',
+]);
+
+$research = new DelegationWorker(
+    new AgentProfile(['id' => 'research', 'capabilities' => ['evidence.read']]),
+    static fn (DelegationRequest $request): DelegationResult => DelegationResult::fromRequest(
+        $request,
+        'research',
+        DelegationStatus::COMPLETED,
+        ['company' => 'Example Co', 'verified' => true],
+        [],
+        [['source' => 'crm-record']]
+    )
+);
+$review = new DelegationWorker(
+    new AgentProfile(['id' => 'review', 'capabilities' => ['decision.review', 'peer.results.read']]),
+    static fn (DelegationRequest $request, array $peers): DelegationResult => DelegationResult::fromRequest(
+        $request,
+        'review',
+        DelegationStatus::COMPLETED,
+        ['decision' => ($peers[0]['output']['verified'] ?? false) ? 'qualified' : 'manual_review']
+    )
+);
+
+$result = (new Orchestrator([
+    'pattern' => OrchestrationConfig::HIERARCHICAL,
+    'supervisor' => static fn (): array => ['output' => ['workers' => ['research', 'review']]],
+    'workers' => ['research' => $research, 'review' => $review],
+]))->run([
+    'delegations' => ['research' => $researchRequest, 'review' => $reviewRequest],
+])->toArray();
+
+print_r($result);

--- a/src/Automata/LLM/Agent/Delegation/AgentProfile.php
+++ b/src/Automata/LLM/Agent/Delegation/AgentProfile.php
@@ -18,7 +18,7 @@ class AgentProfile extends DelegationValue
 
     public function hasCapability(string $capability): bool
     {
-        return in_array($capability, $this->capabilities(), true);
+        return Arr::has($this->capabilities(), $capability, true);
     }
 
     protected function defaults(): array

--- a/src/Automata/LLM/Agent/Delegation/AgentProfile.php
+++ b/src/Automata/LLM/Agent/Delegation/AgentProfile.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+use BlueFission\Arr;
+
+class AgentProfile extends DelegationValue
+{
+    public function id(): string
+    {
+        return (string)$this->field('id');
+    }
+
+    public function capabilities(): array
+    {
+        return Arr::make($this->field('capabilities') ?? [])->toArray();
+    }
+
+    public function hasCapability(string $capability): bool
+    {
+        return in_array($capability, $this->capabilities(), true);
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'role' => 'specialist',
+            'capabilities' => [],
+            'parent_id' => null,
+            'peer_ids' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/CapabilityGrant.php
+++ b/src/Automata/LLM/Agent/Delegation/CapabilityGrant.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+class CapabilityGrant extends DelegationValue
+{
+    public function permits(string $capability, string $sourceAgentId, string $targetAgentId): bool
+    {
+        return (bool)$this->field('granted')
+            && $this->field('capability') === $capability
+            && $this->field('source_agent_id') === $sourceAgentId
+            && $this->field('target_agent_id') === $targetAgentId;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'capability' => '',
+            'source_agent_id' => '',
+            'target_agent_id' => '',
+            'granted' => false,
+            'transferable' => false,
+            'constraints' => [],
+            'reason' => '',
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationGoal.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationGoal.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+class DelegationGoal extends DelegationValue
+{
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'objective' => '',
+            'criteria' => [],
+            'initiative_id' => null,
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationMessage.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+class DelegationMessage extends DelegationValue
+{
+    public const TYPE_PROGRESS = 'progress';
+    public const TYPE_PEER_HANDOFF = 'peer_handoff';
+    public const TYPE_EVIDENCE = 'evidence';
+
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'delegation_id' => '',
+            'type' => self::TYPE_PROGRESS,
+            'source_agent_id' => '',
+            'target_agent_id' => '',
+            'payload' => [],
+            'correlation_id' => '',
+            'causation_id' => '',
+            'trace_id' => '',
+            'evidence' => [],
+            'diagnostics' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationRequest.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationRequest.php
@@ -30,12 +30,11 @@ class DelegationRequest extends DelegationValue
 
     public function grants(): array
     {
-        return array_map(
-            static fn (mixed $grant): CapabilityGrant => $grant instanceof CapabilityGrant
+        return Arr::make($this->field('capability_grants') ?? [])
+            ->map(static fn (mixed $grant): CapabilityGrant => $grant instanceof CapabilityGrant
                 ? $grant
-                : new CapabilityGrant(Arr::make($grant)->toArray()),
-            Arr::make($this->field('capability_grants') ?? [])->toArray()
-        );
+                : new CapabilityGrant(Arr::make($grant)->toArray()))
+            ->toArray();
     }
 
     public function permits(string $capability): bool

--- a/src/Automata/LLM/Agent/Delegation/DelegationRequest.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationRequest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+use BlueFission\Arr;
+use DateTimeImmutable;
+use Throwable;
+
+class DelegationRequest extends DelegationValue
+{
+    public function id(): string
+    {
+        return (string)$this->field('id');
+    }
+
+    public function sourceAgentId(): string
+    {
+        return (string)$this->field('source_agent_id');
+    }
+
+    public function targetAgentId(): string
+    {
+        return (string)$this->field('target_agent_id');
+    }
+
+    public function requiredCapabilities(): array
+    {
+        return Arr::make($this->field('required_capabilities') ?? [])->toArray();
+    }
+
+    public function grants(): array
+    {
+        return array_map(
+            static fn (mixed $grant): CapabilityGrant => $grant instanceof CapabilityGrant
+                ? $grant
+                : new CapabilityGrant(Arr::make($grant)->toArray()),
+            Arr::make($this->field('capability_grants') ?? [])->toArray()
+        );
+    }
+
+    public function permits(string $capability): bool
+    {
+        foreach ($this->grants() as $grant) {
+            if ($grant->permits($capability, $this->sourceAgentId(), $this->targetAgentId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isCancelled(): bool
+    {
+        return (bool)$this->field('cancelled');
+    }
+
+    public function isTimedOut(?DateTimeImmutable $now = null): bool
+    {
+        $deadline = $this->field('deadline');
+        if (!$deadline) {
+            return false;
+        }
+
+        try {
+            return new DateTimeImmutable((string)$deadline) <= ($now ?? new DateTimeImmutable());
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    public function peerAgentIds(): array
+    {
+        return Arr::make($this->field('peer_agent_ids') ?? [])->toArray();
+    }
+
+    public function allowsPeerResults(): bool
+    {
+        return (bool)$this->field('allow_peer_results') && $this->permits('peer.results.read');
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'parent_id' => null,
+            'source_agent_id' => '',
+            'target_agent_id' => '',
+            'task' => [],
+            'goal' => [],
+            'context' => [],
+            'tools' => [],
+            'budget' => [],
+            'policies' => [],
+            'completion_criteria' => [],
+            'required_capabilities' => [],
+            'capability_grants' => [],
+            'peer_agent_ids' => [],
+            'allow_peer_results' => false,
+            'cancelled' => false,
+            'deadline' => null,
+            'correlation_id' => '',
+            'causation_id' => '',
+            'trace_id' => '',
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationResult.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationResult.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+class DelegationResult extends DelegationValue
+{
+    public function status(): string
+    {
+        return (string)$this->field('status');
+    }
+
+    public function output(): mixed
+    {
+        return $this->field('output');
+    }
+
+    public static function rejected(DelegationRequest $request, string $agentId, string $reason): self
+    {
+        return self::fromRequest($request, $agentId, DelegationStatus::REJECTED, null, [
+            'reason' => $reason,
+        ]);
+    }
+
+    public static function fromRequest(
+        DelegationRequest $request,
+        string $agentId,
+        string $status,
+        mixed $output = null,
+        array $diagnostics = [],
+        array $evidence = []
+    ): self {
+        $data = $request->toArray();
+
+        return new self([
+            'delegation_id' => $request->id(),
+            'agent_id' => $agentId,
+            'status' => $status,
+            'output' => $output,
+            'evidence' => $evidence,
+            'diagnostics' => $diagnostics,
+            'correlation_id' => $data['correlation_id'] ?? '',
+            'causation_id' => $data['causation_id'] ?? '',
+            'trace_id' => $data['trace_id'] ?? '',
+        ]);
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'delegation_id' => '',
+            'agent_id' => '',
+            'status' => DelegationStatus::COMPLETED,
+            'output' => null,
+            'evidence' => [],
+            'diagnostics' => [],
+            'messages' => [],
+            'correlation_id' => '',
+            'causation_id' => '',
+            'trace_id' => '',
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationStatus.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+final class DelegationStatus
+{
+    public const PENDING = 'pending';
+    public const ACCEPTED = 'accepted';
+    public const REJECTED = 'rejected';
+    public const IN_PROGRESS = 'in_progress';
+    public const COMPLETED = 'completed';
+    public const PARTIAL = 'partial';
+    public const FAILED = 'failed';
+    public const CANCELLED = 'cancelled';
+    public const TIMED_OUT = 'timed_out';
+
+    public static function terminal(): array
+    {
+        return [
+            self::REJECTED,
+            self::COMPLETED,
+            self::PARTIAL,
+            self::FAILED,
+            self::CANCELLED,
+            self::TIMED_OUT,
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationTask.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationTask.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+class DelegationTask extends DelegationValue
+{
+    protected function defaults(): array
+    {
+        return [
+            'id' => '',
+            'goal_id' => null,
+            'kind' => 'delegate_task',
+            'input' => [],
+            'completion_criteria' => [],
+            'status' => DelegationStatus::PENDING,
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationValue.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationValue.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+abstract class DelegationValue extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig($this->defaults(), $data));
+    }
+
+    abstract protected function defaults(): array;
+
+    public function toArray(): array
+    {
+        return parent::toArray();
+    }
+}

--- a/src/Automata/LLM/Agent/Delegation/DelegationWorker.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationWorker.php
@@ -107,11 +107,11 @@ class DelegationWorker
 
         $allowedPeers = $request->peerAgentIds();
 
-        return array_values(array_filter(
-            $priorResults,
-            static fn (mixed $result): bool => Arr::is($result)
-                && in_array((string)($result['name'] ?? ''), $allowedPeers, true)
-        ));
+        return Arr::make($priorResults)
+            ->filter(static fn (mixed $result): bool => Arr::is($result)
+                && Arr::has($allowedPeers, (string)($result['name'] ?? ''), true))
+            ->values()
+            ->toArray();
     }
 
     protected function normalize(DelegationResult $result): array
@@ -119,7 +119,11 @@ class DelegationWorker
         return [
             'status' => $result->status(),
             'output' => $result->output(),
-            'confidence' => in_array($result->status(), [DelegationStatus::COMPLETED, DelegationStatus::PARTIAL], true) ? 1.0 : 0.0,
+            'confidence' => Arr::has(
+                [DelegationStatus::COMPLETED, DelegationStatus::PARTIAL],
+                $result->status(),
+                true
+            ) ? 1.0 : 0.0,
             'metadata' => ['delegation' => $result->toArray()],
         ];
     }

--- a/src/Automata/LLM/Agent/Delegation/DelegationWorker.php
+++ b/src/Automata/LLM/Agent/Delegation/DelegationWorker.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace BlueFission\Automata\LLM\Agent\Delegation;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use Throwable;
+
+class DelegationWorker
+{
+    public function __construct(
+        protected AgentProfile $profile,
+        protected mixed $handler
+    ) {
+    }
+
+    public function __invoke(array $context = [], array $priorResults = []): array
+    {
+        $request = $this->request($context);
+        if (!$request) {
+            return $this->normalize(DelegationResult::rejected(
+                new DelegationRequest(['target_agent_id' => $this->profile->id()]),
+                $this->profile->id(),
+                'delegation_request_missing'
+            ));
+        }
+
+        if ($request->targetAgentId() !== $this->profile->id()) {
+            return $this->normalize(DelegationResult::rejected($request, $this->profile->id(), 'target_agent_mismatch'));
+        }
+
+        if ($request->isCancelled()) {
+            return $this->normalize(DelegationResult::fromRequest(
+                $request,
+                $this->profile->id(),
+                DelegationStatus::CANCELLED
+            ));
+        }
+
+        if ($request->isTimedOut()) {
+            return $this->normalize(DelegationResult::fromRequest(
+                $request,
+                $this->profile->id(),
+                DelegationStatus::TIMED_OUT
+            ));
+        }
+
+        foreach ($request->requiredCapabilities() as $capability) {
+            if (!$this->profile->hasCapability((string)$capability) || !$request->permits((string)$capability)) {
+                return $this->normalize(DelegationResult::rejected(
+                    $request,
+                    $this->profile->id(),
+                    'capability_not_granted:' . $capability
+                ));
+            }
+        }
+
+        if (!Func::isCallable($this->handler)) {
+            return $this->normalize(DelegationResult::fromRequest(
+                $request,
+                $this->profile->id(),
+                DelegationStatus::FAILED,
+                null,
+                ['reason' => 'handler_not_callable']
+            ));
+        }
+
+        try {
+            $result = ($this->handler)($request, $this->peerResults($request, $priorResults));
+            if (!$result instanceof DelegationResult) {
+                $result = DelegationResult::fromRequest(
+                    $request,
+                    $this->profile->id(),
+                    DelegationStatus::COMPLETED,
+                    $result
+                );
+            }
+        } catch (Throwable $exception) {
+            $result = DelegationResult::fromRequest(
+                $request,
+                $this->profile->id(),
+                DelegationStatus::FAILED,
+                null,
+                ['reason' => $exception->getMessage(), 'exception' => $exception::class]
+            );
+        }
+
+        return $this->normalize($result);
+    }
+
+    protected function request(array $context): ?DelegationRequest
+    {
+        $requests = Arr::make($context['delegations'] ?? [])->toArray();
+        $request = $requests[$this->profile->id()] ?? $context['delegation'] ?? null;
+        if ($request instanceof DelegationRequest) {
+            return $request;
+        }
+
+        return Arr::is($request) ? new DelegationRequest($request) : null;
+    }
+
+    protected function peerResults(DelegationRequest $request, array $priorResults): array
+    {
+        if (!$this->profile->hasCapability('peer.results.read') || !$request->allowsPeerResults()) {
+            return [];
+        }
+
+        $allowedPeers = $request->peerAgentIds();
+
+        return array_values(array_filter(
+            $priorResults,
+            static fn (mixed $result): bool => Arr::is($result)
+                && in_array((string)($result['name'] ?? ''), $allowedPeers, true)
+        ));
+    }
+
+    protected function normalize(DelegationResult $result): array
+    {
+        return [
+            'status' => $result->status(),
+            'output' => $result->output(),
+            'confidence' => in_array($result->status(), [DelegationStatus::COMPLETED, DelegationStatus::PARTIAL], true) ? 1.0 : 0.0,
+            'metadata' => ['delegation' => $result->toArray()],
+        ];
+    }
+}

--- a/src/Automata/LLM/Agent/Orchestration/Pattern/HierarchicalPattern.php
+++ b/src/Automata/LLM/Agent/Orchestration/Pattern/HierarchicalPattern.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Automata\LLM\Agent\Orchestration\Pattern;
 
 use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationStatus;
 use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationConfig;
 use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationResult;
 
@@ -21,7 +22,10 @@ class HierarchicalPattern extends AbstractPattern
             'confidence' => 1.0,
         ];
 
-        $selected = $plan['output']['workers'] ?? Arr::keys($config->workers());
+        $planStatus = (string)($plan['status'] ?? DelegationStatus::COMPLETED);
+        $selected = in_array($planStatus, [DelegationStatus::COMPLETED, DelegationStatus::ACCEPTED], true)
+            ? ($plan['output']['workers'] ?? Arr::keys($config->workers()))
+            : [];
         $workerResults = [$plan + ['name' => 'supervisor']];
         foreach ($selected as $name) {
             if (!Arr::hasKey($config->workers(), $name)) {
@@ -47,12 +51,56 @@ class HierarchicalPattern extends AbstractPattern
         $merged = $this->mergeWorkerResults($config, $mergeable);
 
         return new OrchestrationResult([
+            'status' => $this->aggregateStatus($workerResults),
             'pattern' => $this->name(),
             'output' => $merged['output'],
             'worker_results' => $workerResults,
             'conflicts' => $merged['conflicts'],
             'confidence' => $this->averageConfidence($workerResults),
-            'metadata' => ['plan' => $plan['output']],
+            'metadata' => ['plan' => $plan['output'] ?? null],
         ]);
+    }
+
+    protected function aggregateStatus(array $workerResults): string
+    {
+        $statuses = array_map(
+            static fn (array $result): string => (string)($result['status'] ?? DelegationStatus::COMPLETED),
+            array_slice($workerResults, 1)
+        );
+        if (Arr::count($statuses) === 0) {
+            return (string)($workerResults[0]['status'] ?? DelegationStatus::COMPLETED);
+        }
+
+        $completed = array_filter(
+            $statuses,
+            static fn (string $status): bool => $status === DelegationStatus::COMPLETED
+        );
+        $partial = array_filter(
+            $statuses,
+            static fn (string $status): bool => $status === DelegationStatus::PARTIAL
+        );
+        $active = array_filter($statuses, static fn (string $status): bool => in_array($status, [
+            DelegationStatus::PENDING,
+            DelegationStatus::ACCEPTED,
+            DelegationStatus::IN_PROGRESS,
+        ], true));
+        $failed = array_filter($statuses, static fn (string $status): bool => in_array($status, [
+            DelegationStatus::REJECTED,
+            DelegationStatus::FAILED,
+            DelegationStatus::CANCELLED,
+            DelegationStatus::TIMED_OUT,
+        ], true));
+
+        if (Arr::count($partial) > 0 || (Arr::count($failed) > 0 && Arr::count($completed) > 0)) {
+            return DelegationStatus::PARTIAL;
+        }
+
+        if (Arr::count($active) > 0) {
+            return Arr::count($completed) > 0 || Arr::count($failed) > 0
+                ? DelegationStatus::PARTIAL
+                : DelegationStatus::IN_PROGRESS;
+        }
+
+        return Arr::count($failed) > 0 ? DelegationStatus::FAILED : DelegationStatus::COMPLETED;
     }
 }

--- a/src/Automata/LLM/Agent/Orchestration/Pattern/HierarchicalPattern.php
+++ b/src/Automata/LLM/Agent/Orchestration/Pattern/HierarchicalPattern.php
@@ -23,7 +23,7 @@ class HierarchicalPattern extends AbstractPattern
         ];
 
         $planStatus = (string)($plan['status'] ?? DelegationStatus::COMPLETED);
-        $selected = in_array($planStatus, [DelegationStatus::COMPLETED, DelegationStatus::ACCEPTED], true)
+        $selected = Arr::has([DelegationStatus::COMPLETED, DelegationStatus::ACCEPTED], $planStatus, true)
             ? ($plan['output']['workers'] ?? Arr::keys($config->workers()))
             : [];
         $workerResults = [$plan + ['name' => 'supervisor']];
@@ -42,12 +42,7 @@ class HierarchicalPattern extends AbstractPattern
             }
         }
 
-        $mergeable = [];
-        foreach ($workerResults as $index => $result) {
-            if ($index > 0) {
-                $mergeable[] = $result;
-            }
-        }
+        $mergeable = Arr::make($workerResults)->slice(1)->toArray();
         $merged = $this->mergeWorkerResults($config, $mergeable);
 
         return new OrchestrationResult([
@@ -63,44 +58,43 @@ class HierarchicalPattern extends AbstractPattern
 
     protected function aggregateStatus(array $workerResults): string
     {
-        $statuses = array_map(
-            static fn (array $result): string => (string)($result['status'] ?? DelegationStatus::COMPLETED),
-            array_slice($workerResults, 1)
-        );
+        $statuses = Arr::make($workerResults)
+            ->slice(1)
+            ->map(static fn (array $result): string => (string)($result['status'] ?? DelegationStatus::COMPLETED))
+            ->toArray();
         if (Arr::count($statuses) === 0) {
             return (string)($workerResults[0]['status'] ?? DelegationStatus::COMPLETED);
         }
 
-        $completed = array_filter(
-            $statuses,
+        $statuses = Arr::make($statuses);
+        $completed = $statuses->filter(
             static fn (string $status): bool => $status === DelegationStatus::COMPLETED
         );
-        $partial = array_filter(
-            $statuses,
+        $partial = $statuses->filter(
             static fn (string $status): bool => $status === DelegationStatus::PARTIAL
         );
-        $active = array_filter($statuses, static fn (string $status): bool => in_array($status, [
+        $active = $statuses->filter(static fn (string $status): bool => Arr::has([
             DelegationStatus::PENDING,
             DelegationStatus::ACCEPTED,
             DelegationStatus::IN_PROGRESS,
-        ], true));
-        $failed = array_filter($statuses, static fn (string $status): bool => in_array($status, [
+        ], $status, true));
+        $failed = $statuses->filter(static fn (string $status): bool => Arr::has([
             DelegationStatus::REJECTED,
             DelegationStatus::FAILED,
             DelegationStatus::CANCELLED,
             DelegationStatus::TIMED_OUT,
-        ], true));
+        ], $status, true));
 
-        if (Arr::count($partial) > 0 || (Arr::count($failed) > 0 && Arr::count($completed) > 0)) {
+        if ($partial->count() > 0 || ($failed->count() > 0 && $completed->count() > 0)) {
             return DelegationStatus::PARTIAL;
         }
 
-        if (Arr::count($active) > 0) {
-            return Arr::count($completed) > 0 || Arr::count($failed) > 0
+        if ($active->count() > 0) {
+            return $completed->count() > 0 || $failed->count() > 0
                 ? DelegationStatus::PARTIAL
                 : DelegationStatus::IN_PROGRESS;
         }
 
-        return Arr::count($failed) > 0 ? DelegationStatus::FAILED : DelegationStatus::COMPLETED;
+        return $failed->count() > 0 ? DelegationStatus::FAILED : DelegationStatus::COMPLETED;
     }
 }

--- a/tests/Automata/LLM/AgentDelegationContractsTest.php
+++ b/tests/Automata/LLM/AgentDelegationContractsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace BlueFission\Tests\Automata\LLM;
+
+use BlueFission\Automata\LLM\Agent\Delegation\AgentProfile;
+use BlueFission\Automata\LLM\Agent\Delegation\CapabilityGrant;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationRequest;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationResult;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationStatus;
+use BlueFission\Automata\LLM\Agent\Delegation\DelegationWorker;
+use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationConfig;
+use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
+use PHPUnit\Framework\TestCase;
+
+class AgentDelegationContractsTest extends TestCase
+{
+    public function testHierarchicalDelegationSupportsScopedPeerHandoff(): void
+    {
+        $researchRequest = $this->request('research', ['evidence.read']);
+        $reviewRequest = $this->request('review', ['decision.review'], [
+            $this->grant('review', 'decision.review'),
+            $this->grant('review', 'peer.results.read'),
+        ], ['research']);
+
+        $research = new DelegationWorker(
+            new AgentProfile(['id' => 'research', 'capabilities' => ['evidence.read']]),
+            static fn (DelegationRequest $request): DelegationResult => DelegationResult::fromRequest(
+                $request,
+                'research',
+                DelegationStatus::COMPLETED,
+                ['fact' => 'verified'],
+                [],
+                [['source' => 'record-42']]
+            )
+        );
+        $review = new DelegationWorker(
+            new AgentProfile(['id' => 'review', 'capabilities' => ['decision.review', 'peer.results.read']]),
+            static function (DelegationRequest $request, array $peerResults): DelegationResult {
+                return DelegationResult::fromRequest(
+                    $request,
+                    'review',
+                    DelegationStatus::COMPLETED,
+                    ['reviewed' => $peerResults[0]['output']['fact'] ?? null]
+                );
+            }
+        );
+
+        $result = (new Orchestrator([
+            'pattern' => OrchestrationConfig::HIERARCHICAL,
+            'supervisor' => static fn (): array => ['output' => ['workers' => ['research', 'review']]],
+            'workers' => ['research' => $research, 'review' => $review],
+        ]))->run([
+            'delegations' => ['research' => $researchRequest, 'review' => $reviewRequest],
+        ])->toArray();
+
+        $this->assertSame(DelegationStatus::COMPLETED, $result['status']);
+        $this->assertSame('verified', $result['output']['fact']);
+        $this->assertSame('verified', $result['output']['reviewed']);
+        $this->assertSame(
+            [['source' => 'record-42']],
+            $result['worker_results'][1]['metadata']['delegation']['evidence']
+        );
+        $this->assertSame('trace-review', $result['worker_results'][2]['metadata']['delegation']['trace_id']);
+    }
+
+    public function testWorkerRejectsCapabilitiesThatWereNotGranted(): void
+    {
+        $invoked = false;
+        $worker = new DelegationWorker(
+            new AgentProfile(['id' => 'research', 'capabilities' => ['evidence.read']]),
+            static function () use (&$invoked): array {
+                $invoked = true;
+                return [];
+            }
+        );
+
+        $result = $worker([
+            'delegation' => $this->request('research', ['evidence.read'], []),
+        ]);
+
+        $this->assertFalse($invoked);
+        $this->assertSame(DelegationStatus::REJECTED, $result['status']);
+        $this->assertSame(
+            'capability_not_granted:evidence.read',
+            $result['metadata']['delegation']['diagnostics']['reason']
+        );
+    }
+
+    public function testCancellationAndDeadlineStopExecution(): void
+    {
+        $worker = new DelegationWorker(
+            new AgentProfile(['id' => 'research', 'capabilities' => []]),
+            static fn (): array => ['should_not_run' => true]
+        );
+
+        $cancelled = $worker(['delegation' => $this->request('research', [], [], [], ['cancelled' => true])]);
+        $timedOut = $worker(['delegation' => $this->request('research', [], [], [], [
+            'deadline' => '2000-01-01T00:00:00Z',
+        ])]);
+
+        $this->assertSame(DelegationStatus::CANCELLED, $cancelled['status']);
+        $this->assertSame(DelegationStatus::TIMED_OUT, $timedOut['status']);
+    }
+
+    public function testHierarchicalPatternReportsPartialFailure(): void
+    {
+        $complete = new DelegationWorker(
+            new AgentProfile(['id' => 'complete', 'capabilities' => []]),
+            static fn (): array => ['answer' => 'usable']
+        );
+        $failed = new DelegationWorker(
+            new AgentProfile(['id' => 'failed', 'capabilities' => []]),
+            static function (): void {
+                throw new \RuntimeException('specialist unavailable');
+            }
+        );
+
+        $result = (new Orchestrator([
+            'pattern' => OrchestrationConfig::HIERARCHICAL,
+            'supervisor' => static fn (): array => ['output' => ['workers' => ['complete', 'failed']]],
+            'workers' => ['complete' => $complete, 'failed' => $failed],
+        ]))->run([
+            'delegations' => [
+                'complete' => $this->request('complete'),
+                'failed' => $this->request('failed'),
+            ],
+        ])->toArray();
+
+        $this->assertSame(DelegationStatus::PARTIAL, $result['status']);
+        $this->assertSame('usable', $result['output']['answer']);
+        $this->assertSame(
+            'specialist unavailable',
+            $result['worker_results'][2]['metadata']['delegation']['diagnostics']['reason']
+        );
+    }
+
+    private function request(
+        string $target,
+        array $requiredCapabilities = [],
+        ?array $grants = null,
+        array $peers = [],
+        array $overrides = []
+    ): DelegationRequest {
+        $grants ??= array_map(fn (string $capability): CapabilityGrant => $this->grant($target, $capability), $requiredCapabilities);
+
+        return new DelegationRequest(array_merge([
+            'id' => 'delegation-' . $target,
+            'source_agent_id' => 'coordinator',
+            'target_agent_id' => $target,
+            'required_capabilities' => $requiredCapabilities,
+            'capability_grants' => $grants,
+            'peer_agent_ids' => $peers,
+            'allow_peer_results' => $peers !== [],
+            'correlation_id' => 'correlation-1',
+            'causation_id' => 'coordinator-plan',
+            'trace_id' => 'trace-' . $target,
+        ], $overrides));
+    }
+
+    private function grant(string $target, string $capability): CapabilityGrant
+    {
+        return new CapabilityGrant([
+            'capability' => $capability,
+            'source_agent_id' => 'coordinator',
+            'target_agent_id' => $target,
+            'granted' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Intent

Define provider-neutral hierarchical delegation contracts and adapt them to Automata's existing hierarchical orchestration pattern.

Closes #79.

## User stories and acceptance criteria

- Coordinators can address a bounded task to one identified specialist.
- Specialists execute only capabilities advertised by their profile and explicitly granted by the coordinator.
- Cancellation and expired deadlines stop execution before a handler runs.
- Peer results remain private unless the receiving specialist advertises and receives an exact `peer.results.read` grant for named peers.
- Results preserve status, evidence, diagnostics, and correlation lineage.
- Hierarchical orchestration reports failed, partial, and active outcomes instead of masking every run as completed.

## Key files changed

- `src/Automata/LLM/Agent/Delegation/*`: delegation value contracts and callable worker adapter.
- `src/Automata/LLM/Agent/Orchestration/Pattern/HierarchicalPattern.php`: supervisor gating and aggregate statuses.
- `tests/Automata/LLM/AgentDelegationContractsTest.php`: capability, lifecycle, peer handoff, and partial-failure coverage.
- `docs/agent-delegation.md`: contract and trust-boundary guide.
- `examples/generic/agent_hierarchical_delegation.php`: executable coordinator/research/review flow.

## How to test

```bash
composer validate --strict
vendor/bin/phpunit --do-not-cache-result
php examples/generic/agent_hierarchical_delegation.php
```

Full local result: 371 tests, 1,227 assertions, two deprecations, one skipped, zero failures.

## QA checklist

- [x] Exact source and target identities are enforced for capability grants.
- [x] Capability denial does not invoke the worker handler.
- [x] Cancellation and timeout are terminal before execution.
- [x] Peer handoff exposes only explicitly named prior results.
- [x] Partial specialist failure remains visible in the orchestration result.
- [x] Existing orchestration tests remain green.
- [x] The documented example executes successfully.

## Approval conditions

- Public contract names and namespace are acceptable for the alpha API.
- Non-transitive capability grants and private-by-default peer results match the intended trust model.
- `OrchestrationConfig::HIERARCHICAL` remains the supported execution adapter for this contract.