### PR TITLE
Define inert claim normalization contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `bluefission/automata` library is a comprehensive PHP framework designed to 
 - **Anomaly Detection**: Score behavioral activity, fingerprints, and context to flag unusual or risky patterns.
 - **Media Ingestion**: Normalize text, image, audio, video, document, and URL inputs into consistent pipelines.
 - **Natural Language Processing (NLP)**: Tools for text parsing, analysis, and understanding, enabling the library to process and interpret human language.
+- **Claim Normalization**: Normalize raw, wrapped, and adapter-parsed textual claims into inspectable Statement semantics while preserving typed predicates as inert data. See [Claim Normalization](docs/claim-normalization.md).
 - **Bounded Language Prediction**: Lightweight Markov and trigram predictors support single-sentence updates and bounded bulk training for moderate local catalogs without requiring a hosted model.
 - **Large Language Models (LLM)**: Facilitate prompting and generating responses using large pre-trained models, integrating with tools like GPT for advanced text generation.
 - **Agent Capabilities**: Register deterministic tool contracts, scoped tool catalogs, permission checks, lifecycle hooks, session memory, Holoscene comprehension, orchestration patterns, DevElation-backed agent state/goal decisions, interpreter-facing integration contracts, and persona orchestration contracts around LLM agent loops. See [Agent Capabilities](docs/agent-capabilities.md) and [Agent Persona Orchestration Contracts](docs/agent-persona-orchestration-contracts.md).

--- a/docs/claim-normalization.md
+++ b/docs/claim-normalization.md
@@ -1,0 +1,52 @@
+# Claim Normalization
+
+Automata provides provider-neutral claim normalization contracts under
+`BlueFission\Automata\Language\Claims`. They let parsers and processors converge
+raw documents, versioned wrappers, and textual claims on `Statement` semantics
+without treating predicates as executable host expressions.
+
+## Boundaries
+
+- `ClaimEnvelope` preserves the source form, original payload, source context,
+  policy, correlation, causation, trace, and metadata.
+- `ClaimNormalizer` deterministically handles raw and wrapped payloads. Text
+  parsing is injected by the host because language grammar belongs to the parser
+  adapter rather than this interchange layer.
+- `ClaimPredicate` stores comparison and logical operator trees as inert data.
+  Predicates are never assigned to `Statement::condition()` and this normalizer
+  does not evaluate them.
+- `ClaimNormalizationResult` returns the normalized `Statement`, optional typed
+  predicate, evidence, and stable diagnostics.
+- Statuses distinguish normalized, unsupported, ambiguous, malformed, and
+  policy-rejected inputs.
+
+Processor, query planner, storage, and mutation behavior remain adapter-owned.
+A consumer must explicitly translate a `ClaimPredicate` into its own safe query
+or policy representation after validation. No host-language expression should
+be accepted as an operator.
+
+## Text Parser Adapter
+
+Text parsers receive the source text, source context, and envelope. They return
+an associative semantic payload, a `statement` wrapper, or a single `candidates`
+entry. Multiple candidates are reported as ambiguous instead of being selected
+implicitly.
+
+```php
+$normalizer = new ClaimNormalizer(
+    fn (string $text, array $context): array => [
+        'statement' => [
+            'subject' => ['name' => 'incident'],
+            'behavior' => 'requires',
+            'object' => ['name' => 'review'],
+        ],
+        'evidence' => ['grammar' => 'application-v1'],
+    ]
+);
+```
+
+Run the complete example with:
+
+```bash
+php examples/generic/claim_normalization.php
+```

--- a/examples/generic/claim_normalization.php
+++ b/examples/generic/claim_normalization.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use BlueFission\Automata\Language\Claims\ClaimEnvelope;
+use BlueFission\Automata\Language\Claims\ClaimNormalizer;
+use BlueFission\Automata\Language\Claims\ClaimSourceForm;
+use BlueFission\Automata\Language\Claims\PredicateOperator;
+use BlueFission\Net\HTTP;
+
+$normalizer = new ClaimNormalizer(
+    fn (string $text, array $context): array => [
+        'statement' => [
+            'subject' => ['name' => 'incident', 'meta' => ['source_text' => $text]],
+            'behavior' => 'requires',
+            'relationship' => 'needs',
+            'object' => ['name' => 'review'],
+            'context' => ['scope' => $context['scope'] ?? 'unknown'],
+        ],
+        'predicate' => [
+            'operator' => PredicateOperator::GREATER_THAN_OR_EQUAL,
+            'path' => 'confidence',
+            'value' => 0.8,
+        ],
+        'evidence' => ['grammar' => 'example-v1'],
+    ]
+);
+
+$result = $normalizer->normalize(new ClaimEnvelope([
+    'source_form' => ClaimSourceForm::TEXT,
+    'payload' => 'Incident requires review when confidence is at least 0.8.',
+    'source_context' => ['document' => 'release-spec', 'scope' => 'release'],
+    'policy' => ['allow_normalization' => true],
+]));
+
+print HTTP::jsonEncode($result->toArray()) . PHP_EOL;

--- a/src/Automata/Language/Claims/ClaimDiagnostic.php
+++ b/src/Automata/Language/Claims/ClaimDiagnostic.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+class ClaimDiagnostic extends ClaimValue
+{
+    public const INFO = 'info';
+    public const WARNING = 'warning';
+    public const ERROR = 'error';
+
+    public function code(): string
+    {
+        return (string)$this->field('code');
+    }
+
+    public function severity(): string
+    {
+        return (string)$this->field('severity');
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'code' => '',
+            'message' => '',
+            'severity' => self::ERROR,
+            'details' => [],
+            'evidence' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/Language/Claims/ClaimEnvelope.php
+++ b/src/Automata/Language/Claims/ClaimEnvelope.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+
+class ClaimEnvelope extends ClaimValue
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $claimId = (string)$this->field('claim_id');
+        if ($claimId === '') {
+            $claimId = 'claim_' . Str::uuid4();
+            $this->field('claim_id', $claimId);
+        }
+
+        foreach (['correlation_id', 'trace_id'] as $field) {
+            if ((string)$this->field($field) === '') {
+                $this->field($field, $claimId);
+            }
+        }
+    }
+
+    public function id(): string
+    {
+        return (string)$this->field('claim_id');
+    }
+
+    public function sourceForm(): string
+    {
+        return (string)$this->field('source_form');
+    }
+
+    public function payload(): mixed
+    {
+        return $this->field('payload');
+    }
+
+    public function sourceContext(): array
+    {
+        return Arr::make($this->field('source_context') ?? [])->toArray();
+    }
+
+    public function policy(): array
+    {
+        return Arr::make($this->field('policy') ?? [])->toArray();
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'contract_version' => '1.0',
+            'claim_id' => '',
+            'source_form' => ClaimSourceForm::RAW,
+            'payload' => null,
+            'source_context' => [],
+            'correlation_id' => '',
+            'causation_id' => '',
+            'trace_id' => '',
+            'policy' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/Language/Claims/ClaimNormalizationResult.php
+++ b/src/Automata/Language/Claims/ClaimNormalizationResult.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+use BlueFission\Arr;
+use BlueFission\Automata\Language\Statement;
+
+class ClaimNormalizationResult extends ClaimValue
+{
+    public function status(): string
+    {
+        return (string)$this->field('status');
+    }
+
+    public function normalized(): bool
+    {
+        return $this->status() === ClaimNormalizationStatus::NORMALIZED;
+    }
+
+    public function envelope(): ClaimEnvelope
+    {
+        $envelope = $this->field('envelope');
+
+        return $envelope instanceof ClaimEnvelope
+            ? $envelope
+            : new ClaimEnvelope(Arr::make($envelope)->toArray());
+    }
+
+    public function statement(): ?Statement
+    {
+        $statement = $this->field('statement');
+
+        return $statement instanceof Statement ? $statement : null;
+    }
+
+    public function predicate(): ?ClaimPredicate
+    {
+        $predicate = $this->field('predicate');
+        if ($predicate === null || $predicate === []) {
+            return null;
+        }
+
+        return $predicate instanceof ClaimPredicate
+            ? $predicate
+            : new ClaimPredicate(Arr::make($predicate)->toArray());
+    }
+
+    public function diagnostics(): array
+    {
+        return array_map(
+            static fn (mixed $diagnostic): ClaimDiagnostic => $diagnostic instanceof ClaimDiagnostic
+                ? $diagnostic
+                : new ClaimDiagnostic(Arr::make($diagnostic)->toArray()),
+            Arr::make($this->field('diagnostics') ?? [])->toArray()
+        );
+    }
+
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['envelope'] = $this->envelope()->toArray();
+        $data['statement'] = $this->statement()?->snapshot();
+        $data['predicate'] = $this->predicate()?->toArray();
+        $data['diagnostics'] = array_map(
+            static fn (ClaimDiagnostic $diagnostic): array => $diagnostic->toArray(),
+            $this->diagnostics()
+        );
+
+        return $data;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'status' => ClaimNormalizationStatus::MALFORMED,
+            'envelope' => [],
+            'statement' => null,
+            'predicate' => null,
+            'evidence' => [],
+            'diagnostics' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/Language/Claims/ClaimNormalizationResult.php
+++ b/src/Automata/Language/Claims/ClaimNormalizationResult.php
@@ -47,12 +47,11 @@ class ClaimNormalizationResult extends ClaimValue
 
     public function diagnostics(): array
     {
-        return array_map(
-            static fn (mixed $diagnostic): ClaimDiagnostic => $diagnostic instanceof ClaimDiagnostic
+        return Arr::make($this->field('diagnostics') ?? [])
+            ->map(static fn (mixed $diagnostic): ClaimDiagnostic => $diagnostic instanceof ClaimDiagnostic
                 ? $diagnostic
-                : new ClaimDiagnostic(Arr::make($diagnostic)->toArray()),
-            Arr::make($this->field('diagnostics') ?? [])->toArray()
-        );
+                : new ClaimDiagnostic(Arr::make($diagnostic)->toArray()))
+            ->toArray();
     }
 
     public function toArray(): array
@@ -61,10 +60,9 @@ class ClaimNormalizationResult extends ClaimValue
         $data['envelope'] = $this->envelope()->toArray();
         $data['statement'] = $this->statement()?->snapshot();
         $data['predicate'] = $this->predicate()?->toArray();
-        $data['diagnostics'] = array_map(
-            static fn (ClaimDiagnostic $diagnostic): array => $diagnostic->toArray(),
-            $this->diagnostics()
-        );
+        $data['diagnostics'] = Arr::make($this->diagnostics())
+            ->map(static fn (ClaimDiagnostic $diagnostic): array => $diagnostic->toArray())
+            ->toArray();
 
         return $data;
     }

--- a/src/Automata/Language/Claims/ClaimNormalizationStatus.php
+++ b/src/Automata/Language/Claims/ClaimNormalizationStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+final class ClaimNormalizationStatus
+{
+    public const NORMALIZED = 'normalized';
+    public const UNSUPPORTED = 'unsupported';
+    public const AMBIGUOUS = 'ambiguous';
+    public const MALFORMED = 'malformed';
+    public const POLICY_REJECTED = 'policy_rejected';
+
+    public static function all(): array
+    {
+        return [
+            self::NORMALIZED,
+            self::UNSUPPORTED,
+            self::AMBIGUOUS,
+            self::MALFORMED,
+            self::POLICY_REJECTED,
+        ];
+    }
+}

--- a/src/Automata/Language/Claims/ClaimNormalizer.php
+++ b/src/Automata/Language/Claims/ClaimNormalizer.php
@@ -56,13 +56,13 @@ class ClaimNormalizer implements IClaimNormalizer
             return $normalized;
         }
 
-        if (isset($normalized['candidates']) && Arr::is($normalized['candidates']) && count($normalized['candidates']) !== 1) {
+        if (isset($normalized['candidates']) && Arr::is($normalized['candidates']) && Arr::size($normalized['candidates']) !== 1) {
             return $this->failure(
                 $envelope,
                 ClaimNormalizationStatus::AMBIGUOUS,
                 'ambiguous_claim',
                 'The claim produced multiple semantic candidates.',
-                ['candidate_count' => count($normalized['candidates'])]
+                ['candidate_count' => Arr::size($normalized['candidates'])]
             );
         }
 

--- a/src/Automata/Language/Claims/ClaimNormalizer.php
+++ b/src/Automata/Language/Claims/ClaimNormalizer.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+use BlueFission\Arr;
+use BlueFission\Automata\Language\Statement;
+use BlueFission\Str;
+use Throwable;
+
+class ClaimNormalizer implements IClaimNormalizer
+{
+    private const STATEMENT_FIELDS = [
+        'type',
+        'context',
+        'priority',
+        'subject',
+        'negation',
+        'modality',
+        'behavior',
+        'object',
+        'relationship',
+        'indirect_object',
+        'position',
+    ];
+
+    protected $textParser;
+
+    public function __construct(?callable $textParser = null)
+    {
+        $this->textParser = $textParser;
+    }
+
+    public function normalize(ClaimEnvelope $envelope): ClaimNormalizationResult
+    {
+        if (($envelope->policy()['allow_normalization'] ?? true) !== true) {
+            return $this->failure(
+                $envelope,
+                ClaimNormalizationStatus::POLICY_REJECTED,
+                'normalization_not_allowed',
+                'Claim normalization is not allowed by policy.'
+            );
+        }
+
+        if (!ClaimSourceForm::isKnown($envelope->sourceForm())) {
+            return $this->failure(
+                $envelope,
+                ClaimNormalizationStatus::UNSUPPORTED,
+                'unsupported_source_form',
+                'The claim source form is not supported.',
+                ['source_form' => $envelope->sourceForm()]
+            );
+        }
+
+        $normalized = $this->normalizedPayload($envelope);
+        if ($normalized instanceof ClaimNormalizationResult) {
+            return $normalized;
+        }
+
+        if (isset($normalized['candidates']) && Arr::is($normalized['candidates']) && count($normalized['candidates']) !== 1) {
+            return $this->failure(
+                $envelope,
+                ClaimNormalizationStatus::AMBIGUOUS,
+                'ambiguous_claim',
+                'The claim produced multiple semantic candidates.',
+                ['candidate_count' => count($normalized['candidates'])]
+            );
+        }
+
+        if (isset($normalized['candidates'][0]) && Arr::isAssoc($normalized['candidates'][0])) {
+            $normalized = Arr::make($normalized['candidates'][0])->toArray();
+        }
+
+        $statementData = $normalized['statement'] ?? $normalized['claim'] ?? $normalized;
+        if (!Arr::isAssoc($statementData)) {
+            return $this->failure(
+                $envelope,
+                ClaimNormalizationStatus::MALFORMED,
+                'malformed_statement',
+                'The normalized claim must contain an associative statement payload.'
+            );
+        }
+
+        $predicateData = $normalized['predicate'] ?? ($statementData['predicate'] ?? null);
+        $statement = new Statement();
+        $statement->assign($this->statementPayload(Arr::make($statementData)->toArray()));
+
+        if ($predicateData !== null
+            && $predicateData !== []
+            && !$predicateData instanceof ClaimPredicate
+            && !Arr::isAssoc($predicateData)) {
+            return new ClaimNormalizationResult([
+                'status' => ClaimNormalizationStatus::MALFORMED,
+                'envelope' => $envelope,
+                'statement' => $statement,
+                'evidence' => $this->evidence($envelope, $normalized),
+                'diagnostics' => [new ClaimDiagnostic([
+                    'code' => 'malformed_predicate',
+                    'message' => 'The claim predicate must be an associative typed value.',
+                ])],
+            ]);
+        }
+
+        $predicate = $this->predicate($predicateData);
+        $unsupportedOperator = $predicate ? $this->unsupportedPredicateOperator($predicate) : null;
+        if ($predicate && $unsupportedOperator !== null) {
+            return new ClaimNormalizationResult([
+                'status' => ClaimNormalizationStatus::MALFORMED,
+                'envelope' => $envelope,
+                'statement' => $statement,
+                'predicate' => $predicate,
+                'evidence' => $this->evidence($envelope, $normalized),
+                'diagnostics' => [new ClaimDiagnostic([
+                    'code' => 'unsupported_predicate_operator',
+                    'message' => 'The claim contains an unsupported predicate operator.',
+                    'details' => ['operator' => $unsupportedOperator],
+                ])],
+            ]);
+        }
+
+        if ($predicate && !$predicate->structureIsValid()) {
+            return new ClaimNormalizationResult([
+                'status' => ClaimNormalizationStatus::MALFORMED,
+                'envelope' => $envelope,
+                'statement' => $statement,
+                'predicate' => $predicate,
+                'evidence' => $this->evidence($envelope, $normalized),
+                'diagnostics' => [new ClaimDiagnostic([
+                    'code' => 'malformed_predicate',
+                    'message' => 'The claim predicate structure is invalid for its operator.',
+                ])],
+            ]);
+        }
+
+        return new ClaimNormalizationResult([
+            'status' => ClaimNormalizationStatus::NORMALIZED,
+            'envelope' => $envelope,
+            'statement' => $statement,
+            'predicate' => $predicate,
+            'evidence' => $this->evidence($envelope, $normalized),
+        ]);
+    }
+
+    private function normalizedPayload(ClaimEnvelope $envelope): array|ClaimNormalizationResult
+    {
+        $payload = $envelope->payload();
+
+        if ($envelope->sourceForm() === ClaimSourceForm::TEXT) {
+            $text = Arr::isAssoc($payload) ? ($payload['text'] ?? '') : $payload;
+            if (!is_string($text) || Str::trim($text) === '') {
+                return $this->failure(
+                    $envelope,
+                    ClaimNormalizationStatus::MALFORMED,
+                    'missing_claim_text',
+                    'A textual claim must contain non-empty text.'
+                );
+            }
+
+            if (!$this->textParser) {
+                return $this->failure(
+                    $envelope,
+                    ClaimNormalizationStatus::UNSUPPORTED,
+                    'text_parser_unavailable',
+                    'No textual claim parser adapter is configured.'
+                );
+            }
+
+            try {
+                $payload = ($this->textParser)($text, $envelope->sourceContext(), $envelope);
+            } catch (Throwable $exception) {
+                return $this->failure(
+                    $envelope,
+                    ClaimNormalizationStatus::MALFORMED,
+                    'text_parser_failed',
+                    'The textual claim parser failed.',
+                    ['exception' => $exception::class]
+                );
+            }
+        }
+
+        if (!Arr::isAssoc($payload)) {
+            return $this->failure(
+                $envelope,
+                ClaimNormalizationStatus::MALFORMED,
+                'malformed_claim_payload',
+                'The claim payload must normalize to an associative array.'
+            );
+        }
+
+        $payload = Arr::make($payload)->toArray();
+
+        if ($envelope->sourceForm() === ClaimSourceForm::WRAPPED) {
+            if (!isset($payload['statement']) && !isset($payload['claim']) && !isset($payload['candidates'])) {
+                return $this->failure(
+                    $envelope,
+                    ClaimNormalizationStatus::MALFORMED,
+                    'missing_wrapped_claim',
+                    'A wrapped claim must contain statement, claim, or candidates.'
+                );
+            }
+        }
+
+        return $payload;
+    }
+
+    private function statementPayload(array $payload): array
+    {
+        $statement = [];
+
+        foreach (self::STATEMENT_FIELDS as $field) {
+            if (array_key_exists($field, $payload)) {
+                $statement[$field] = $payload[$field];
+            }
+        }
+
+        return $statement;
+    }
+
+    private function predicate(mixed $payload): ?ClaimPredicate
+    {
+        if ($payload === null || $payload === []) {
+            return null;
+        }
+
+        if ($payload instanceof ClaimPredicate) {
+            return $payload;
+        }
+
+        return Arr::isAssoc($payload)
+            ? new ClaimPredicate(Arr::make($payload)->toArray())
+            : null;
+    }
+
+    private function unsupportedPredicateOperator(ClaimPredicate $predicate): ?string
+    {
+        if (!$predicate->isKnown()) {
+            return $predicate->operator();
+        }
+
+        foreach ($predicate->children() as $child) {
+            $unsupported = $this->unsupportedPredicateOperator($child);
+            if ($unsupported !== null) {
+                return $unsupported;
+            }
+        }
+
+        return null;
+    }
+
+    private function evidence(ClaimEnvelope $envelope, array $normalized): array
+    {
+        return [
+            'source_form' => $envelope->sourceForm(),
+            'source_context' => $envelope->sourceContext(),
+            'normalization' => Arr::make($normalized['evidence'] ?? [])->toArray(),
+        ];
+    }
+
+    private function failure(
+        ClaimEnvelope $envelope,
+        string $status,
+        string $code,
+        string $message,
+        array $details = []
+    ): ClaimNormalizationResult {
+        return new ClaimNormalizationResult([
+            'status' => $status,
+            'envelope' => $envelope,
+            'diagnostics' => [new ClaimDiagnostic([
+                'code' => $code,
+                'message' => $message,
+                'details' => $details,
+            ])],
+        ]);
+    }
+}

--- a/src/Automata/Language/Claims/ClaimPredicate.php
+++ b/src/Automata/Language/Claims/ClaimPredicate.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+use BlueFission\Arr;
+
+class ClaimPredicate extends ClaimValue
+{
+    public function operator(): string
+    {
+        return (string)$this->field('operator');
+    }
+
+    public function isKnown(): bool
+    {
+        return PredicateOperator::isKnown($this->operator());
+    }
+
+    public function children(): array
+    {
+        return array_map(
+            static fn (mixed $child): ClaimPredicate => $child instanceof ClaimPredicate
+                ? $child
+                : new ClaimPredicate(Arr::make($child)->toArray()),
+            Arr::make($this->field('children') ?? [])->toArray()
+        );
+    }
+
+    public function structureIsValid(): bool
+    {
+        $children = $this->children();
+
+        if (PredicateOperator::isLogical($this->operator())) {
+            $validCount = $this->operator() === PredicateOperator::NOT
+                ? count($children) === 1
+                : count($children) > 0;
+
+            if (!$validCount) {
+                return false;
+            }
+
+            foreach ($children as $child) {
+                if (!$child->structureIsValid()) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return count($children) === 0 && trim((string)$this->field('path')) !== '';
+    }
+
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['children'] = array_map(
+            static fn (ClaimPredicate $predicate): array => $predicate->toArray(),
+            $this->children()
+        );
+
+        return $data;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'operator' => PredicateOperator::EQUALS,
+            'path' => null,
+            'value' => null,
+            'children' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/src/Automata/Language/Claims/ClaimPredicate.php
+++ b/src/Automata/Language/Claims/ClaimPredicate.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Automata\Language\Claims;
 
 use BlueFission\Arr;
+use BlueFission\Str;
 
 class ClaimPredicate extends ClaimValue
 {
@@ -18,12 +19,11 @@ class ClaimPredicate extends ClaimValue
 
     public function children(): array
     {
-        return array_map(
-            static fn (mixed $child): ClaimPredicate => $child instanceof ClaimPredicate
+        return Arr::make($this->field('children') ?? [])
+            ->map(static fn (mixed $child): ClaimPredicate => $child instanceof ClaimPredicate
                 ? $child
-                : new ClaimPredicate(Arr::make($child)->toArray()),
-            Arr::make($this->field('children') ?? [])->toArray()
-        );
+                : new ClaimPredicate(Arr::make($child)->toArray()))
+            ->toArray();
     }
 
     public function structureIsValid(): bool
@@ -32,8 +32,8 @@ class ClaimPredicate extends ClaimValue
 
         if (PredicateOperator::isLogical($this->operator())) {
             $validCount = $this->operator() === PredicateOperator::NOT
-                ? count($children) === 1
-                : count($children) > 0;
+                ? Arr::size($children) === 1
+                : Arr::size($children) > 0;
 
             if (!$validCount) {
                 return false;
@@ -48,16 +48,15 @@ class ClaimPredicate extends ClaimValue
             return true;
         }
 
-        return count($children) === 0 && trim((string)$this->field('path')) !== '';
+        return Arr::size($children) === 0 && Str::trim((string)$this->field('path')) !== '';
     }
 
     public function toArray(): array
     {
         $data = parent::toArray();
-        $data['children'] = array_map(
-            static fn (ClaimPredicate $predicate): array => $predicate->toArray(),
-            $this->children()
-        );
+        $data['children'] = Arr::make($this->children())
+            ->map(static fn (ClaimPredicate $predicate): array => $predicate->toArray())
+            ->toArray();
 
         return $data;
     }

--- a/src/Automata/Language/Claims/ClaimSourceForm.php
+++ b/src/Automata/Language/Claims/ClaimSourceForm.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+final class ClaimSourceForm
+{
+    public const RAW = 'raw';
+    public const WRAPPED = 'wrapped';
+    public const TEXT = 'text';
+
+    public static function all(): array
+    {
+        return [self::RAW, self::WRAPPED, self::TEXT];
+    }
+
+    public static function isKnown(string $form): bool
+    {
+        return in_array($form, self::all(), true);
+    }
+}

--- a/src/Automata/Language/Claims/ClaimValue.php
+++ b/src/Automata/Language/Claims/ClaimValue.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+use BlueFission\Automata\LLM\Agent\ToolDefinition;
+use BlueFission\Obj;
+
+abstract class ClaimValue extends Obj
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->assign(ToolDefinition::mergeConfig($this->defaults(), $data));
+    }
+
+    abstract protected function defaults(): array;
+
+    public function toArray(): array
+    {
+        return parent::toArray();
+    }
+}

--- a/src/Automata/Language/Claims/IClaimNormalizer.php
+++ b/src/Automata/Language/Claims/IClaimNormalizer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+interface IClaimNormalizer
+{
+    public function normalize(ClaimEnvelope $envelope): ClaimNormalizationResult;
+}

--- a/src/Automata/Language/Claims/PredicateOperator.php
+++ b/src/Automata/Language/Claims/PredicateOperator.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BlueFission\Automata\Language\Claims;
+
+final class PredicateOperator
+{
+    public const EQUALS = 'equals';
+    public const NOT_EQUALS = 'not_equals';
+    public const GREATER_THAN = 'greater_than';
+    public const GREATER_THAN_OR_EQUAL = 'greater_than_or_equal';
+    public const LESS_THAN = 'less_than';
+    public const LESS_THAN_OR_EQUAL = 'less_than_or_equal';
+    public const IN = 'in';
+    public const CONTAINS = 'contains';
+    public const AND = 'and';
+    public const OR = 'or';
+    public const NOT = 'not';
+
+    public static function all(): array
+    {
+        return [
+            self::EQUALS,
+            self::NOT_EQUALS,
+            self::GREATER_THAN,
+            self::GREATER_THAN_OR_EQUAL,
+            self::LESS_THAN,
+            self::LESS_THAN_OR_EQUAL,
+            self::IN,
+            self::CONTAINS,
+            self::AND,
+            self::OR,
+            self::NOT,
+        ];
+    }
+
+    public static function isKnown(string $operator): bool
+    {
+        return in_array($operator, self::all(), true);
+    }
+
+    public static function isLogical(string $operator): bool
+    {
+        return in_array($operator, [self::AND, self::OR, self::NOT], true);
+    }
+}

--- a/tests/Automata/Language/ClaimNormalizationTest.php
+++ b/tests/Automata/Language/ClaimNormalizationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace BlueFission\Tests\Automata\Language;
+
+use BlueFission\Automata\Language\Claims\ClaimEnvelope;
+use BlueFission\Automata\Language\Claims\ClaimNormalizationStatus;
+use BlueFission\Automata\Language\Claims\ClaimNormalizer;
+use BlueFission\Automata\Language\Claims\ClaimPredicate;
+use BlueFission\Automata\Language\Claims\ClaimSourceForm;
+use BlueFission\Automata\Language\Claims\PredicateOperator;
+use PHPUnit\Framework\TestCase;
+
+class ClaimNormalizationTest extends TestCase
+{
+    private array $semantic = [
+        'subject' => ['name' => 'incident'],
+        'behavior' => 'requires',
+        'relationship' => 'needs',
+        'object' => ['name' => 'review'],
+        'context' => ['scope' => 'release'],
+    ];
+
+    private array $predicate = [
+        'operator' => PredicateOperator::GREATER_THAN_OR_EQUAL,
+        'path' => 'confidence',
+        'value' => 0.8,
+    ];
+
+    public function testEnvelopeCreatesStableCorrelationAndTraceIdentifiers(): void
+    {
+        $envelope = new ClaimEnvelope(['payload' => $this->semantic]);
+
+        $this->assertNotSame('', $envelope->id());
+        $this->assertSame($envelope->id(), $envelope->field('correlation_id'));
+        $this->assertSame($envelope->id(), $envelope->field('trace_id'));
+    }
+
+    public function testRawWrappedAndTextClaimsProduceEquivalentSemantics(): void
+    {
+        $normalizer = new ClaimNormalizer(fn (): array => [
+            'statement' => $this->semantic,
+            'predicate' => $this->predicate,
+            'evidence' => ['parser' => 'fixture'],
+        ]);
+        $raw = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::RAW,
+            'payload' => array_merge($this->semantic, ['predicate' => $this->predicate]),
+        ]));
+        $wrapped = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::WRAPPED,
+            'payload' => ['statement' => $this->semantic, 'predicate' => $this->predicate],
+        ]));
+        $text = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::TEXT,
+            'payload' => 'Incident requires review when confidence is at least 0.8.',
+        ]));
+
+        $this->assertTrue($raw->normalized());
+        $this->assertTrue($wrapped->normalized());
+        $this->assertTrue($text->normalized());
+
+        $rawSnapshot = $this->semanticSnapshot($raw->statement()->snapshot());
+        $this->assertSame($rawSnapshot, $this->semanticSnapshot($wrapped->statement()->snapshot()));
+        $this->assertSame($rawSnapshot, $this->semanticSnapshot($text->statement()->snapshot()));
+        $this->assertSame($raw->predicate()->toArray(), $wrapped->predicate()->toArray());
+        $this->assertSame($raw->predicate()->toArray(), $text->predicate()->toArray());
+    }
+
+    public function testPredicateRemainsSeparateFromEvaluativeStatementConditions(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'payload' => array_merge($this->semantic, ['predicate' => $this->predicate]),
+        ]));
+
+        $this->assertInstanceOf(ClaimPredicate::class, $result->predicate());
+        $this->assertSame([], $result->statement()->conditions());
+        $this->assertSame('', $result->statement()->field('condition'));
+    }
+
+    public function testLogicalPredicateTreeRemainsTypedData(): void
+    {
+        $predicate = [
+            'operator' => PredicateOperator::AND,
+            'children' => [
+                $this->predicate,
+                ['operator' => PredicateOperator::EQUALS, 'path' => 'status', 'value' => 'approved'],
+            ],
+        ];
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'payload' => array_merge($this->semantic, ['predicate' => $predicate]),
+        ]));
+
+        $this->assertTrue($result->normalized());
+        $this->assertSame(PredicateOperator::AND, $result->predicate()->operator());
+        $this->assertCount(2, $result->predicate()->children());
+        $this->assertSame('status', $result->predicate()->children()[1]->field('path'));
+    }
+
+    public function testUnsupportedPredicateProducesDiagnosticWithoutExecution(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'payload' => array_merge($this->semantic, [
+                'predicate' => ['operator' => 'execute_host_expression', 'value' => 'dangerous()'],
+            ]),
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::MALFORMED, $result->status());
+        $this->assertSame('unsupported_predicate_operator', $result->diagnostics()[0]->code());
+        $this->assertSame('execute_host_expression', $result->predicate()->operator());
+        $this->assertSame([], $result->statement()->conditions());
+    }
+
+    public function testMalformedPredicatePayloadFailsClosed(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'payload' => array_merge($this->semantic, ['predicate' => 'confidence >= 0.8']),
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::MALFORMED, $result->status());
+        $this->assertSame('malformed_predicate', $result->diagnostics()[0]->code());
+        $this->assertNull($result->predicate());
+    }
+
+    public function testEmptyLogicalPredicateFailsClosed(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'payload' => array_merge($this->semantic, [
+                'predicate' => ['operator' => PredicateOperator::AND, 'children' => []],
+            ]),
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::MALFORMED, $result->status());
+        $this->assertSame('malformed_predicate', $result->diagnostics()[0]->code());
+    }
+
+    public function testTextClaimsRequireAnInjectedParser(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::TEXT,
+            'payload' => 'Incident requires review.',
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::UNSUPPORTED, $result->status());
+        $this->assertSame('text_parser_unavailable', $result->diagnostics()[0]->code());
+    }
+
+    public function testPolicyCanRejectNormalizationBeforeParserInvocation(): void
+    {
+        $calls = 0;
+        $normalizer = new ClaimNormalizer(function () use (&$calls): array {
+            $calls++;
+            return $this->semantic;
+        });
+        $result = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::TEXT,
+            'payload' => 'Incident requires review.',
+            'policy' => ['allow_normalization' => false],
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::POLICY_REJECTED, $result->status());
+        $this->assertSame(0, $calls);
+    }
+
+    public function testMultipleParserCandidatesAreExplicitlyAmbiguous(): void
+    {
+        $normalizer = new ClaimNormalizer(fn (): array => [
+            'candidates' => [$this->semantic, array_merge($this->semantic, ['behavior' => 'suggests'])],
+        ]);
+        $result = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::TEXT,
+            'payload' => 'Incident may require review.',
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::AMBIGUOUS, $result->status());
+        $this->assertSame(2, $result->diagnostics()[0]->field('details')['candidate_count']);
+    }
+
+    public function testSourceContextAndParserEvidenceRemainInspectable(): void
+    {
+        $normalizer = new ClaimNormalizer(fn (): array => [
+            'statement' => $this->semantic,
+            'evidence' => ['grammar' => 'fixture-v1'],
+        ]);
+        $result = $normalizer->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::TEXT,
+            'payload' => 'Incident requires review.',
+            'source_context' => ['document' => 'spec-7', 'line' => 14],
+        ]));
+        $evidence = $result->toArray()['evidence'];
+
+        $this->assertSame(ClaimSourceForm::TEXT, $evidence['source_form']);
+        $this->assertSame('spec-7', $evidence['source_context']['document']);
+        $this->assertSame('fixture-v1', $evidence['normalization']['grammar']);
+    }
+
+    public function testMalformedWrappedClaimHasStableDiagnostic(): void
+    {
+        $result = (new ClaimNormalizer())->normalize(new ClaimEnvelope([
+            'source_form' => ClaimSourceForm::WRAPPED,
+            'payload' => ['version' => '1.0'],
+        ]));
+
+        $this->assertSame(ClaimNormalizationStatus::MALFORMED, $result->status());
+        $this->assertSame('missing_wrapped_claim', $result->diagnostics()[0]->code());
+    }
+
+    private function semanticSnapshot(array $snapshot): array
+    {
+        return [
+            'subject' => $snapshot['subject'],
+            'behavior' => $snapshot['behavior'],
+            'relationship' => $snapshot['relationship'],
+            'object' => $snapshot['object'],
+            'context' => $snapshot['context'],
+        ];
+    }
+}


### PR DESCRIPTION
## Intent

Define provider-neutral claim normalization contracts that converge raw documents, versioned wrappers, and adapter-parsed text on Automata `Statement` semantics while preserving typed predicates as inert, inspectable data.

Closes #89.

## User stories and acceptance criteria

- Parser and processor adapters can exchange a versioned claim envelope with source context, policy, and trace identifiers.
- Raw, wrapped, and textual fixtures normalize to equivalent Statement semantics.
- Comparison and logical predicate trees remain typed data and are never assigned to evaluative Statement conditions.
- Unsupported, ambiguous, malformed, policy-rejected, and parser-failure states produce stable diagnostics.
- Text grammar stays injectable and adapter-owned; no host expression, query, storage, or mutation execution is introduced.

## Key files changed

- `src/Automata/Language/Claims/`: envelope, source/status vocabulary, inert predicate/operator types, diagnostics, result, interface, and deterministic normalizer.
- `tests/Automata/Language/ClaimNormalizationTest.php`: semantic equivalence, policy, ambiguity, malformed input, predicate recursion, and non-execution coverage.
- `docs/claim-normalization.md`: contract and ownership guidance.
- `examples/generic/claim_normalization.php`: executable text-adapter example.
- `README.md`: feature discovery link.

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/Automata/Language/ClaimNormalizationTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
php examples/generic/claim_normalization.php
```

Observed: focused 12 tests / 37 assertions; full 379 tests / 1,251 assertions with 2 existing deprecations and 1 expected skip; Composer validation and example execution passed.

## QA checklist

- [x] PHP 8.2 syntax validation passes.
- [x] Raw, wrapped, and textual fixtures produce equivalent semantic fields.
- [x] Predicate operators and child trees remain separate from Statement conditions.
- [x] Scalar, structurally invalid, and unsupported predicates fail closed.
- [x] Policy rejection occurs before text parser invocation.
- [x] Full test suite passes.

## Approval conditions

- Public vocabulary remains provider, parser, query, and storage agnostic.
- Predicate data cannot execute through this contract surface.
- Diagnostic/status semantics are sufficient for downstream adapters.
- CI confirms the local validation evidence.
