### PR TITLE
Define reusable qualification automation primitives

### DIFF
--- a/docs/qualification-primitives.md
+++ b/docs/qualification-primitives.md
@@ -1,0 +1,23 @@
+# Qualification automation primitives
+
+Automata provides deterministic, domain-neutral contracts for advisory qualification decisions. They can support lead qualification, intake prioritization, eligibility review, or other scored workflows without owning a CRM schema, delivery transport, or platform router.
+
+## Existing capability inventory
+
+- `GoalDecision` already represents bounded, ranked action options.
+- `Assessment`, `Classification\Result`, and `Condition` provide evaluation and criterion concepts.
+- `ReviewRecord` preserves human corrections, evidence, confidence, and policy strategy.
+- Agent traces, governance, lane pressure, and orchestration provide execution-time controls when a host chooses to act on an advisory result.
+
+The `Qualification` namespace composes these patterns into a narrower reusable workflow contract rather than replacing them.
+
+## Contracts
+
+- `QualificationCriterion` identifies a weighted signal and any required minimum.
+- `QualificationScorer` deterministically returns a normalized `QualificationScore` with confidence, reasons, unmet criteria, evidence, and trace data.
+- `NurtureSuggestion` is an advisory action with explicit allowed and prohibited conditions. Suggestions require review by default.
+- `FollowUpPlan` holds a bounded number of semantic steps, plan and step expiry, stop conditions, and review metadata.
+- `QualificationAudit` preserves evaluator, rule version, timestamps, evidence, review data, and correlation lineage.
+- `QualificationResult` is the transport-neutral envelope for the score, safe suggestions, bounded plan, and audit record.
+
+Scores remain advisory. A missing or below-minimum required criterion routes the result to `review`; it does not authorize a platform action. Hosts own consent policy, routing, delivery channels, CRM payloads, persistence, and side effects.

--- a/examples/generic/qualification_workflow.php
+++ b/examples/generic/qualification_workflow.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Automata\Qualification\FollowUpPlan;
+use BlueFission\Automata\Qualification\NurtureSuggestion;
+use BlueFission\Automata\Qualification\QualificationAudit;
+use BlueFission\Automata\Qualification\QualificationResult;
+use BlueFission\Automata\Qualification\QualificationScorer;
+
+$score = (new QualificationScorer([
+    ['key' => 'fit', 'weight' => 2, 'required' => true, 'minimum' => 0.5],
+    ['key' => 'intent', 'weight' => 1],
+    ['key' => 'consent', 'weight' => 1, 'required' => true, 'minimum' => 1.0],
+]))->score('subject-42', [
+    'fit' => ['value' => 0.85, 'confidence' => 0.9, 'evidence' => ['profile-match']],
+    'intent' => ['value' => 0.65, 'confidence' => 0.8],
+    'consent' => ['value' => 1.0, 'confidence' => 1.0, 'evidence' => ['consent-record']],
+], ['trace_id' => 'trace-qualification-42']);
+
+$suggestion = new NurtureSuggestion([
+    'id' => 'resource-education',
+    'action' => 'offer_relevant_resource',
+    'reason' => 'Fit is strong and intent is still developing.',
+    'allowed_when' => ['consent' => true],
+    'prohibited_when' => ['do_not_contact' => true],
+]);
+$plan = new FollowUpPlan([
+    'id' => 'plan-42',
+    'subject_id' => 'subject-42',
+    'max_steps' => 2,
+    'stop_conditions' => ['converted' => true],
+    'steps' => [
+        ['id' => 'review-evidence', 'action' => 'review_new_evidence', 'requires_review' => false],
+        ['id' => 'human-review', 'action' => 'request_human_review', 'requires_review' => true],
+    ],
+]);
+
+$result = new QualificationResult([
+    'score' => $score,
+    'suggestions' => $suggestion->isAllowed(['consent' => true, 'do_not_contact' => false]) ? [$suggestion] : [],
+    'follow_up_plan' => $plan,
+    'audit' => new QualificationAudit([
+        'trace_id' => 'trace-qualification-42',
+        'subject_id' => 'subject-42',
+        'rule_version' => 'qualification-rules-1',
+        'evidence' => $score->toArray()['evidence'],
+    ]),
+]);
+
+print_r($result->toArray());

--- a/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
+++ b/src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php
@@ -30,6 +30,12 @@ use BlueFission\Automata\LLM\Agent\Security\RuntimeLogicValidator;
 use BlueFission\Automata\LLM\Agent\State\AgentState;
 use BlueFission\Automata\LLM\Agent\Telemetry\TaskTrace;
 use BlueFission\Automata\Memory\IWorkingMemory;
+use BlueFission\Automata\Qualification\FollowUpPlan;
+use BlueFission\Automata\Qualification\NurtureSuggestion;
+use BlueFission\Automata\Qualification\QualificationAudit;
+use BlueFission\Automata\Qualification\QualificationResult;
+use BlueFission\Automata\Qualification\QualificationScore;
+use BlueFission\Automata\Qualification\QualificationScorer;
 use BlueFission\Automata\LLM\Agent\ToolCatalog;
 use BlueFission\Automata\LLM\Agent\ToolDefinition;
 use BlueFission\Automata\LLM\Agent\ToolExecutionResult;
@@ -40,7 +46,7 @@ use BlueFission\Obj;
 
 class AgentIntegrationContract extends Obj
 {
-    public const VERSION = '1.2.0';
+    public const VERSION = '1.3.0';
 
     public const FEATURE_AGENT = 'agent.runtime';
     public const FEATURE_TOOLS = 'agent.tool_contracts';
@@ -56,6 +62,7 @@ class AgentIntegrationContract extends Obj
     public const FEATURE_SECURITY = 'agent.runtime_security';
     public const FEATURE_LANE_PRESSURE = 'agent.lane_pressure';
     public const FEATURE_CAPABILITY_VOCABULARY = 'agent.capability_vocabulary';
+    public const FEATURE_QUALIFICATION = 'agent.qualification';
 
     public const TEMPLATE_AGENT = 'agent';
     public const TEMPLATE_TOOL = 'tool';
@@ -71,6 +78,7 @@ class AgentIntegrationContract extends Obj
     public const TEMPLATE_SECURITY = 'security';
     public const TEMPLATE_LANES = 'lanes';
     public const TEMPLATE_CAPABILITY = 'capability';
+    public const TEMPLATE_QUALIFICATION = 'qualification';
 
     /**
      * Build the standard Automata integration surface for adapter contracts.
@@ -320,6 +328,13 @@ class AgentIntegrationContract extends Obj
                     'inputs' => ['capability_term', 'adapter_contract', 'fixture_payload'],
                     'outputs' => ['term_definition', 'stable_fields', 'aliases', 'compatibility_constraints'],
                 ],
+                self::FEATURE_QUALIFICATION => [
+                    'summary' => 'Advisory qualification scoring, safe nurture suggestions, bounded follow-up plans, and audit records.',
+                    'classes' => [QualificationScorer::class, QualificationScore::class, NurtureSuggestion::class, FollowUpPlan::class, QualificationResult::class, QualificationAudit::class],
+                    'constructs' => ['qualification.criterion', 'qualification.score', 'qualification.suggestion', 'qualification.follow_up', 'qualification.audit'],
+                    'inputs' => ['subject_id', 'criteria', 'signals', 'context', 'trace'],
+                    'outputs' => ['qualification_result', 'score', 'suggestions', 'follow_up_plan', 'audit'],
+                ],
             ],
             'capability_vocabulary' => [
                 'goal' => [
@@ -370,6 +385,18 @@ class AgentIntegrationContract extends Obj
                         'Scores and confidence are advisory unless policy or goal criteria bind them to a threshold.',
                     ],
                 ],
+                'qualification' => [
+                    'feature' => self::FEATURE_QUALIFICATION,
+                    'definition' => 'An advisory scored evaluation with safe suggestions, bounded follow-up planning, and auditable evidence.',
+                    'classes' => [QualificationScorer::class, QualificationScore::class, QualificationResult::class],
+                    'stable_fields' => ['subject_id', 'score', 'confidence', 'status', 'reasons', 'unmet_criteria', 'evidence', 'suggestions', 'follow_up_plan', 'audit'],
+                    'aliases' => ['lead_qualification', 'eligibility_scoring', 'intake_priority'],
+                    'constraints' => [
+                        'Scores and suggestions remain advisory until a host policy authorizes an action.',
+                        'Transport, delivery channels, CRM payloads, and platform routing remain host-owned.',
+                        'Required missing or below-minimum criteria route to review rather than authorizing execution.',
+                    ],
+                ],
                 'lane_pressure' => [
                     'feature' => self::FEATURE_LANE_PRESSURE,
                     'definition' => 'A provider-neutral pressure assessment across semantic, operational, and execution lanes.',
@@ -410,6 +437,7 @@ class AgentIntegrationContract extends Obj
                 self::TEMPLATE_SECURITY => ['feature' => self::FEATURE_SECURITY, 'constructs' => ['security.scan', 'security.validate', 'security.sanitize']],
                 self::TEMPLATE_LANES => ['feature' => self::FEATURE_LANE_PRESSURE, 'constructs' => ['lane.semantic', 'lane.operational', 'lane.execution', 'lane.pressure', 'lane.profile.long_horizon']],
                 self::TEMPLATE_CAPABILITY => ['feature' => self::FEATURE_CAPABILITY_VOCABULARY, 'constructs' => ['capability.goal', 'capability.statement', 'capability.feedback', 'capability.domain_evaluation', 'capability.lane_pressure']],
+                self::TEMPLATE_QUALIFICATION => ['feature' => self::FEATURE_QUALIFICATION, 'constructs' => ['qualification.criterion', 'qualification.score', 'qualification.suggestion', 'qualification.follow_up', 'qualification.audit']],
             ],
             'hooks' => AgentHook::all(),
             'tool_catalog_filters' => [

--- a/src/Automata/Qualification/FollowUpPlan.php
+++ b/src/Automata/Qualification/FollowUpPlan.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Throwable;
+
+class FollowUpPlan extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        $data = ToolDefinition::mergeConfig([
+            'id' => '',
+            'subject_id' => '',
+            'steps' => [],
+            'max_steps' => 3,
+            'stop_conditions' => [],
+            'expires_at' => null,
+            'requires_review' => true,
+            'trace' => [],
+            'metadata' => [],
+        ], $data);
+        $maxSteps = (int)$data['max_steps'];
+        if ($maxSteps < 1 || Arr::count($data['steps']) > $maxSteps) {
+            throw new InvalidArgumentException('Follow-up steps exceed the bounded plan limit.');
+        }
+
+        parent::__construct();
+        $this->assign($data);
+    }
+
+    public function next(array $context = [], ?DateTimeImmutable $now = null): ?array
+    {
+        $now ??= new DateTimeImmutable();
+        if ($this->expired($this->field('expires_at'), $now) || $this->matches($this->field('stop_conditions'), $context)) {
+            return null;
+        }
+
+        foreach (Arr::make($this->field('steps') ?? [])->toArray() as $step) {
+            $step = Arr::make($step)->toArray();
+            if ($this->expired($step['expires_at'] ?? null, $now)) {
+                continue;
+            }
+            if ($this->future($step['not_before'] ?? null, $now)) {
+                continue;
+            }
+            if ($this->matches($step['stop_conditions'] ?? [], $context)) {
+                return null;
+            }
+
+            return $step;
+        }
+
+        return null;
+    }
+
+    protected function matches(mixed $conditions, array $context): bool
+    {
+        $conditions = Arr::make($conditions ?? [])->toArray();
+        if ($conditions === []) {
+            return false;
+        }
+        foreach ($conditions as $key => $expected) {
+            if (!Arr::hasKey($context, $key) || $context[$key] !== $expected) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function expired(mixed $value, DateTimeImmutable $now): bool
+    {
+        if (!$value) {
+            return false;
+        }
+        try {
+            return new DateTimeImmutable((string)$value) <= $now;
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    protected function future(mixed $value, DateTimeImmutable $now): bool
+    {
+        if (!$value) {
+            return false;
+        }
+        try {
+            return new DateTimeImmutable((string)$value) > $now;
+        } catch (Throwable) {
+            return true;
+        }
+    }
+}

--- a/src/Automata/Qualification/NurtureSuggestion.php
+++ b/src/Automata/Qualification/NurtureSuggestion.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+class NurtureSuggestion extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig([
+            'id' => '',
+            'action' => '',
+            'reason' => '',
+            'priority' => 0,
+            'allowed_when' => [],
+            'prohibited_when' => [],
+            'requires_review' => true,
+            'evidence' => [],
+            'metadata' => [],
+        ], $data));
+    }
+
+    public function isAllowed(array $context): bool
+    {
+        $allowed = Arr::make($this->field('allowed_when') ?? [])->toArray();
+        $prohibited = Arr::make($this->field('prohibited_when') ?? [])->toArray();
+
+        return $this->matches($allowed, $context) && ($prohibited === [] || !$this->matches($prohibited, $context));
+    }
+
+    protected function matches(array $conditions, array $context): bool
+    {
+        foreach ($conditions as $key => $expected) {
+            if (!Arr::hasKey($context, $key) || $context[$key] !== $expected) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Automata/Qualification/QualificationAudit.php
+++ b/src/Automata/Qualification/QualificationAudit.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+class QualificationAudit extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig([
+            'trace_id' => '',
+            'correlation_id' => '',
+            'subject_id' => '',
+            'evaluator' => 'system',
+            'rule_version' => '',
+            'evaluated_at' => gmdate(DATE_ATOM),
+            'reasons' => [],
+            'evidence' => [],
+            'review' => [],
+            'metadata' => [],
+        ], $data));
+    }
+}

--- a/src/Automata/Qualification/QualificationCriterion.php
+++ b/src/Automata/Qualification/QualificationCriterion.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Num;
+use BlueFission\Obj;
+
+class QualificationCriterion extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig([
+            'key' => '',
+            'weight' => 1.0,
+            'minimum' => 0.0,
+            'required' => false,
+            'reason' => '',
+            'metadata' => [],
+        ], $data));
+    }
+
+    public function key(): string
+    {
+        return (string)$this->field('key');
+    }
+
+    public function weight(): float
+    {
+        return Num::max(0.0, (float)$this->field('weight'));
+    }
+
+    public function minimum(): float
+    {
+        return Num::min(1.0, Num::max(0.0, (float)$this->field('minimum')));
+    }
+
+    public function required(): bool
+    {
+        return (bool)$this->field('required');
+    }
+}

--- a/src/Automata/Qualification/QualificationResult.php
+++ b/src/Automata/Qualification/QualificationResult.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+class QualificationResult extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        $score = $data['score'] ?? [];
+        $plan = $data['follow_up_plan'] ?? null;
+        $audit = $data['audit'] ?? [];
+        $suggestions = array_map(
+            static fn (mixed $suggestion): array => $suggestion instanceof NurtureSuggestion
+                ? $suggestion->toArray()
+                : Arr::make($suggestion)->toArray(),
+            Arr::make($data['suggestions'] ?? [])->toArray()
+        );
+        $data['score'] = $score instanceof QualificationScore ? $score->toArray() : Arr::make($score)->toArray();
+        $data['suggestions'] = $suggestions;
+        $data['follow_up_plan'] = $plan instanceof FollowUpPlan ? $plan->toArray() : $plan;
+        $data['audit'] = $audit instanceof QualificationAudit ? $audit->toArray() : Arr::make($audit)->toArray();
+
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig([
+            'score' => [],
+            'suggestions' => [],
+            'follow_up_plan' => null,
+            'audit' => [],
+            'metadata' => [],
+        ], $data));
+    }
+}

--- a/src/Automata/Qualification/QualificationScore.php
+++ b/src/Automata/Qualification/QualificationScore.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Num;
+use BlueFission\Obj;
+
+class QualificationScore extends Obj
+{
+    public const STATUS_QUALIFIED = 'qualified';
+    public const STATUS_NURTURE = 'nurture';
+    public const STATUS_REVIEW = 'review';
+    public const STATUS_DISQUALIFIED = 'disqualified';
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig([
+            'subject_id' => '',
+            'score' => 0.0,
+            'confidence' => 0.0,
+            'status' => self::STATUS_REVIEW,
+            'reasons' => [],
+            'unmet_criteria' => [],
+            'evidence' => [],
+            'trace' => [],
+            'metadata' => [],
+        ], $data));
+    }
+
+    public function score(): float
+    {
+        return Num::min(1.0, Num::max(0.0, (float)$this->field('score')));
+    }
+
+    public function confidence(): float
+    {
+        return Num::min(1.0, Num::max(0.0, (float)$this->field('confidence')));
+    }
+
+    public function status(): string
+    {
+        return (string)$this->field('status');
+    }
+
+    public function unmetCriteria(): array
+    {
+        return Arr::make($this->field('unmet_criteria') ?? [])->toArray();
+    }
+
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['score'] = $this->score();
+        $data['confidence'] = $this->confidence();
+
+        return $data;
+    }
+}

--- a/src/Automata/Qualification/QualificationScorer.php
+++ b/src/Automata/Qualification/QualificationScorer.php
@@ -14,12 +14,11 @@ class QualificationScorer
         protected float $qualifiedThreshold = 0.7,
         protected float $nurtureThreshold = 0.4
     ) {
-        $this->criteria = array_map(
-            static fn (mixed $criterion): QualificationCriterion => $criterion instanceof QualificationCriterion
+        $this->criteria = Arr::make($criteria)
+            ->map(static fn (mixed $criterion): QualificationCriterion => $criterion instanceof QualificationCriterion
                 ? $criterion
-                : new QualificationCriterion(Arr::make($criterion)->toArray()),
-            $criteria
-        );
+                : new QualificationCriterion(Arr::make($criterion)->toArray()))
+            ->toArray();
     }
 
     public function score(string $subjectId, array $signals, array $trace = []): QualificationScore
@@ -75,7 +74,7 @@ class QualificationScorer
             'confidence' => $confidence,
             'status' => $this->status($score, $unmet),
             'reasons' => $reasons,
-            'unmet_criteria' => array_values(array_unique($unmet)),
+            'unmet_criteria' => Arr::make($unmet)->unique()->values()->toArray(),
             'evidence' => $evidence,
             'trace' => $trace,
         ]);

--- a/src/Automata/Qualification/QualificationScorer.php
+++ b/src/Automata/Qualification/QualificationScorer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace BlueFission\Automata\Qualification;
+
+use BlueFission\Arr;
+use BlueFission\Num;
+
+class QualificationScorer
+{
+    protected array $criteria;
+
+    public function __construct(
+        array $criteria,
+        protected float $qualifiedThreshold = 0.7,
+        protected float $nurtureThreshold = 0.4
+    ) {
+        $this->criteria = array_map(
+            static fn (mixed $criterion): QualificationCriterion => $criterion instanceof QualificationCriterion
+                ? $criterion
+                : new QualificationCriterion(Arr::make($criterion)->toArray()),
+            $criteria
+        );
+    }
+
+    public function score(string $subjectId, array $signals, array $trace = []): QualificationScore
+    {
+        $totalWeight = 0.0;
+        $observedWeight = 0.0;
+        $weightedScore = 0.0;
+        $weightedConfidence = 0.0;
+        $reasons = [];
+        $unmet = [];
+        $evidence = [];
+
+        foreach ($this->criteria as $criterion) {
+            $weight = $criterion->weight();
+            $totalWeight += $weight;
+            $key = $criterion->key();
+            if ($key === '' || !Arr::hasKey($signals, $key)) {
+                if ($criterion->required()) {
+                    $unmet[] = $key;
+                    $reasons[] = 'missing_required:' . $key;
+                }
+                continue;
+            }
+
+            $signal = $signals[$key];
+            $payload = Arr::is($signal) ? Arr::make($signal)->toArray() : ['value' => $signal];
+            $value = Num::isValid($payload['value'] ?? null) ? (float)$payload['value'] : 0.0;
+            $value = Num::min(1.0, Num::max(0.0, $value));
+            $confidence = Num::isValid($payload['confidence'] ?? null) ? (float)$payload['confidence'] : 1.0;
+            $confidence = Num::min(1.0, Num::max(0.0, $confidence));
+
+            $observedWeight += $weight;
+            $weightedScore += $value * $weight;
+            $weightedConfidence += $confidence * $weight;
+            if (Arr::hasKey($payload, 'evidence')) {
+                $evidence[$key] = $payload['evidence'];
+            }
+            if ($criterion->required() && $value < $criterion->minimum()) {
+                $unmet[] = $key;
+                $reasons[] = 'below_minimum:' . $key;
+            }
+        }
+
+        $score = $observedWeight > 0.0 ? $weightedScore / $observedWeight : 0.0;
+        $coverage = $totalWeight > 0.0 ? $observedWeight / $totalWeight : 0.0;
+        $confidence = $observedWeight > 0.0
+            ? ($weightedConfidence / $observedWeight) * $coverage
+            : 0.0;
+
+        return new QualificationScore([
+            'subject_id' => $subjectId,
+            'score' => $score,
+            'confidence' => $confidence,
+            'status' => $this->status($score, $unmet),
+            'reasons' => $reasons,
+            'unmet_criteria' => array_values(array_unique($unmet)),
+            'evidence' => $evidence,
+            'trace' => $trace,
+        ]);
+    }
+
+    protected function status(float $score, array $unmet): string
+    {
+        if ($unmet !== []) {
+            return QualificationScore::STATUS_REVIEW;
+        }
+        if ($score >= Num::min(1.0, Num::max(0.0, $this->qualifiedThreshold))) {
+            return QualificationScore::STATUS_QUALIFIED;
+        }
+        if ($score >= Num::min(1.0, Num::max(0.0, $this->nurtureThreshold))) {
+            return QualificationScore::STATUS_NURTURE;
+        }
+
+        return QualificationScore::STATUS_DISQUALIFIED;
+    }
+}

--- a/tests/Automata/LLM/AgentIntegrationContractTest.php
+++ b/tests/Automata/LLM/AgentIntegrationContractTest.php
@@ -65,6 +65,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_TELEMETRY));
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_LANE_PRESSURE));
         $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_CAPABILITY_VOCABULARY));
+        $this->assertTrue($contract->supports(AgentIntegrationContract::FEATURE_QUALIFICATION));
         $this->assertSame(
             'Deterministic tool definitions, catalog retrieval, execution, and structured results.',
             $contract->feature(AgentIntegrationContract::FEATURE_TOOLS)['summary']
@@ -123,7 +124,7 @@ class AgentIntegrationContractTest extends TestCase
     {
         $json = AgentIntegrationContract::standard()->toJson();
 
-        $this->assertStringContainsString('"version":"1.2.0"', $json);
+        $this->assertStringContainsString('"version":"1.3.0"', $json);
         $this->assertStringContainsString('"agent.tool_contracts"', $json);
         $this->assertStringContainsString('"agent.holoscene_comprehension"', $json);
         $this->assertStringContainsString('"agent.lane_pressure"', $json);
@@ -154,6 +155,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertArrayHasKey('statement', $vocabulary);
         $this->assertArrayHasKey('feedback', $vocabulary);
         $this->assertArrayHasKey('domain_evaluation', $vocabulary);
+        $this->assertArrayHasKey('qualification', $vocabulary);
         $this->assertArrayHasKey('lane_pressure', $vocabulary);
         $this->assertSame(
             AgentIntegrationContract::FEATURE_HOLOSCENE,
@@ -163,6 +165,7 @@ class AgentIntegrationContractTest extends TestCase
         $this->assertContains('corrected_value', $contract->capabilityVocabulary('feedback')['stable_fields']);
         $this->assertContains(ReviewRecord::class, $contract->capabilityVocabulary('feedback')['classes']);
         $this->assertContains('unmet_conditions', $contract->capabilityVocabulary('domain_evaluation')['stable_fields']);
+        $this->assertContains('follow_up_plan', $contract->capabilityVocabulary('qualification')['stable_fields']);
         $this->assertStringContainsString(
             'provider internal architecture',
             $contract->capabilityVocabulary('lane_pressure')['constraints'][0]

--- a/tests/Automata/Qualification/QualificationPrimitivesTest.php
+++ b/tests/Automata/Qualification/QualificationPrimitivesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Qualification;
+
+use BlueFission\Automata\Qualification\FollowUpPlan;
+use BlueFission\Automata\Qualification\NurtureSuggestion;
+use BlueFission\Automata\Qualification\QualificationAudit;
+use BlueFission\Automata\Qualification\QualificationCriterion;
+use BlueFission\Automata\Qualification\QualificationResult;
+use BlueFission\Automata\Qualification\QualificationScore;
+use BlueFission\Automata\Qualification\QualificationScorer;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class QualificationPrimitivesTest extends TestCase
+{
+    public function testScorerProducesWeightedAdvisoryDecision(): void
+    {
+        $scorer = new QualificationScorer([
+            new QualificationCriterion(['key' => 'fit', 'weight' => 2, 'required' => true, 'minimum' => 0.5]),
+            new QualificationCriterion(['key' => 'intent', 'weight' => 1]),
+        ]);
+
+        $score = $scorer->score('subject-1', [
+            'fit' => ['value' => 0.9, 'confidence' => 0.8, 'evidence' => ['profile-match']],
+            'intent' => ['value' => 0.6, 'confidence' => 0.9],
+        ], ['trace_id' => 'trace-1']);
+
+        $this->assertSame(QualificationScore::STATUS_QUALIFIED, $score->status());
+        $this->assertEqualsWithDelta(0.8, $score->score(), 0.0001);
+        $this->assertEqualsWithDelta(0.8333, $score->confidence(), 0.0001);
+        $this->assertSame(['profile-match'], $score->toArray()['evidence']['fit']);
+    }
+
+    public function testMissingRequiredEvidenceRoutesToReview(): void
+    {
+        $score = (new QualificationScorer([
+            ['key' => 'consent', 'required' => true, 'minimum' => 1.0],
+            ['key' => 'fit', 'weight' => 2],
+        ]))->score('subject-2', ['fit' => 0.9]);
+
+        $this->assertSame(QualificationScore::STATUS_REVIEW, $score->status());
+        $this->assertSame(['consent'], $score->unmetCriteria());
+        $this->assertEqualsWithDelta(0.6667, $score->confidence(), 0.0001);
+    }
+
+    public function testNurtureSuggestionHonorsAllowedAndProhibitedConditions(): void
+    {
+        $suggestion = new NurtureSuggestion([
+            'action' => 'offer_relevant_resource',
+            'allowed_when' => ['consent' => true],
+            'prohibited_when' => ['do_not_contact' => true],
+        ]);
+
+        $this->assertTrue($suggestion->isAllowed(['consent' => true, 'do_not_contact' => false]));
+        $this->assertFalse($suggestion->isAllowed(['consent' => true, 'do_not_contact' => true]));
+        $this->assertFalse($suggestion->isAllowed(['consent' => false]));
+    }
+
+    public function testFollowUpPlanIsBoundedAndStopsOnContext(): void
+    {
+        $plan = new FollowUpPlan([
+            'max_steps' => 2,
+            'stop_conditions' => ['converted' => true],
+            'steps' => [
+                ['id' => 'step-1', 'action' => 'review_new_evidence', 'not_before' => '2026-08-28T00:00:00Z'],
+                ['id' => 'step-2', 'action' => 'request_human_review'],
+            ],
+        ]);
+
+        $this->assertSame('step-1', $plan->next([], new DateTimeImmutable('2026-08-29T00:00:00Z'))['id']);
+        $this->assertNull($plan->next(['converted' => true], new DateTimeImmutable('2026-08-29T00:00:00Z')));
+    }
+
+    public function testFollowUpPlanRejectsUnboundedSteps(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FollowUpPlan(['max_steps' => 1, 'steps' => [['id' => 'a'], ['id' => 'b']]]);
+    }
+
+    public function testResultPreservesScorePlanSuggestionsAndAudit(): void
+    {
+        $result = new QualificationResult([
+            'score' => new QualificationScore(['subject_id' => 'subject-3', 'score' => 0.5, 'status' => 'nurture']),
+            'suggestions' => [new NurtureSuggestion(['id' => 'suggestion-1', 'action' => 'offer_resource'])],
+            'follow_up_plan' => new FollowUpPlan(['steps' => [['id' => 'step-1', 'action' => 'review']]]),
+            'audit' => new QualificationAudit(['trace_id' => 'trace-3', 'rule_version' => 'rules-1']),
+        ]);
+        $payload = $result->toArray();
+
+        $this->assertSame('nurture', $payload['score']['status']);
+        $this->assertSame('suggestion-1', $payload['suggestions'][0]['id']);
+        $this->assertSame('step-1', $payload['follow_up_plan']['steps'][0]['id']);
+        $this->assertSame('trace-3', $payload['audit']['trace_id']);
+    }
+}


### PR DESCRIPTION
## Intent

Define Automata-owned, provider-neutral primitives for advisory qualification scoring, safe nurture suggestions, bounded follow-up planning, and audit metadata.

Closes #77.

## User stories and acceptance criteria

- Consumers can score weighted domain signals without importing CRM or transport concepts.
- Missing or below-minimum required evidence routes to review.
- Suggestions expose explicit allowed/prohibited conditions and require review by default.
- Follow-up plans enforce a maximum step count, expiry, and stop conditions.
- Results preserve scores, confidence, reasons, evidence, trace data, suggestions, plans, and audit metadata.
- The integration contract advertises the additive qualification feature and vocabulary.
- Transport, CRM payloads, persistence, and platform routing remain outside Automata.

## Key files changed

- `src/Automata/Qualification/*`: score, suggestion, follow-up, audit, and result contracts.
- `src/Automata/LLM/Agent/Integration/AgentIntegrationContract.php`: qualification feature and vocabulary.
- `tests/Automata/Qualification/QualificationPrimitivesTest.php`: deterministic and boundary coverage.
- `docs/qualification-primitives.md`: existing capability inventory and ownership boundary.
- `examples/generic/qualification_workflow.php`: executable generic workflow.

## How to test

```bash
composer validate --strict
vendor/bin/phpunit --do-not-cache-result
php examples/generic/qualification_workflow.php
```

Full local result: 373 tests, 1,234 assertions, two deprecations, one skipped, zero failures.

## QA checklist

- [x] Weighted score and confidence normalize deterministically.
- [x] Required evidence failures route to review.
- [x] Prohibited conditions suppress nurture suggestions.
- [x] Follow-up steps are bounded and stop conditions are honored.
- [x] Result envelopes normalize nested contracts to arrays.
- [x] Existing integration contract coverage remains green.
- [x] Generic example executes successfully.

## Approval conditions

- The `Qualification` namespace and integration contract version 1.3.0 are acceptable for the alpha API.
- Qualification output remains advisory and does not authorize side effects.
- Host systems retain consent policy, CRM mapping, delivery, persistence, and routing ownership.