### PR TITLE
Consume tagged SimpleClients alpha release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,32 +22,6 @@
             "role": "Developer"
         }
     ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "bluefission/simpleclients",
-                "version": "dev-master",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/BlueFissionTech/simpleclients.git",
-                    "reference": "858ea3575b5eb725879c0066d152e07538019392"
-                },
-                "require": {
-                    "bluefission/develation": "^1.0.0-alpha",
-                    "simplehtmldom/simplehtmldom": "^2.0@RC"
-                },
-                "autoload": {
-                    "psr-4": {
-                        "BlueFission\\": "src/"
-                    },
-                    "classmap": [
-                        "src/"
-                    ]
-                }
-            }
-        }
-    ],
     "minimum-stability": "dev",
     "require": {
         "php": ">=8.2",
@@ -56,7 +30,7 @@
         "php-ai/php-ml": "^0.10.0"
     },
     "require-dev": {
-        "bluefission/simpleclients": "dev-master",
+        "bluefission/simpleclients": "^0.1.0-alpha",
         "phpunit/phpunit": "^11.5"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8aa703771888a5e43288ba74c4f14d9f",
+    "content-hash": "18dd310d8c94353035cd4f6ec81d0ac8",
     "packages": [
         {
             "name": "bluefission/chronicler",
@@ -364,15 +364,30 @@
     "packages-dev": [
         {
             "name": "bluefission/simpleclients",
-            "version": "dev-master",
+            "version": "v0.1.1-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/simpleclients.git",
-                "reference": "858ea3575b5eb725879c0066d152e07538019392"
+                "reference": "9321728041b016e1e80eca6fcd4dff9e24e720ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BlueFissionTech/simpleclients/zipball/9321728041b016e1e80eca6fcd4dff9e24e720ce",
+                "reference": "9321728041b016e1e80eca6fcd4dff9e24e720ce",
+                "shasum": ""
             },
             "require": {
-                "bluefission/develation": "^1.0.0-alpha",
+                "bluefission/develation": "^1.3.39",
+                "ext-json": "*",
+                "php": ">=8.2",
                 "simplehtmldom/simplehtmldom": "^2.0@RC"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "suggest": {
+                "bluefission/automata": "Enables Automata-backed LLM provider clients such as OpenAIClient.",
+                "gemini-api-php/client": "Provide a Gemini SDK implementation when using GoogleGeminiClient without an injected test double."
             },
             "type": "library",
             "autoload": {
@@ -382,7 +397,38 @@
                 "classmap": [
                     "src/"
                 ]
-            }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Devon Scott",
+                    "email": "dscott@bluefission.com",
+                    "homepage": "https://bluefission.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Simple client wrappers for Blue Fission provider integrations",
+            "homepage": "https://github.com/BlueFissionTech/simpleclients",
+            "keywords": [
+                "api",
+                "bluefission",
+                "clients",
+                "http",
+                "materia",
+                "php",
+                "providers",
+                "services",
+                "simpleclients",
+                "transports"
+            ],
+            "support": {
+                "issues": "https://github.com/BlueFissionTech/simpleclients/issues",
+                "source": "https://github.com/BlueFissionTech/simpleclients"
+            },
+            "time": "2026-08-23T12:47:43+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2255,9 +2301,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "bluefission/simpleclients": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -56,7 +56,8 @@ final class ComposerMetadataTest extends TestCase
         $this->assertArrayNotHasKey('orhanerday/open-ai', $require);
         $this->assertArrayNotHasKey('symfony/http-client', $require);
 
-        $this->assertSame('dev-master', $requireDev['bluefission/simpleclients']);
+        $this->assertSame('^0.1.0-alpha', $requireDev['bluefission/simpleclients']);
+        $this->assertArrayNotHasKey('repositories', $composer);
         $this->assertArrayHasKey('bluefission/simpleclients', $suggest);
         $this->assertArrayHasKey('google-gemini-php/client', $suggest);
         $this->assertArrayHasKey('nyholm/psr7', $suggest);


### PR DESCRIPTION
## Intent

Consume the tagged SimpleClients alpha release from Packagist and remove Automata's inline development-package override.

Closes #87.

## User stories and acceptance criteria

- Contributors resolve SimpleClients from its registered tagged package rather than a pinned development branch definition.
- Runtime consumers remain unaffected because SimpleClients stays optional in `require-dev` and `suggest`.
- The lockfile records the tagged source, package metadata, and stable alpha constraint.
- Existing root dependencies do not move as a side effect of this update.

## Key files changed

- `composer.json`: removes the inline package repository and changes SimpleClients to `^0.1.0-alpha`.
- `composer.lock`: resolves `bluefission/simpleclients v0.1.1-alpha` at its tagged source while retaining DevElation `v1.3.41`.
- `tests/ComposerMetadataTest.php`: verifies the tagged constraint and absence of a root repository override.

## How to test

```bash
composer validate --strict
composer audit --locked --no-interaction
composer check-platform-reqs --lock
composer install --dry-run --no-interaction
vendor/bin/phpunit --do-not-cache-result tests/ComposerMetadataTest.php
vendor/bin/phpunit --do-not-cache-result tests/Automata/LLM/ClaudeGrokClientTest.php tests/Automata/LLM/GoogleGeminiClientTest.php tests/Automata/Media/SimpleClientsHandlersTest.php
vendor/bin/phpunit --do-not-cache-result
```

Observed: metadata 5 tests / 41 assertions; SimpleClients-facing 7 tests / 14 assertions; full 367 tests / 1,215 assertions with 2 existing deprecations and 1 expected skip. Composer validation, audit, platform checks, and dry-run installation passed with no security advisories.

## QA checklist

- [x] Lockfile resolves SimpleClients `v0.1.1-alpha`.
- [x] DevElation remains locked at `v1.3.41`.
- [x] No inline Composer repository remains.
- [x] Optional provider clients remain outside runtime requirements.
- [x] Full test suite passes.

## Approval conditions

- CI completes a clean install from the tagged Packagist graph.
- Provider adapter tests remain green.
- Review confirms no unrelated dependency movement.
