### PR TITLE
Consume DevElation 1.3.44

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -50,16 +50,16 @@
         },
         {
             "name": "bluefission/develation",
-            "version": "v1.3.43",
+            "version": "v1.3.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6"
+                "reference": "096a10250164227662134f996f6ddd083605a5c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6",
-                "reference": "1707d69d6e12cb888af16a3dc64f92ab3ca6e2f6",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/096a10250164227662134f996f6ddd083605a5c7",
+                "reference": "096a10250164227662134f996f6ddd083605a5c7",
                 "shasum": ""
             },
             "require": {
@@ -122,7 +122,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-08-19T22:53:03+00:00"
+            "time": "2026-08-31T20:50:17+00:00"
         },
         {
             "name": "php-ai/php-ml",

--- a/tests/Automata/Adapters/CarrierAdapterTest.php
+++ b/tests/Automata/Adapters/CarrierAdapterTest.php
@@ -23,4 +23,18 @@ class CarrierAdapterTest extends TestCase
         $this->assertSame('ready', $adapter->field('status'));
         $this->assertSame('high', $adapter->snapshot()['meta']['priority']);
     }
+
+    public function testCarrierAdapterPreservesExplicitNullAssignment(): void
+    {
+        $carrier = new class extends Obj {
+        };
+
+        $adapter = new CarrierAdapter($carrier);
+        $adapter->field('status', 'ready');
+        $adapter->field('status', null);
+
+        $this->assertNull($adapter->field('status'));
+        $this->assertArrayHasKey('status', $adapter->snapshot());
+        $this->assertNull($adapter->snapshot()['status']);
+    }
 }

--- a/tests/Automata/Language/StatementTest.php
+++ b/tests/Automata/Language/StatementTest.php
@@ -23,6 +23,16 @@ class StatementTest extends TestCase
         $this->assertGreaterThan($initial, $after);
     }
 
+    public function testSemanticFieldPreservesExplicitNullAssignment(): void
+    {
+        $statement = new Statement();
+        $statement->field('subject', 'HospitalA');
+        $statement->field('subject', null);
+
+        $this->assertNull($statement->field('subject'));
+        $this->assertNull($statement->snapshot()['subject']);
+    }
+
     public function testEntitiesReturnsSubjectObjectAndIndirectObject(): void
     {
         $statement = new Statement();


### PR DESCRIPTION
## Intent summary

Consume DevElation v1.3.44 and prove Automata preserves explicit null assignments through native Obj field semantics.

## User stories / acceptance criteria

- Resolve only bluefission/develation v1.3.44 at source 096a10250164227662134f996f6ddd083605a5c7.
- Preserve read-versus-write dispatch in Automata field adapters without duplicate framework workarounds.
- Cover explicit null assignment through CarrierAdapter and semantic Statement fields.
- Keep capability, routing, authority, and execution boundaries unchanged.

## Key files changed

- composer.lock
- tests/Automata/Adapters/CarrierAdapterTest.php
- tests/Automata/Language/StatementTest.php

## How to test

- composer validate --strict --no-check-publish
- composer check-platform-reqs
- vendor/bin/phpunit --do-not-cache-result
- php examples/generic/agent_capability_registry.php
- php examples/generic/agent_integration_contract.php
- php examples/generic/strategy_routing.php

## QA checklist

- [x] Dependency diff is limited to DevElation v1.3.44.
- [x] Obj field callsites audited; no production workaround is required.
- [x] Focused suite: 54 tests, 241 assertions.
- [x] Full PHP 8.2 suite: 435 tests, 1,477 assertions, 2 existing deprecations, 1 skipped.
- [x] Composer validation/platform checks and representative examples pass.

## Approval conditions

- CI passes for exact head f0625c35dea3b8947d1937dfd0c665e9b10dbf50.
- No unresolved review findings.
- Merge closes #100 after independent review.

Closes #100