### PR TITLE
Consume DevElation 1.3.43 for v1.0.0-alpha.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -50,16 +50,16 @@
         },
         {
             "name": "bluefission/develation",
-            "version": "v1.3.41",
+            "version": "v1.3.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91"
+                "reference": "1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/25bdd65152ef39a83524b30eb47cba2c061ded91",
-                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6",
+                "reference": "1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6",
                 "shasum": ""
             },
             "require": {
@@ -75,7 +75,11 @@
                 "phpunit/phpunit": "^11.5"
             },
             "suggest": {
-                "cboden/ratchet": "Install to use the optional BlueFission\\Async\\Sock Ratchet websocket transport."
+                "cboden/ratchet": "Install to use the optional BlueFission\\Async\\Sock Ratchet websocket transport.",
+                "ext-memcached": "Install to use Memcached storage and MemQueue.",
+                "ext-mongodb": "Install with mongodb/mongodb to use the MongoLink database adapter.",
+                "ext-redis": "Install to use Redis connections, storage, and reliable queues.",
+                "mongodb/mongodb": "Install with ext-mongodb to use the MongoLink database adapter."
             },
             "type": "library",
             "autoload": {
@@ -118,7 +122,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-08-07T19:31:33+00:00"
+            "time": "2026-08-19T22:53:03+00:00"
         },
         {
             "name": "php-ai/php-ml",


### PR DESCRIPTION
## Intent

Consume the latest compatible DevElation release and prepare Automata v1.0.0-alpha.5 after the capability registry, adaptive strategy routing, native Obj field, and helper-alignment changes landed.

Closes #98.

## User stories and acceptance criteria

- Consumers receive Automata against DevElation v1.3.43.
- The dependency update introduces no unrelated lock-file churn.
- Automata remains compatible with PHP 8.2+.
- The complete suite and representative agent/routing examples pass before release.
- v1.0.0-alpha.5 is tagged from merged master, not from this feature branch.

## Key files changed

- composer.lock: updates bluefission/develation from v1.3.41 to v1.3.43 and records its current optional extension suggestions.

## How to test

- composer validate --strict
- composer check-platform-reqs
- vendor/bin/phpunit --do-not-cache-result
- php examples/generic/agent_capability_registry.php
- php examples/generic/agent_integration_contract.php
- php examples/generic/strategy_routing.php

## QA checklist

- [x] Composer metadata validates strictly.
- [x] Platform requirements pass on PHP 8.2.11.
- [x] Full suite passes: 433 tests, 1,472 assertions, 2 existing deprecations, 1 skipped test.
- [x] Capability registry, integration contract, and strategy routing examples execute successfully.
- [x] Diff whitespace check passes.

## Approval conditions

- Only the intended DevElation package is updated.
- No environment-specific configuration or secrets are committed.
- Release publication occurs after merge and a clean master revalidation.